### PR TITLE
Daily reading list → podcast, fully automated

### DIFF
--- a/dhk-daily-brief/README.md
+++ b/dhk-daily-brief/README.md
@@ -139,6 +139,18 @@ python3 scripts/daily_brief.py --upload-only --wait-for-audio --max-wait-minutes
 python3 scripts/daily_brief.py --wait-for-studio-status --max-wait-minutes 20 --poll-interval-seconds 20
 ```
 
+Default behavior now includes both waits:
+
+- `--wait-for-studio-status` is ON by default
+- `--wait-for-audio` is ON by default
+
+Opt out when needed:
+
+```bash
+python3 scripts/daily_brief.py --no-wait-for-studio-status
+python3 scripts/daily_brief.py --no-wait-for-audio
+```
+
 The script writes a per-date manifest for idempotency at:
 
 - `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`

--- a/dhk-daily-brief/README.md
+++ b/dhk-daily-brief/README.md
@@ -153,6 +153,7 @@ Upload-only waiting behavior:
 NotebookLM status waiting (recommended when downloading in the same run):
 
 - `--wait-for-studio-status` polls `nlm studio status <notebook_id> --json`.
+- It first waits for matching `reading-list-YYYY-MM-DD-NN ...` notebooks to appear.
 - It waits up to `--max-wait-minutes` for studio readiness per notebook.
 - Notebooks not ready by timeout are skipped (reported in output).
 

--- a/dhk-daily-brief/README.md
+++ b/dhk-daily-brief/README.md
@@ -151,6 +151,8 @@ python3 scripts/daily_brief.py --no-wait-for-studio-status
 python3 scripts/daily_brief.py --no-wait-for-audio
 ```
 
+Large MP3 uploads to element.fm may need a longer timeout than JSON calls. Use `--upload-timeout` (default 900s); each upload also scales from file size up to 1 hour.
+
 The script writes a per-date manifest for idempotency at:
 
 - `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`
@@ -174,6 +176,30 @@ Combined guard mode:
 - Use both `--wait-for-studio-status` and `--wait-for-audio` in the same run.
 - The pipeline first waits for NotebookLM studio readiness.
 - After download, it applies the rolling quiet-window file wait before upload.
+
+### Cleanup mode
+
+Dry-run (show what would be deleted):
+
+```bash
+python3 scripts/daily_brief.py --cleanup-old
+```
+
+Actually delete:
+
+```bash
+python3 scripts/daily_brief.py --cleanup-old --cleanup-apply
+```
+
+Optional cutoff date (default: today):
+
+```bash
+python3 scripts/daily_brief.py --cleanup-old --cleanup-cutoff-date 2026-03-20
+```
+
+Cleanup behavior:
+- Deletes local podcast audio files older than the cutoff date (matching `YYYY-MM-DD-<slug>.mp3|m4a`).
+- Deletes NotebookLM `reading-list-*` notebooks older than the cutoff date only when a downloaded audio file exists for that notebook’s date+category.
 
 Newsletter tracking for label migration:
 

--- a/dhk-daily-brief/README.md
+++ b/dhk-daily-brief/README.md
@@ -1,314 +1,54 @@
-# DHK Daily Brief — From Inbox to Earbuds
+# DHK Daily Brief
 
-A personal AI-powered podcast pipeline that converts my daily reading list into
-audio episodes, published to [element.fm](https://element.fm) and available in
-Overcast and Apple Podcasts.
+A personal AI pipeline that converts my morning newsletter reading list into published podcast episodes — automatically, every day.
 
----
-
-## How It Works
-
-```
-Starred Gmail
-     ↓
-NotebookLM notebooks (per category, via Claude + MCP)
-     ↓
-Audio Overview generated (NotebookLM)
-     ↓
-nlm CLI download → iCloud Personal Podcast folder
-     ↓
-upload_to_elementfm.py → element.fm "DHK Daily Brief" show
-     ↓
-Overcast / Apple Podcasts (via RSS)
-```
+**Newsletters in. Podcast out. No manual steps.**
 
 ---
 
-## Episode Categories
+## What it does
 
-| File | Category | Description |
-|------|----------|-------------|
-| `YYYY-MM-DD-news.m4a` | 📰 News & Current Affairs | Dispatches, news digests, current events |
-| `YYYY-MM-DD-think.m4a` | 🧠 Things to Think About | Opinion, analysis, ideas, economics, culture |
-| `YYYY-MM-DD-professional.m4a` | 💼 Professional Reading | Industry, technical, career-relevant content |
+Each morning at 6am, the pipeline:
+
+1. Fetches labeled newsletters from Gmail
+2. Triages them into categories (news, ideas, professional)
+3. Creates NotebookLM notebooks per category, loads the content, generates a ~12-minute audio overview
+4. Converts and uploads each episode to Element.fm
+5. Episodes appear in Apple Podcasts
+
+The result: three episodes a day, insight-first, ready to listen during a commute — built entirely from what I was already reading anyway.
 
 ---
 
-## Setup
+## Docs
 
-### Prerequisites
+| Document | Description |
+|---|---|
+| [Process Overview](process-overview.md) | End-to-end design: inputs, phases, parameters, file locations |
+| [Key Ideas](docs/key-ideas.md) | Architectural principles and design decisions |
+| [Context](docs/context.md) | Where this project stands and how it got here |
+| [Installation](docs/install.md) | Prerequisites, environment setup, launchd configuration |
 
-- macOS with zsh
-- Python 3
-- [ffmpeg](https://ffmpeg.org) (`brew install ffmpeg`)
-- [notebooklm-mcp-cli](https://github.com/jacob-bd/notebooklm-mcp-cli) (`uv tool install notebooklm-mcp-cli`)
-- An [element.fm](https://element.fm) account with a show created
-- Claude Desktop with MCP integrations: Gmail, NotebookLM, Todoist
+---
 
-### Environment Variables
-
-Add to `~/.zshrc`:
-
-```zsh
-export CLAUDE_ELEMENT_FM_KEY='your-element-fm-api-key'
-```
-
-Then reload: `source ~/.zshrc`
-
-### Config file (optional)
-
-By default the scripts use the iCloud “Personal Podcast” folder:
-
-- `~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast`
-
-You can override this by creating:
-
-- `~/.config/dhk-daily-brief/config.json`
-
-Example:
-
-```json
-{
-  "audio_dir": "/Users/dhk/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast",
-  "audio_format": "mp3"
-}
-```
-
-Precedence:
-
-- CLI `--audio-dir ...` (highest)
-- `~/.config/dhk-daily-brief/config.json` `"audio_dir"`
-- `DHK_DAILY_BRIEF_AUDIO_DIR` env var
-- Default iCloud folder (lowest)
-
-Audio format:
-
-- Supported: `mp3`, `m4a`
-- Default: `mp3`
-- CLI override: `--audio-format mp3|m4a`
-
-### Install Scripts
+## Quick start
 
 ```bash
-cp scripts/upload_to_elementfm.py ~/scripts/
-cp scripts/personal_podcast_rss.py ~/scripts/
+# Run the full pipeline for today
+daily-brief
+
+# Check what's been published
+daily-brief --show-status
+
+# Upload already-downloaded audio to Element.fm
+daily-brief --upload-only
+
+# Dry run — preview without doing anything
+daily-brief --dry-run
 ```
 
 ---
 
-## Scripts
+## Part of Adventures in AI
 
-### `upload_to_elementfm.py`
-
-Converts a `.m4a` audio file to `.mp3`, creates an episode on element.fm, uploads
-the audio, and publishes it.
-
-```bash
-# Upload and publish
-python3 ~/scripts/upload_to_elementfm.py \
-  "/Users/dhk/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/2026-03-21-news.m4a"
-
-# Custom title
-python3 ~/scripts/upload_to_elementfm.py \
-  "/path/to/file.m4a" --title "Custom Episode Title"
-
-# Dry run
-python3 ~/scripts/upload_to_elementfm.py \
-  "/path/to/file.m4a" --dry-run
-
-# Upload all of today's episodes
-DATE="$(date +%Y-%m-%d)"
-BASE="/Users/dhk/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast"
-for cat in news think professional; do
-  python3 ~/scripts/upload_to_elementfm.py "$BASE/${DATE}-${cat}.m4a"
-done
-```
-
-### `daily_brief.py`
-
-End-to-end runner: finds NotebookLM reading-list notebooks for a date, downloads audio via `nlm`, and uploads to element.fm.
-
-```bash
-python3 scripts/daily_brief.py
-python3 scripts/daily_brief.py --date 2026-03-19
-python3 scripts/daily_brief.py --download-only
-python3 scripts/daily_brief.py --upload-only
-python3 scripts/daily_brief.py --audio-dir "/path/to/podcasts"
-python3 scripts/daily_brief.py --audio-format mp3
-python3 scripts/daily_brief.py --upload-only --wait-for-audio --max-wait-minutes 15 --poll-interval-seconds 20
-python3 scripts/daily_brief.py --wait-for-studio-status --max-wait-minutes 20 --poll-interval-seconds 20
-```
-
-Default behavior now includes both waits:
-
-- `--wait-for-studio-status` is ON by default
-- `--wait-for-audio` is ON by default
-
-Opt out when needed:
-
-```bash
-python3 scripts/daily_brief.py --no-wait-for-studio-status
-python3 scripts/daily_brief.py --no-wait-for-audio
-```
-
-Large MP3 uploads to element.fm may need a longer timeout than JSON calls. Use `--upload-timeout` (default 900s); each upload also scales from file size up to 1 hour.
-
-The script writes a per-date manifest for idempotency at:
-
-- `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`
-
-Upload-only waiting behavior:
-
-- `--wait-for-audio` enables rolling-window waiting for `YYYY-MM-DD-<slug>.<format>` files.
-- It waits up to `--max-wait-minutes` for a first file.
-- Whenever a new file appears, the timer resets for another `--max-wait-minutes`.
-- If no new file appears within a window, it proceeds with files found so far.
-
-NotebookLM status waiting (recommended when downloading in the same run):
-
-- `--wait-for-studio-status` polls `nlm studio status <notebook_id> --json`.
-- It first waits for matching `reading-list-YYYY-MM-DD-NN ...` notebooks to appear.
-- It waits up to `--max-wait-minutes` for studio readiness per notebook.
-- Notebooks not ready by timeout are skipped (reported in output).
-
-Combined guard mode:
-
-- Use both `--wait-for-studio-status` and `--wait-for-audio` in the same run.
-- The pipeline first waits for NotebookLM studio readiness.
-- After download, it applies the rolling quiet-window file wait before upload.
-
-### Cleanup mode
-
-Dry-run (show what would be deleted):
-
-```bash
-python3 scripts/daily_brief.py --cleanup-old
-```
-
-Actually delete:
-
-```bash
-python3 scripts/daily_brief.py --cleanup-old --cleanup-apply
-```
-
-Optional cutoff date (default: today):
-
-```bash
-python3 scripts/daily_brief.py --cleanup-old --cleanup-cutoff-date 2026-03-20
-```
-
-Cleanup behavior:
-- Deletes local podcast audio files older than the cutoff date (matching `YYYY-MM-DD-<slug>.mp3|m4a`).
-- Deletes NotebookLM `reading-list-*` notebooks older than the cutoff date only when a downloaded audio file exists for that notebook’s date+category.
-
-Newsletter tracking for label migration:
-
-- Sender registry file: `dhk-daily-brief/data/newsletter_sender_registry.json`
-- Updated by the `reading-list-builder` skill during starred triage runs.
-
-### `suggest_gmail_label_filters.py`
-
-Reads the sender registry and ranks likely newsletter senders to help migrate from starred-based triage to a Gmail label workflow.
-
-```bash
-# default suggestions
-python3 scripts/suggest_gmail_label_filters.py
-
-# stricter threshold + include one copy/paste OR query
-python3 scripts/suggest_gmail_label_filters.py --min-count 3 --top 20 --emit-or-query
-
-# bias toward one listening category
-python3 scripts/suggest_gmail_label_filters.py --preferred-category think
-```
-
-### `personal_podcast_rss.py`
-
-Local RSS feed server — serves your iCloud Personal Podcast folder as a podcast
-feed. Alternative to element.fm for Overcast on same WiFi.
-
-```bash
-python3 ~/scripts/personal_podcast_rss.py
-# Then subscribe in Overcast to: http://<your-mac-ip>:8765/feed.rss
-```
-
-Optional overrides:
-
-```bash
-python3 ~/scripts/personal_podcast_rss.py --audio-dir "/path/to/podcasts" --port 8765
-```
-
----
-
-## element.fm Config
-
-| Setting | Value |
-|---------|-------|
-| Show | DHK Daily Brief — From Inbox to Earbuds |
-| Show ID | `d5be8d71-5fe3-4d2c-b641-0cd7343e4e36` |
-| Workspace ID | `b08a0951-94a4-441d-a446-81cc7950749c` |
-| API Auth | `Authorization: Token $CLAUDE_ELEMENT_FM_KEY` |
-| API Base | `https://app.element.fm/api/workspaces/{workspace_id}/shows/{show_id}` |
-
-### element.fm API Endpoints
-
-```
-GET    /episodes                     → list episodes
-POST   /episodes                     → create episode
-GET    /episodes/{id}                → get episode
-PATCH  /episodes/{id}                → update episode metadata
-POST   /episodes/{id}/audio          → upload audio (multipart, MP3 only)
-POST   /episodes/{id}/publish        → publish episode
-```
-
----
-
-## Audio Download (NotebookLM CLI)
-
-MCP `download_artifact` fails due to Google auth cookie requirements.
-Use the `nlm` CLI directly:
-
-```bash
-nlm download audio "<notebook-id>" \
-  --output "/Users/dhk/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/YYYY-MM-DD-news.m4a"
-```
-
----
-
-## Claude Skills
-
-The `skills/` directory contains Claude skill files that drive the automated
-pipeline via Claude Desktop + MCP integrations.
-
-| Skill | Trigger | Description |
-|-------|---------|-------------|
-| `reading-list-builder` | "process my starred emails" | Triages Gmail → NotebookLM → Todoist |
-| `personal-podcast` | "upload my podcasts" | Uploads audio to element.fm |
-
-To install, copy the `skills/user/` directory to your Claude skills path.
-
----
-
-## Listening
-
-- **Overcast**: Subscribe via element.fm RSS feed URL (in show settings → Distribution)
-- **Apple Podcasts**: Submit RSS feed at [podcasters.apple.com](https://podcasters.apple.com) (one-time, 24-48hr approval)
-
----
-
-## Artwork
-
-`docs/podcast-cover.svg` — 1400×1400 podcast cover art. Convert to PNG for upload:
-
-```bash
-# ImageMagick
-magick docs/podcast-cover.svg docs/podcast-cover.png
-
-# Or open in browser and export
-```
-
----
-
-## Part of: Adventures in AI
-
-This project lives in the [adventures-in-ai](https://github.com/dhk/adventures-in-ai)
-repo — a collection of personal AI workflow experiments by DHK.
+This project lives in [adventures-in-ai](https://github.com/dhk/adventures-in-ai) — a collection of personal AI workflow experiments by DHK.

--- a/dhk-daily-brief/README.md
+++ b/dhk-daily-brief/README.md
@@ -135,11 +135,32 @@ python3 scripts/daily_brief.py --download-only
 python3 scripts/daily_brief.py --upload-only
 python3 scripts/daily_brief.py --audio-dir "/path/to/podcasts"
 python3 scripts/daily_brief.py --audio-format mp3
+python3 scripts/daily_brief.py --upload-only --wait-for-audio --max-wait-minutes 15 --poll-interval-seconds 20
+python3 scripts/daily_brief.py --wait-for-studio-status --max-wait-minutes 20 --poll-interval-seconds 20
 ```
 
 The script writes a per-date manifest for idempotency at:
 
 - `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`
+
+Upload-only waiting behavior:
+
+- `--wait-for-audio` enables rolling-window waiting for `YYYY-MM-DD-<slug>.<format>` files.
+- It waits up to `--max-wait-minutes` for a first file.
+- Whenever a new file appears, the timer resets for another `--max-wait-minutes`.
+- If no new file appears within a window, it proceeds with files found so far.
+
+NotebookLM status waiting (recommended when downloading in the same run):
+
+- `--wait-for-studio-status` polls `nlm studio status <notebook_id> --json`.
+- It waits up to `--max-wait-minutes` for studio readiness per notebook.
+- Notebooks not ready by timeout are skipped (reported in output).
+
+Combined guard mode:
+
+- Use both `--wait-for-studio-status` and `--wait-for-audio` in the same run.
+- The pipeline first waits for NotebookLM studio readiness.
+- After download, it applies the rolling quiet-window file wait before upload.
 
 Newsletter tracking for label migration:
 

--- a/dhk-daily-brief/README.md
+++ b/dhk-daily-brief/README.md
@@ -55,6 +55,38 @@ export CLAUDE_ELEMENT_FM_KEY='your-element-fm-api-key'
 
 Then reload: `source ~/.zshrc`
 
+### Config file (optional)
+
+By default the scripts use the iCloud “Personal Podcast” folder:
+
+- `~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast`
+
+You can override this by creating:
+
+- `~/.config/dhk-daily-brief/config.json`
+
+Example:
+
+```json
+{
+  "audio_dir": "/Users/dhk/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast",
+  "audio_format": "mp3"
+}
+```
+
+Precedence:
+
+- CLI `--audio-dir ...` (highest)
+- `~/.config/dhk-daily-brief/config.json` `"audio_dir"`
+- `DHK_DAILY_BRIEF_AUDIO_DIR` env var
+- Default iCloud folder (lowest)
+
+Audio format:
+
+- Supported: `mp3`, `m4a`
+- Default: `mp3`
+- CLI override: `--audio-format mp3|m4a`
+
 ### Install Scripts
 
 ```bash
@@ -92,6 +124,43 @@ for cat in news think professional; do
 done
 ```
 
+### `daily_brief.py`
+
+End-to-end runner: finds NotebookLM reading-list notebooks for a date, downloads audio via `nlm`, and uploads to element.fm.
+
+```bash
+python3 scripts/daily_brief.py
+python3 scripts/daily_brief.py --date 2026-03-19
+python3 scripts/daily_brief.py --download-only
+python3 scripts/daily_brief.py --upload-only
+python3 scripts/daily_brief.py --audio-dir "/path/to/podcasts"
+python3 scripts/daily_brief.py --audio-format mp3
+```
+
+The script writes a per-date manifest for idempotency at:
+
+- `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`
+
+Newsletter tracking for label migration:
+
+- Sender registry file: `dhk-daily-brief/data/newsletter_sender_registry.json`
+- Updated by the `reading-list-builder` skill during starred triage runs.
+
+### `suggest_gmail_label_filters.py`
+
+Reads the sender registry and ranks likely newsletter senders to help migrate from starred-based triage to a Gmail label workflow.
+
+```bash
+# default suggestions
+python3 scripts/suggest_gmail_label_filters.py
+
+# stricter threshold + include one copy/paste OR query
+python3 scripts/suggest_gmail_label_filters.py --min-count 3 --top 20 --emit-or-query
+
+# bias toward one listening category
+python3 scripts/suggest_gmail_label_filters.py --preferred-category think
+```
+
 ### `personal_podcast_rss.py`
 
 Local RSS feed server — serves your iCloud Personal Podcast folder as a podcast
@@ -100,6 +169,12 @@ feed. Alternative to element.fm for Overcast on same WiFi.
 ```bash
 python3 ~/scripts/personal_podcast_rss.py
 # Then subscribe in Overcast to: http://<your-mac-ip>:8765/feed.rss
+```
+
+Optional overrides:
+
+```bash
+python3 ~/scripts/personal_podcast_rss.py --audio-dir "/path/to/podcasts" --port 8765
 ```
 
 ---

--- a/dhk-daily-brief/automate-podcast-context-snapshot-2026-03-23.md
+++ b/dhk-daily-brief/automate-podcast-context-snapshot-2026-03-23.md
@@ -1,0 +1,200 @@
+# DHK Daily Brief — System Context Document
+
+**Owner:** Dave Holmes-Kinsella (davehk@gmail.com)  
+**Last updated:** March 23, 2026  
+**Purpose:** Share this document with another LLM to provide full context on the DHK Daily Brief system — what it is, how it works, and how to operate it.
+
+---
+
+## What This Is
+
+The **DHK Daily Brief** is a personal podcast system that automatically converts Dave's starred Gmail newsletters into categorized, AI-generated audio episodes (~15 minutes each). It runs daily, either manually via Claude.ai or on a schedule via Claude Code + cron.
+
+The podcast is published at:
+- **RSS feed:** `https://cdn.element.fm/b08a0951-94a4-441d-a446-81cc7950749c/d5be8d71-5fe3-4d2c-b641-0cd7343e4e36/rss.xml`
+- **Show page:** `https://shows.element.fm/show/daily-thinking`
+- **Hosting platform:** Element.fm
+- **Listed in:** Apple Podcasts (show title: "DHK Daily Brief")
+
+---
+
+## How It Works — End to End
+
+### Step 1: Email Triage (Gmail → Classification)
+
+The workflow fetches all starred emails from Gmail for today (or a specified date range):
+```
+gmail_search_messages(q="is:starred after:YYYY/MM/DD")
+```
+
+Each email is read in full, then classified into one of four categories:
+
+| Category | Icon | Destination |
+|---|---|---|
+| News & Current Affairs | 📰 | NotebookLM notebook |
+| Things to Think About | 🧠 | NotebookLM notebook |
+| Professional Reading | 💼 | NotebookLM notebook |
+| To-Do | 📋 | Todoist Today Pile |
+
+**To-Do signals:** action requests, replies needed, deadlines, SENT emails starred for follow-up, receipts/invoices, subject patterns like "Re:", "Action required", "Following up".
+
+**Ambiguity rule:** Default to To-Do if any action is implied, even loosely.
+
+When run interactively (via Claude.ai), a triage table is shown for user approval before anything is created. The user can reclassify items. When run automated (via cron), the triage step is skipped and the workflow proceeds directly.
+
+---
+
+### Step 2: To-Dos → Todoist
+
+To-do emails are added as a **single grouped task** to the "Today Pile" project in Todoist:
+
+```
+add-tasks([{
+  content: "📬 Email triage — YYYY-MM-DD",
+  projectId: <Today Pile ID>,
+  description: "• \"<subject>\" — <sender/note>\n• ...",
+  dueString: "today",
+  priority: "p3"
+}])
+```
+
+If the Today Pile project doesn't exist, it's created automatically (orange, favorited).
+
+---
+
+### Step 3: To-Reads → NotebookLM
+
+One NotebookLM notebook is created per non-empty read category, named:
+- `reading-list-YYYY-MM-DD-01 📰 News & Current Affairs`
+- `reading-list-YYYY-MM-DD-02 🧠 Things to Think About`
+- `reading-list-YYYY-MM-DD-03 💼 Professional Reading`
+
+Each email is added as a text source (`source_add`, `wait=True`). Bodies are truncated to ~8,000 characters if very long.
+
+After all sources are loaded, an audio overview is generated for each notebook:
+```
+studio_create(
+  artifact_type="audio",
+  audio_format="deep_dive",
+  audio_length="long",
+  focus_prompt="This is a personal podcast for one listener. Open with the 2-3
+    most important ideas across all sources — give the signal first. Then go
+    deeper on each piece in turn. Close with commentary and open questions.
+    Prioritize insight over summary. Target roughly 15 minutes of content."
+)
+```
+
+---
+
+### Step 4: Publish to Element.fm
+
+The generated audio files are uploaded to Element.fm and published as episodes of the DHK Daily Brief podcast. Each episode corresponds to one category notebook (e.g. one episode for News, one for Things to Think About).
+
+**Important RSS note:** Each episode must have a unique `<itunes:episode>` number. Duplicate episode numbers cause Apple Podcasts to suppress episodes from the directory listing.
+
+After publishing, force Apple Podcasts to re-crawl at:
+`https://podcastsconnect.apple.com` → find the show → Refresh Feed.
+
+---
+
+## MCP Integrations Required
+
+This workflow requires three MCP servers to be connected:
+
+| Service | MCP URL | Used for |
+|---|---|---|
+| Gmail | `https://gmail.mcp.claude.com/mcp` | Fetching starred emails |
+| Google NotebookLM | `notebooklm-mcp-cli` (local) | Creating notebooks, adding sources, generating audio |
+| Todoist | `https://ai.todoist.net/mcp` | Adding to-do tasks to Today Pile |
+
+---
+
+## Automation Setup (Claude Code + Cron)
+
+The workflow can be run unattended every morning via Claude Code in headless (`-p`) mode.
+
+**Key files:**
+- `~/.claude/skills/reading-list-builder.md` — the skill/prompt that Claude Code reads
+- `~/bin/run-reading-list.sh` — the shell script invoked by cron
+- Logs written to `~/logs/reading-list/YYYY-MM-DD.log`
+
+**Cron schedule (7am daily):**
+```
+0 7 * * * /Users/davehk/bin/run-reading-list.sh
+```
+
+On macOS, launchd is recommended over cron for reliability.
+
+**Known issue:** As of March 2026, HTTP-based MCP servers in `~/.claude.json` don't load in Claude Code's `-p` (headless) mode (GitHub issue #34131). The run script works around this by passing `--mcp-server` flags explicitly:
+```bash
+claude -p "$(cat "$SKILL_FILE")" \
+  --mcp-server "gmail=https://gmail.mcp.claude.com/mcp" \
+  --mcp-server "todoist=https://ai.todoist.net/mcp" \
+  --mcp-server "notebooklm=..." \
+  --allowedTools "mcp__gmail__*,mcp__todoist__*,mcp__notebooklm__*" \
+  --dangerously-skip-permissions \
+  --output-format text
+```
+
+---
+
+## Operating the Workflow Manually (Claude.ai)
+
+To trigger the workflow in Claude.ai, say any of:
+- "create today's reading list"
+- "process my starred emails"
+- "run my email triage"
+- "build my reading list"
+
+The skill name is **`reading-list-builder`**.
+
+**Interactive mode behavior:**
+1. Fetches and reads all starred emails
+2. Shows a triage table grouped by category
+3. Waits for user confirmation (or reclassification requests)
+4. Creates NotebookLM notebooks + generates audio
+5. Adds any to-dos to Todoist Today Pile
+6. Reports back with notebook links
+
+**User preferences established in prior sessions:**
+- Audio length: ~15 minutes ("long" setting)
+- Audio are referred to as "personal podcasts"
+- Items can be excluded at the triage step (e.g. "cut Chuck Norris")
+- Reclassification is supported — user can move items between categories before proceeding
+
+---
+
+## Notebook Naming Convention
+
+```
+reading-list-YYYY-MM-DD-NN CATEGORY_EMOJI Category Name
+```
+
+Examples:
+- `reading-list-2026-03-21-01 📰 News & Current Affairs`
+- `reading-list-2026-03-21-02 🧠 Things to Think About`
+- `reading-list-2026-03-21-03 💼 Professional Reading`
+
+If running for a date range, the end date (today) is used. If a notebook with today's date already exists, the numeric suffix is incremented (01 → 02 → 03).
+
+---
+
+## Edge Cases & Known Behaviors
+
+- **No starred emails:** Report and stop. Offer to widen the date range.
+- **HTML-only email body:** Use subject + snippet as source text; note "[body unavailable]" in the title.
+- **All to-reads, no to-dos:** Skip Todoist entirely.
+- **All to-dos, no to-reads:** Skip NotebookLM entirely.
+- **Tool call limit hit mid-run:** Report exactly what was completed and what remains so the user can continue in the next turn.
+- **Duplicate episode numbers in RSS:** Causes Apple Podcasts to suppress episodes. Fix in Element.fm, then force re-crawl via Podcasts Connect.
+
+---
+
+## User Context
+
+- **Name:** Dave (goes by DHK)
+- **Email:** davehk@gmail.com
+- **Work:** DHK Consulting; Substack called "dhkondata" (data topics); consulting work with Synctera
+- **Stack:** Claude.ai (claude.ai), Claude Desktop with MCP integrations, Todoist Pro, Google NotebookLM, Element.fm
+- **Productivity style:** Prefers concrete over vague tasks, aggressive cleanup, knock-off-and-organize mode for lighter days
+- **Tone preference:** Direct, no unnecessary hedging, skip the meta-commentary

--- a/dhk-daily-brief/automate-podcast-context-snapshot-2026-03-24.md
+++ b/dhk-daily-brief/automate-podcast-context-snapshot-2026-03-24.md
@@ -1,0 +1,370 @@
+# DHK Daily Brief — System Context Document
+
+**Owner:** Dave Holmes-Kinsella (davehk@gmail.com)
+**Last updated:** March 24, 2026
+**Purpose:** Share this document with another LLM to provide full context on the DHK Daily Brief system — what it is, how it works, and how to operate it.
+
+---
+
+## What This Is
+
+The **DHK Daily Brief** is a personal podcast system that automatically converts Dave's starred Gmail newsletters into categorized, AI-generated audio episodes (~12 minutes each). It runs daily, either manually via Claude.ai or on a schedule via Claude Code + cron.
+
+The podcast is published at:
+- **RSS feed:** `https://cdn.element.fm/b08a0951-94a4-441d-a446-81cc7950749c/d5be8d71-5fe3-4d2c-b641-0cd7343e4e36/rss.xml`
+- **Show page:** `https://shows.element.fm/show/daily-thinking`
+- **Hosting platform:** Element.fm
+- **Listed in:** Apple Podcasts (show title: "DHK Daily Brief")
+
+---
+
+## How It Works — End to End
+
+The pipeline has two distinct phases:
+
+1. **Email triage + audio generation** — handled by the `reading-list-builder` Claude skill (interactive or cron)
+2. **Audio download + Element.fm publishing** — handled by `scripts/daily_brief.py` (separate Python script)
+
+---
+
+### Phase 1: Email Triage → NotebookLM (reading-list-builder skill)
+
+#### Step 1: Email Triage (Gmail → Classification)
+
+The workflow fetches all starred emails from Gmail for today (or a specified date range):
+```
+gmail_search_messages(q="is:starred after:YYYY/MM/DD")
+```
+
+Each email is read in full, then classified into one of four categories:
+
+| Category | Icon | Destination |
+|---|---|---|
+| News & Current Affairs | 📰 | NotebookLM notebook |
+| Things to Think About | 🧠 | NotebookLM notebook |
+| Professional Reading | 💼 | NotebookLM notebook |
+| To-Do | 📋 | Todoist Today Pile |
+
+**To-Do signals:** action requests, replies needed, deadlines, SENT emails starred for follow-up, receipts/invoices, subject patterns like "Re:", "Action required", "Following up".
+
+**Ambiguity rule:** Default to To-Do if any action is implied, even loosely.
+
+When run interactively (via Claude.ai), a triage table is shown for user approval before anything is created. The user can reclassify items. When run automated (via cron), the triage step is skipped and the workflow proceeds directly.
+
+#### Step 2: To-Dos → Todoist
+
+To-do emails are added as a **single grouped task** to the "Today Pile" project in Todoist:
+
+```
+add-tasks([{
+  content: "📬 Email triage — YYYY-MM-DD",
+  projectId: <Today Pile ID>,
+  description: "• \"<subject>\" — <sender/note>\n• ...",
+  dueString: "today",
+  priority: "p3"
+}])
+```
+
+If the Today Pile project doesn't exist, it's created automatically (orange, favorited).
+
+#### Step 3: To-Reads → NotebookLM
+
+One NotebookLM notebook is created per non-empty read category, named:
+- `reading-list-YYYY-MM-DD-01 📰 News & Current Affairs`
+- `reading-list-YYYY-MM-DD-02 🧠 Things to Think About`
+- `reading-list-YYYY-MM-DD-03 💼 Professional Reading`
+
+Each email is added as a text source (`source_add`, `wait=True`). Bodies are truncated to ~8,000 characters if very long.
+
+After all sources are loaded, an audio overview is generated for each notebook:
+```
+studio_create(
+  artifact_type="audio",
+  audio_format="deep_dive",
+  audio_length="long",
+  focus_prompt="Open with the 3-5 most important ideas or takeaways across all the
+    sources — give me the signal first. Then go deeper on each piece in turn. Close
+    with any commentary, opinions, or open questions raised in the material. Prioritize
+    insight over summary. Target roughly 12 minutes of content."
+)
+```
+
+#### Step 4: Download Audio to iCloud
+
+After audio generation completes (polled via `studio_status`), each audio file is downloaded to the iCloud Personal Podcast folder:
+
+```
+~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/
+```
+
+Filename convention: `YYYY-MM-DD-<slug>.mp3`
+- `2026-03-21-news.mp3`
+- `2026-03-21-think.mp3`
+- `2026-03-21-professional.mp3`
+
+Category slugs: `news`, `think`, `professional`
+
+---
+
+### Phase 2: Element.fm Publishing (daily_brief.py)
+
+The `scripts/daily_brief.py` script handles downloading audio from NotebookLM via the `nlm` CLI and uploading to Element.fm. It runs separately from the skill — either manually or via cron after audio generation completes.
+
+**Basic usage:**
+```bash
+python3 scripts/daily_brief.py                   # full pipeline for today
+python3 scripts/daily_brief.py --date 2026-03-19 # specific date
+python3 scripts/daily_brief.py --download-only   # nlm download only, skip upload
+python3 scripts/daily_brief.py --upload-only     # upload only (files already exist)
+python3 scripts/daily_brief.py --dry-run         # preview without doing anything
+```
+
+**Key behaviors:**
+- Waits for NotebookLM notebooks to appear (`--wait-for-studio-status`, on by default)
+- Polls `nlm studio status` until audio generation completes
+- Rolling-window file wait for downloaded audio before uploading
+- Idempotent: per-date manifest at `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json` tracks episode IDs, upload and publish status — safe to re-run
+- Auto-converts m4a → mp3 via ffmpeg if needed
+
+**Important RSS note:** Each episode must have a unique `<itunes:episode>` number. Duplicate episode numbers cause Apple Podcasts to suppress episodes from the directory listing. The script handles this automatically via `get_next_episode_number()`.
+
+After publishing, force Apple Podcasts to re-crawl at:
+`https://podcastsconnect.apple.com` → find the show → Refresh Feed.
+
+**Element.fm API credentials:**
+- Env var: `CLAUDE_ELEMENT_FM_KEY`
+- Workspace ID: `b08a0951-94a4-441d-a446-81cc7950749c`
+- Show ID: `d5be8d71-5fe3-4d2c-b641-0cd7343e4e36`
+
+---
+
+## Supporting Scripts
+
+### `scripts/elementfm_client.py`
+REST client for the Element.fm API. Handles authentication, retries with exponential backoff, multipart audio upload, episode create/patch/publish. Used by `daily_brief.py`.
+
+### `scripts/podcast_config.py`
+Configuration, parsing, and utility functions shared across scripts:
+- `resolve_audio_dir()` — config precedence: CLI > `~/.config/dhk-daily-brief/config.json` > env var `DHK_DAILY_BRIEF_AUDIO_DIR` > iCloud default
+- `resolve_audio_format()` — same precedence, default `mp3`
+- `parse_episode_title_from_filename()` — e.g. `2026-03-21-news.mp3` → `📰 News & Current Affairs — Mar 21, 2026`
+- `parse_reading_list_notebook_title()` — extracts date, nn, category from notebook name
+- `manifest_path_for_date()` — `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`
+
+### `scripts/subprocess_utils.py`
+Subprocess wrapper with configurable timeout and exponential-backoff retries. Returns a `RunResult` dataclass (returncode, stdout, stderr, attempts, elapsed).
+
+### `scripts/upload_to_elementfm.py`
+Standalone script to upload a single audio file to Element.fm (useful for one-off uploads or re-uploads). Wraps `elementfm_client.py`.
+
+### `scripts/suggest_gmail_label_filters.py`
+Reads `data/newsletter_sender_registry.json` and generates Gmail filter query suggestions ranked by frequency. Supports `--preferred-category`, `--min-count`, `--top`, `--emit-or-query`. Useful for migrating from starred-based workflow to label-based.
+
+### `scripts/personal_podcast_rss.py`
+Serves the iCloud Personal Podcast folder as a local RSS feed (default port 8765). Lets Overcast subscribe to the local feed before episodes are uploaded to Element.fm.
+
+---
+
+## Configuration
+
+### `~/.config/dhk-daily-brief/config.json`
+Optional JSON config file. Supported keys:
+```json
+{
+  "audio_dir": "/path/to/audio",
+  "audio_format": "mp3"
+}
+```
+
+### Environment Variables
+| Variable | Purpose |
+|---|---|
+| `CLAUDE_ELEMENT_FM_KEY` | Element.fm API token (required for upload) |
+| `DHK_DAILY_BRIEF_AUDIO_DIR` | Override audio directory |
+
+---
+
+## Newsletter Sender Registry
+
+The skill maintains a running registry at `dhk-daily-brief/data/newsletter_sender_registry.json`. For every non-to-do newsletter seen in triage, it tracks sender email/name, first/last seen, count, category usage, and recent subjects. Schema:
+
+```json
+{
+  "version": 1,
+  "updated_at": "ISO-8601",
+  "senders": {
+    "sender@example.com": {
+      "name": "Newsletter Name",
+      "email": "sender@example.com",
+      "first_seen": "YYYY-MM-DD",
+      "last_seen": "YYYY-MM-DD",
+      "count": 12,
+      "categories": {"news": 7, "think": 4, "professional": 1},
+      "last_subject": "...",
+      "subjects": ["...", "..."]
+    }
+  }
+}
+```
+
+Use `suggest_gmail_label_filters.py` to turn this into Gmail filter query snippets.
+
+---
+
+## MCP Integrations Required
+
+This workflow requires three MCP servers to be connected:
+
+| Service | MCP URL | Used for |
+|---|---|---|
+| Gmail | `https://gmail.mcp.claude.com/mcp` | Fetching starred emails |
+| Google NotebookLM | `notebooklm-mcp-cli` (local) | Creating notebooks, adding sources, generating audio |
+| Todoist | `https://ai.todoist.net/mcp` | Adding to-do tasks to Today Pile |
+
+---
+
+## Automation Setup (launchd)
+
+**Status as of March 24, 2026: fully configured and running.**
+
+### Key files
+
+| File | Purpose |
+|---|---|
+| `~/bin/run-reading-list.sh` | Main script invoked by launchd |
+| `~/Library/LaunchAgents/com.dhk.reading-list.plist` | launchd job definition |
+| `~/logs/reading-list/YYYY-MM-DD.log` | Per-run output log (written by the script) |
+| `~/logs/reading-list/launchd.log` | stdout/stderr captured by launchd |
+
+### Schedule
+
+Runs at **6:00am PT daily** via launchd. System timezone is `America/Los_Angeles`.
+
+launchd is preferred over cron on macOS because it wakes the machine from sleep to run jobs (or catches up when the machine wakes if it missed the scheduled time).
+
+To reload after editing the plist:
+```bash
+launchctl unload ~/Library/LaunchAgents/com.dhk.reading-list.plist
+launchctl load ~/Library/LaunchAgents/com.dhk.reading-list.plist
+```
+
+To check status:
+```bash
+launchctl list | grep com.dhk.reading-list
+```
+
+### What run-reading-list.sh does
+
+1. Sources `~/.zshrc` to pick up `CLAUDE_ELEMENT_FM_KEY` and other env vars (cron/launchd run with a bare environment)
+2. Runs the `reading-list-builder` skill headlessly via `claude -p`, passing MCP servers via `--mcp-config` inline JSON
+3. Bails if the skill exits non-zero
+4. Runs `daily_brief.py` to wait for studio audio, download via `nlm`, and upload to Element.fm
+
+### MCP config (inline JSON in the run script)
+
+**Known issue:** As of March 2026, HTTP-based MCP servers in `~/.claude.json` don't load in Claude Code's `-p` (headless) mode (GitHub issue #34131). The run script works around this by passing `--mcp-config` explicitly:
+
+```json
+{
+  "mcpServers": {
+    "gmail":      { "type": "http", "url": "https://gmail.mcp.claude.com/mcp" },
+    "todoist":    { "type": "http", "url": "https://ai.todoist.net/mcp" },
+    "notebooklm": { "type": "stdio", "command": "uvx", "args": ["--from", "notebooklm-mcp-cli", "notebooklm-mcp"] }
+  }
+}
+```
+
+The notebooklm MCP binary is `notebooklm-mcp` (not `notebooklm-mcp-cli`); invoke via `uvx --from notebooklm-mcp-cli notebooklm-mcp`.
+
+---
+
+## Operating the Workflow Manually (Claude.ai)
+
+To trigger the workflow in Claude.ai, say any of:
+- "create today's reading list"
+- "process my starred emails"
+- "run my email triage"
+- "build my reading list"
+
+The skill name is **`reading-list-builder`**.
+
+**Interactive mode behavior:**
+1. Fetches and reads all starred emails
+2. Shows a triage table grouped by category
+3. Waits for user confirmation (or reclassification requests)
+4. Creates NotebookLM notebooks + generates audio
+5. Adds any to-dos to Todoist Today Pile
+6. Downloads audio to iCloud Personal Podcast folder
+7. Reports back with notebook links and download status
+
+Then run `daily_brief.py` separately to upload to Element.fm.
+
+**User preferences established in prior sessions:**
+- Audio length: ~12 minutes ("long" setting)
+- Audio are referred to as "personal podcasts"
+- Items can be excluded at the triage step (e.g. "cut Chuck Norris")
+- Reclassification is supported — user can move items between categories before proceeding
+
+---
+
+## Notebook Naming Convention
+
+```
+reading-list-YYYY-MM-DD-NN CATEGORY_EMOJI Category Name
+```
+
+Examples:
+- `reading-list-2026-03-21-01 📰 News & Current Affairs`
+- `reading-list-2026-03-21-02 🧠 Things to Think About`
+- `reading-list-2026-03-21-03 💼 Professional Reading`
+
+If running for a date range, the end date (today) is used. If a notebook with today's date already exists, the numeric suffix is incremented (01 → 02 → 03).
+
+---
+
+## Audio File Naming Convention
+
+```
+YYYY-MM-DD-<slug>.<ext>
+```
+
+Slugs: `news`, `think`, `professional`
+Extensions: `mp3` (default), `m4a`
+
+Examples: `2026-03-21-news.mp3`, `2026-03-21-think.m4a`
+
+---
+
+## Edge Cases & Known Behaviors
+
+- **No starred emails:** Report and stop. Offer to widen the date range.
+- **HTML-only email body:** Use subject + snippet as source text; note "[body unavailable]" in the title.
+- **All to-reads, no to-dos:** Skip Todoist entirely.
+- **All to-dos, no to-reads:** Skip NotebookLM entirely.
+- **Tool call limit hit mid-run:** Report exactly what was completed and what remains so the user can continue in the next turn.
+- **Duplicate episode numbers in RSS:** Causes Apple Podcasts to suppress episodes. Fix in Element.fm, then force re-crawl via Podcasts Connect.
+- **Studio audio not ready:** `daily_brief.py` will wait up to `--max-wait-minutes` (default 15) before timing out. Re-run with `--no-wait-for-studio-status` to skip the wait if audio is already ready.
+
+---
+
+## Cleanup
+
+`daily_brief.py` supports a cleanup mode for housekeeping:
+```bash
+python3 daily_brief.py --cleanup-old                              # dry-run
+python3 daily_brief.py --cleanup-old --cleanup-apply             # apply
+python3 daily_brief.py --cleanup-old --cleanup-cutoff-date 2026-03-01
+```
+
+Deletes local audio files and NotebookLM notebooks older than the cutoff date. Notebooks are only deleted if a corresponding downloaded audio file exists (prevents data loss if a download was missed).
+
+---
+
+## User Context
+
+- **Name:** Dave (goes by DHK)
+- **Email:** davehk@gmail.com
+- **Work:** DHK Consulting; Substack called "dhkondata" (data topics); consulting work with Synctera
+- **Stack:** Claude.ai (claude.ai), Claude Desktop with MCP integrations, Todoist Pro, Google NotebookLM, Element.fm
+- **Productivity style:** Prefers concrete over vague tasks, aggressive cleanup, knock-off-and-organize mode for lighter days
+- **Tone preference:** Direct, no unnecessary hedging, skip the meta-commentary

--- a/dhk-daily-brief/data/newsletter_sender_registry.json
+++ b/dhk-daily-brief/data/newsletter_sender_registry.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "updated_at": null,
+  "senders": {}
+}

--- a/dhk-daily-brief/process-overview.md
+++ b/dhk-daily-brief/process-overview.md
@@ -1,0 +1,107 @@
+# DHK Daily Brief — Process Overview
+
+---
+
+## Inputs
+
+| Input | Source | Notes |
+|---|---|---|
+| Starred Gmail emails | Gmail MCP | Fetched for today (or a date range) |
+| Date | CLI arg or default (today) | Controls which notebooks and audio files are targeted |
+| `CLAUDE_ELEMENT_FM_KEY` | `~/.zshrc` | Required for Element.fm upload |
+| `~/.config/dhk-daily-brief/config.json` | Config file | Sets `audio_dir` and `audio_format` |
+| `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json` | State file | Idempotency — tracks what's been uploaded/published |
+
+---
+
+## Phase 1 — Email Triage + Audio Generation (reading-list-builder skill)
+
+Runs via Claude (`claude -p`) with Gmail, Todoist, and NotebookLM MCPs.
+
+### Steps
+
+1. **Fetch emails** — `gmail_search_messages` for starred emails on the target date
+2. **Read each email** — `gmail_read_message` for full content
+3. **Classify** each email into one of four categories:
+   - 📰 News & Current Affairs → NotebookLM
+   - 🧠 Things to Think About → NotebookLM
+   - 💼 Professional Reading → NotebookLM
+   - 📋 To-Do → Todoist
+4. **Show triage table** and wait for confirmation *(interactive only — skipped in automated/cron mode)*
+5. **Create Todoist task** — one grouped task in "Today Pile" for all to-dos
+6. **Create NotebookLM notebooks** — one per non-empty read category, named `reading-list-YYYY-MM-DD-NN 📰 Category`
+7. **Add sources** — each email body added as a text source (`source_add`)
+8. **Generate audio** — `studio_create` per notebook with:
+   - `audio_format: deep_dive`
+   - `audio_length: long`
+   - Focus prompt targeting ~12 minutes
+9. **Poll for completion** — `studio_status` until done
+10. **Download audio** — `download_artifact` to iCloud Personal Podcast folder
+
+### Outputs
+
+- Up to 3 NotebookLM notebooks
+- Up to 3 audio files in `~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/`
+  - Named `YYYY-MM-DD-news.mp3`, `YYYY-MM-DD-think.mp3`, `YYYY-MM-DD-professional.mp3`
+- 1 Todoist task in Today Pile (if any to-dos)
+- Updated `dhk-daily-brief/data/newsletter_sender_registry.json`
+
+---
+
+## Phase 2 — Upload to Element.fm (daily_brief.py)
+
+Runs as a Python script after Phase 1 completes.
+
+### Steps
+
+1. **Check manifest** — skip any slugs already published
+2. **Find notebooks** — `nlm notebook list`, match by date and category name
+3. **Wait for studio audio** — polls `nlm studio status` until ready (up to 15 min)
+4. **Download audio** — `nlm download audio` to iCloud folder (skips if file exists)
+5. **Wait for files** — rolling-window file watch before uploading
+6. **Upload to Element.fm** — per episode:
+   - Create episode (or reuse existing by title)
+   - Upload MP3
+   - Set description
+   - Publish
+
+### Outputs
+
+- Up to 3 published episodes on Element.fm / DHK Daily Brief podcast
+- Updated manifest at `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json`
+
+---
+
+## Automation
+
+- **Trigger:** launchd at 6:00am PT daily
+- **Script:** `~/bin/run-reading-list.sh`
+- **Guard:** checks manifest before running — exits early if all 3 episodes already published
+- **Skill sync:** copies `SKILL.md` and all Python scripts from repo to `~/.local/share/` and `~/.config/` at start of each run (launchd can't read `~/Documents` directly)
+- **Logs:** `~/logs/reading-list/YYYY-MM-DD.log`
+
+---
+
+## Key Parameters
+
+| Parameter | Current value | Where set |
+|---|---|---|
+| Audio format | `deep_dive` | SKILL.md |
+| Audio length | `long` | SKILL.md |
+| Target duration | ~12 minutes | SKILL.md focus prompt |
+| Output file format | `mp3` | `~/.config/dhk-daily-brief/config.json` |
+| Audio output dir | iCloud Personal Podcast | `~/.config/dhk-daily-brief/config.json` |
+| Slugs processed | `news`, `think`, `professional` | `daily_brief.py` default |
+| Max wait for studio | 15 minutes | `daily_brief.py` default |
+| Poll interval | 20 seconds | `daily_brief.py` default |
+| Element.fm show | DHK Daily Brief | hardcoded in `daily_brief.py` |
+
+---
+
+## Category → Slug Mapping
+
+| Category | Emoji | Slug | Notebook suffix |
+|---|---|---|---|
+| News & Current Affairs | 📰 | `news` | `-01` |
+| Things to Think About | 🧠 | `think` | `-02` |
+| Professional Reading | 💼 | `professional` | `-03` |

--- a/dhk-daily-brief/process-overview.md
+++ b/dhk-daily-brief/process-overview.md
@@ -6,11 +6,26 @@
 
 | Input | Source | Notes |
 |---|---|---|
-| Starred Gmail emails | Gmail MCP | Fetched for today (or a date range) |
+| Labeled Gmail emails | Gmail MCP | Fetched by label (`newsletter/news`, `newsletter/think`, `newsletter/pro`) — no star required |
+| Starred Gmail emails | Gmail MCP | Fallback search for unlabeled starred emails (to-do triage only) |
 | Date | CLI arg or default (today) | Controls which notebooks and audio files are targeted |
 | `CLAUDE_ELEMENT_FM_KEY` | `~/.zshrc` | Required for Element.fm upload |
 | `~/.config/dhk-daily-brief/config.json` | Config file | Sets `audio_dir` and `audio_format` |
 | `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json` | State file | Idempotency — tracks what's been uploaded/published |
+
+---
+
+## Newsletter Label System
+
+Gmail filters auto-label incoming newsletters into three categories. These labels are the primary eligibility gate — no starring required.
+
+| Label | Senders |
+|---|---|
+| `newsletter/news` | sanfrancisco@axios.com, email@washingtonpost.com, dailydigest@email.join1440.com, hello@newsletter.thedispatch.com, newsletters@theatlantic.com |
+| `newsletter/think` | noahpinion@substack.com, yaschamounk@substack.com, persuasion1+francis-fukuyama@substack.com, opinionatedintelligence@substack.com, post+the-weekender@substack.com |
+| `newsletter/pro` | ai.plus@axios.com, dan@tldrnewsletter.com, pragmaticengineer+deepdives@substack.com, lenny@substack.com, newsletter@towardsdatascience.com, hello@mindstream.news, thecode@mail.joinsuperhuman.ai, marketing-team@motherduck.com, info@theinformation.com, marcussawyerr@substack.com |
+
+To add a new newsletter: create a Gmail filter for its sender, apply the appropriate label, and add it to the registry at `dhk-daily-brief/data/newsletter_sender_registry.json`.
 
 ---
 
@@ -20,13 +35,13 @@ Runs via Claude (`claude -p`) with Gmail, Todoist, and NotebookLM MCPs.
 
 ### Steps
 
-1. **Fetch emails** — `gmail_search_messages` for starred emails on the target date
+1. **Fetch emails** — primary: `gmail_search_messages` for labeled emails on the target date; fallback: `gmail_search_messages` for starred emails (to-do triage only)
 2. **Read each email** — `gmail_read_message` for full content
 3. **Classify** each email into one of four categories:
-   - 📰 News & Current Affairs → NotebookLM
-   - 🧠 Things to Think About → NotebookLM
-   - 💼 Professional Reading → NotebookLM
-   - 📋 To-Do → Todoist
+   - 📰 News & Current Affairs → NotebookLM (label hint: `newsletter/news`)
+   - 🧠 Things to Think About → NotebookLM (label hint: `newsletter/think`)
+   - 💼 Professional Reading → NotebookLM (label hint: `newsletter/pro`)
+   - 📋 To-Do → Todoist (unlabeled starred emails default here)
 4. **Show triage table** and wait for confirmation *(interactive only — skipped in automated/cron mode)*
 5. **Create Todoist task** — one grouped task in "Today Pile" for all to-dos
 6. **Create NotebookLM notebooks** — one per non-empty read category, named `reading-list-YYYY-MM-DD-NN 📰 Category`
@@ -34,15 +49,17 @@ Runs via Claude (`claude -p`) with Gmail, Todoist, and NotebookLM MCPs.
 8. **Generate audio** — `studio_create` per notebook with:
    - `audio_format: deep_dive`
    - `audio_length: long`
-   - Focus prompt targeting ~12 minutes
+   - Focus prompt: *"This episode should run approximately 12 minutes. Open with the 3-5 most important ideas or takeaways across all the sources — give me the signal first. Then go deeper on each piece in turn. Close with any commentary, opinions, or open questions raised in the material. Prioritize insight over summary."*
 9. **Poll for completion** — `studio_status` until done
-10. **Download audio** — `download_artifact` to iCloud Personal Podcast folder
+10. **Title & describe each episode** — `notebook_describe` to get AI summary, then `studio_status(action="rename")` to set title with bullet-point key ideas and sources line
+11. **Download audio** — `download_artifact` to iCloud Personal Podcast folder
 
 ### Outputs
 
 - Up to 3 NotebookLM notebooks
 - Up to 3 audio files in `~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/`
   - Named `YYYY-MM-DD-news.mp3`, `YYYY-MM-DD-think.mp3`, `YYYY-MM-DD-professional.mp3`
+- Each audio episode titled with: NotebookLM auto-title + 3-5 insight bullets + sources line
 - 1 Todoist task in Today Pile (if any to-dos)
 - Updated `dhk-daily-brief/data/newsletter_sender_registry.json`
 
@@ -62,7 +79,7 @@ Runs as a Python script after Phase 1 completes.
 6. **Upload to Element.fm** — per episode:
    - Create episode (or reuse existing by title)
    - Upload MP3
-   - Set description
+   - Set description (uses episode title with bullets and sources from Phase 1)
    - Publish
 
 ### Outputs
@@ -100,8 +117,22 @@ Runs as a Python script after Phase 1 completes.
 
 ## Category → Slug Mapping
 
-| Category | Emoji | Slug | Notebook suffix |
-|---|---|---|---|
-| News & Current Affairs | 📰 | `news` | `-01` |
-| Things to Think About | 🧠 | `think` | `-02` |
-| Professional Reading | 💼 | `professional` | `-03` |
+| Category | Emoji | Slug | Notebook suffix | Gmail label |
+|---|---|---|---|---|
+| News & Current Affairs | 📰 | `news` | `-01` | `newsletter/news` |
+| Things to Think About | 🧠 | `think` | `-02` | `newsletter/think` |
+| Professional Reading | 💼 | `professional` | `-03` | `newsletter/pro` |
+
+---
+
+## File Locations
+
+| File | Path |
+|---|---|
+| Repo (source of truth) | `~/Documents/dev/adventures-in-ai/dhk-daily-brief/` |
+| Live skill (deployed by sync) | `~/.local/share/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md` |
+| Config | `~/.config/dhk-daily-brief/config.json` |
+| Manifest | `~/.local/state/dhk-daily-brief/manifest-YYYY-MM-DD.json` |
+| Logs | `~/logs/reading-list/YYYY-MM-DD.log` |
+| Audio output | `~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/` |
+| Sender registry | `~/Documents/dev/adventures-in-ai/dhk-daily-brief/data/newsletter_sender_registry.json` |

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -31,9 +31,12 @@ from elementfm_client import ElementFmClient, ElementFmConfig
 from podcast_config import (
     CATEGORY_SLUGS,
     CATEGORY_TITLES,
+    elementfm_episode_description,
     manifest_path_for_date,
+    parse_audio_filename,
     parse_episode_title_from_filename,
     parse_reading_list_notebook_title,
+    slug_for_category_title,
     resolve_audio_dir,
     resolve_audio_format,
 )
@@ -216,6 +219,157 @@ def wait_for_notebooks_for_date(
     return {}
 
 
+def _parse_iso_date(date_str: str) -> date:
+    return datetime.strptime(date_str, "%Y-%m-%d").date()
+
+
+def cleanup_old_items(*, audio_dir: Path, cutoff_date_str: str, apply: bool) -> int:
+    """
+    Cleanup mode (dry-run by default).
+
+    Deletes local podcast audio files older than cutoff_date in the expected naming scheme.
+    Deletes NotebookLM reading-list notebooks older than cutoff_date ONLY if a downloaded audio
+    file exists for that (date, category slug).
+    """
+    header(f"Cleanup mode (cutoff: {cutoff_date_str})")
+    if not audio_dir.exists():
+        warn(f"Audio directory not found: {audio_dir}")
+        return 1
+
+    cutoff_date = _parse_iso_date(cutoff_date_str)
+
+    # 1) Audio files (local)
+    supported_exts = {"mp3", "m4a"}
+    allowed_slugs = set(CATEGORY_SLUGS.values())
+
+    audio_deletions: list[tuple[Path, str, str]] = []  # (path, dt, slug)
+    audio_keys: set[tuple[str, str]] = set()  # (dt, slug)
+    audio_kept_wrong_slug: list[tuple[Path, str, str]] = []
+    audio_kept_wrong_ext: list[tuple[Path, str, str]] = []
+
+    for path in audio_dir.iterdir():
+        if not path.is_file():
+            continue
+        parsed = parse_audio_filename(path.name)
+        if not parsed:
+            continue
+        dt, slug, ext = parsed
+        if _parse_iso_date(dt) < cutoff_date:
+            if slug in allowed_slugs and ext in supported_exts:
+                audio_deletions.append((path, dt, slug))
+                audio_keys.add((dt, slug))
+            elif slug not in allowed_slugs:
+                audio_kept_wrong_slug.append((path, dt, slug))
+            elif ext not in supported_exts:
+                audio_kept_wrong_ext.append((path, dt, slug))
+
+    # 2) Notebooks (NotebookLM)
+    nlm_result = run_with_retries(
+        [NLM_CLI, "notebook", "list", "--json"],
+        timeout_s=60,
+        retries=2,
+        initial_backoff_s=1.0,
+    )
+    if nlm_result.returncode != 0:
+        warn(f"nlm notebook list failed: {nlm_result.stderr.strip() or nlm_result.stdout.strip()}")
+        return 1
+
+    try:
+        notebooks_payload = json.loads(nlm_result.stdout)
+    except json.JSONDecodeError:
+        warn("Could not parse nlm output as JSON.")
+        return 1
+
+    notebooks = notebooks_payload.get("notebooks", []) if isinstance(notebooks_payload, dict) else notebooks_payload
+
+    notebook_deletions: list[tuple[str, str, str]] = []  # (nb_id, dt, slug)
+    notebook_kept_no_audio: list[tuple[str, str, str]] = []
+
+    for nb in notebooks:
+        title = nb.get("title", "")
+        nb_id = nb.get("id", "")
+        if not isinstance(title, str) or not isinstance(nb_id, str):
+            continue
+        parsed = parse_reading_list_notebook_title(title)
+        if not parsed:
+            continue
+        dt, _nn, category_title = parsed
+        slug = slug_for_category_title(category_title)
+        if not slug:
+            continue
+        nb_dt = _parse_iso_date(dt)
+        if nb_dt >= cutoff_date:
+            continue
+        if (dt, slug) in audio_keys:
+            notebook_deletions.append((nb_id, dt, slug))
+        else:
+            notebook_kept_no_audio.append((nb_id, dt, slug))
+
+    print(f"  Mode: {'APPLY' if apply else 'DRY-RUN'}")
+    print(f"  Audio deletions:    {len(audio_deletions)}")
+    print(f"  Notebook deletions: {len(notebook_deletions)}")
+    print(f"  Notebooks kept (no audio): {len(notebook_kept_no_audio)}")
+    print(f"  Audio kept (wrong slug): {len(audio_kept_wrong_slug)}")
+    print(f"  Audio kept (wrong ext):  {len(audio_kept_wrong_ext)}")
+
+    if audio_deletions:
+        print("\n  Audio to delete:")
+        for path, dt, slug in sorted(audio_deletions, key=lambda x: (x[1], x[2], str(x[0]))):
+            print(f"    - {path}  ({dt} / {slug})")
+
+    if notebook_deletions:
+        print("\n  Notebooks to delete:")
+        for nb_id, dt, slug in sorted(notebook_deletions, key=lambda x: (x[1], x[2], x[0])):
+            print(f"    - {nb_id}  ({dt} / {slug})")
+
+    if notebook_kept_no_audio:
+        print("\n  Notebooks kept (no matching audio):")
+        for nb_id, dt, slug in sorted(notebook_kept_no_audio, key=lambda x: (x[1], x[2], x[0])):
+            print(f"    - {nb_id}  ({dt} / {slug})")
+
+    if audio_kept_wrong_slug:
+        print("\n  Audio kept (filename matches pattern but slug not one of ours):")
+        for path, dt, slug in sorted(audio_kept_wrong_slug, key=lambda x: (x[1], x[2], str(x[0]))):
+            print(f"    - {path}  ({dt} / {slug})")
+
+    if audio_kept_wrong_ext:
+        print("\n  Audio kept (filename matches pattern but ext is not mp3/m4a):")
+        for path, dt, slug in sorted(audio_kept_wrong_ext, key=lambda x: (x[1], x[2], str(x[0]))):
+            print(f"    - {path}  ({dt} / {slug})")
+
+    if not apply:
+        print("\nDry-run complete. No deletions performed.")
+        return 0
+
+    ok("Applying deletions...")
+
+    audio_errors = 0
+    for path, _dt, _slug in audio_deletions:
+        try:
+            path.unlink()
+        except Exception as e:
+            audio_errors += 1
+            warn(f"Audio delete failed: {path} ({e})")
+
+    notebook_errors = 0
+    for nb_id, _dt, _slug in notebook_deletions:
+        del_res = run_with_retries(
+            [NLM_CLI, "notebook", "delete", "--confirm", nb_id],
+            timeout_s=60,
+            retries=0,
+        )
+        if del_res.returncode != 0:
+            notebook_errors += 1
+            warn(f"Notebook delete failed: {nb_id} ({del_res.stderr.strip() or del_res.stdout.strip()})")
+
+    if audio_errors or notebook_errors:
+        warn(f"Cleanup completed with errors: audio_errors={audio_errors}, notebook_errors={notebook_errors}")
+        return 1
+
+    ok("Cleanup complete.")
+    return 0
+
+
 # ── NotebookLM: Find notebooks for date ────────────────────────────────────────
 
 def find_notebooks_for_date(target_date: str) -> dict:
@@ -260,12 +414,14 @@ def find_notebooks_for_date(target_date: str) -> dict:
         if dt != target_date:
             continue
 
-        for expected_category, slug in CATEGORY_SLUGS.items():
-            if expected_category == category_title or expected_category in category_title:
-                prev = best.get(slug)
-                if prev is None or nn > prev[0]:
-                    best[slug] = (nn, nb_id)
-                    best_titles[slug] = title
+        slug = slug_for_category_title(category_title)
+        if slug:
+            prev = best.get(slug)
+            if prev is None or nn > prev[0]:
+                best[slug] = (nn, nb_id)
+                best_titles[slug] = title
+        else:
+            warn(f"Unrecognized reading-list category (no slug): {title!r}")
 
     found = {slug: nb_id for slug, (_nn, nb_id) in best.items()}
     for slug, nb_id in found.items():
@@ -388,7 +544,13 @@ def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str,
     if not episode_id:
         # Create episode
         print(f"      Creating episode ...", end=" ", flush=True)
-        episode = client.create_episode(title=title, season_number=1, episode_number=episode_number)
+        desc = elementfm_episode_description(title)
+        episode = client.create_episode(
+            title=title,
+            season_number=1,
+            episode_number=episode_number,
+            description=desc,
+        )
         if "error" in episode:
             fail(f"Create failed: {episode['error']}")
             entry["create_error"] = episode.get("error")
@@ -416,8 +578,12 @@ def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str,
     else:
         ok("Audio already uploaded (per manifest), skipping upload")
 
-    # Publish
+    # Publish (element.fm requires a non-empty episode description)
     if not entry.get("published"):
+        desc = elementfm_episode_description(title)
+        patch = client.patch_episode(episode_id=str(episode_id), data={"description": desc})
+        if "error" in patch:
+            warn(f"Set description failed: {patch['error']} — publish may still fail")
         print(f"      Publishing ...", end=" ", flush=True)
         result = client.publish_episode(episode_id=str(episode_id))
         if "error" in result:
@@ -460,7 +626,9 @@ Examples:
     parser.add_argument("--audio-dir", default=None,
                         help="Audio directory (overrides config). Default: iCloud Personal Podcast")
     parser.add_argument("--timeout", type=float, default=30.0,
-                        help="HTTP timeout in seconds (default: 30)")
+                        help="HTTP timeout for JSON API calls in seconds (default: 30)")
+    parser.add_argument("--upload-timeout", type=float, default=900.0,
+                        help="Minimum per-attempt timeout for MP3 uploads in seconds; actual may be higher from file size (default: 900)")
     parser.add_argument("--audio-format", choices=["mp3", "m4a"], default=None,
                         help="Saved output format (default from config, fallback: mp3)")
     parser.add_argument("--wait-for-audio", dest="wait_for_audio", action=argparse.BooleanOptionalAction, default=True,
@@ -471,6 +639,12 @@ Examples:
                         help="Wait window in minutes (default: 15)")
     parser.add_argument("--poll-interval-seconds", type=float, default=20.0,
                         help="Polling interval while waiting (default: 20)")
+    parser.add_argument("--cleanup-old", action="store_true",
+                        help="Cleanup mode: delete downloaded audio + matching reading-list notebooks older than cutoff date (dry-run by default).")
+    parser.add_argument("--cleanup-apply", action="store_true",
+                        help="In cleanup mode, actually perform deletions (default is dry-run).")
+    parser.add_argument("--cleanup-cutoff-date", default=date.today().strftime("%Y-%m-%d"),
+                        help="Cutoff date for cleanup (YYYY-MM-DD). Older than this are eligible (default: today).")
     args = parser.parse_args()
 
     target_date = args.date
@@ -493,6 +667,15 @@ Examples:
 """)
 
     # Validate
+    if args.cleanup_old:
+        sys.exit(
+            cleanup_old_items(
+                audio_dir=audio_dir,
+                cutoff_date_str=args.cleanup_cutoff_date,
+                apply=args.cleanup_apply,
+            )
+        )
+
     if not args.dry_run and not args.download_only:
         if not API_KEY:
             fail("CLAUDE_ELEMENT_FM_KEY not set. Run: source ~/.zshrc")
@@ -527,8 +710,17 @@ Examples:
             warn("No notebooks found before timeout/discovery step.")
             sys.exit(1)
 
+        missing_nb = [s for s in slugs if s not in notebooks]
+        if missing_nb:
+            warn(
+                "No NotebookLM notebook matched for: "
+                + ", ".join(missing_nb)
+                + " (skill may have skipped an empty category, or the notebook title/category differs)."
+            )
+
         if args.wait_for_studio_status and not args.dry_run:
             # Keep only notebooks whose studio artifacts are ready by timeout.
+            before_studio = dict(notebooks)
             ready_slugs = set(
                 wait_for_studio_audio_ready(
                     notebooks=notebooks,
@@ -537,6 +729,13 @@ Examples:
                 )
             )
             notebooks = {slug: nb_id for slug, nb_id in notebooks.items() if slug in ready_slugs}
+            dropped = set(before_studio.keys()) - set(notebooks.keys())
+            if dropped:
+                warn(
+                    "Studio audio not ready in time (skipped these slugs — "
+                    "re-run with --no-wait-for-studio-status or increase --max-wait-minutes): "
+                    + ", ".join(sorted(dropped))
+                )
             if not notebooks:
                 warn("No notebooks became ready within the wait window.")
                 sys.exit(1)
@@ -614,6 +813,7 @@ Examples:
             base_url=BASE_URL,
         ),
         timeout_s=args.timeout,
+        upload_timeout_s=args.upload_timeout,
     )
 
     for slug in downloaded:

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -463,10 +463,10 @@ Examples:
                         help="HTTP timeout in seconds (default: 30)")
     parser.add_argument("--audio-format", choices=["mp3", "m4a"], default=None,
                         help="Saved output format (default from config, fallback: mp3)")
-    parser.add_argument("--wait-for-audio", action="store_true",
-                        help="In upload-only mode, wait for new audio files to appear before uploading")
-    parser.add_argument("--wait-for-studio-status", action="store_true",
-                        help="In non-upload-only mode, poll `nlm studio status` before download")
+    parser.add_argument("--wait-for-audio", dest="wait_for_audio", action=argparse.BooleanOptionalAction, default=True,
+                        help="Wait for new audio files before upload (default: on; disable with --no-wait-for-audio)")
+    parser.add_argument("--wait-for-studio-status", dest="wait_for_studio_status", action=argparse.BooleanOptionalAction, default=True,
+                        help="Poll `nlm studio status` before download (default: on; disable with --no-wait-for-studio-status)")
     parser.add_argument("--max-wait-minutes", type=float, default=15.0,
                         help="Wait window in minutes (default: 15)")
     parser.add_argument("--poll-interval-seconds", type=float, default=20.0,

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -69,6 +69,130 @@ def fail(msg):
     print(f"  ❌  {msg}")
 
 
+def wait_for_audio_files(
+    *,
+    audio_dir: Path,
+    target_date: str,
+    slugs: list[str],
+    audio_format: str,
+    max_wait_minutes: float,
+    poll_interval_seconds: float,
+) -> list[str]:
+    """
+    Rolling-window wait for new audio files.
+
+    Rules:
+      1) Wait up to max_wait_minutes for a first file.
+      2) Every time a NEW file appears, reset the timer for max_wait_minutes.
+      3) If no new file appears within the current window, stop waiting.
+    """
+    header("Waiting for new audio files")
+    wait_s = max(0.0, max_wait_minutes * 60.0)
+    poll_s = max(1.0, poll_interval_seconds)
+
+    seen: set[str] = set()
+    deadline = time.monotonic() + wait_s
+    expected = {slug: audio_dir / f"{target_date}-{slug}.{audio_format}" for slug in slugs}
+
+    print(f"  Window: {max_wait_minutes:.1f} min, poll: {poll_s:.0f}s")
+    print("  Timer resets whenever a NEW audio file appears.")
+
+    while time.monotonic() < deadline:
+        new_files = []
+        for slug, path in expected.items():
+            if slug in seen:
+                continue
+            if path.exists() and path.stat().st_size > 0:
+                seen.add(slug)
+                new_files.append(slug)
+
+        if new_files:
+            for slug in new_files:
+                ok(f"Detected: {target_date}-{slug}.{audio_format}")
+            deadline = time.monotonic() + wait_s
+            continue
+
+        time.sleep(poll_s)
+
+    if seen:
+        ok(f"Quiet period reached; proceeding with {len(seen)} detected file(s).")
+    else:
+        warn("No new files detected before timeout window; proceeding.")
+    return list(seen)
+
+
+def _json_walk_status_values(obj):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k.lower() == "status" and isinstance(v, str):
+                yield v.lower()
+            yield from _json_walk_status_values(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _json_walk_status_values(item)
+
+
+def _audio_completed_from_status_payload(payload: object) -> bool:
+    """
+    Best-effort check for completed audio artifacts in nlm studio status JSON.
+    """
+    if payload is None:
+        return False
+    # Conservative heuristic:
+    # - If any status is explicitly in-progress/pending/processing, not ready.
+    # - Ready when at least one status is completed/succeeded/done.
+    statuses = list(_json_walk_status_values(payload))
+    if not statuses:
+        return False
+    if any(s in {"in_progress", "pending", "processing", "running"} for s in statuses):
+        return False
+    return any(s in {"completed", "succeeded", "success", "done"} for s in statuses)
+
+
+def wait_for_studio_audio_ready(
+    *,
+    notebooks: dict[str, str],
+    max_wait_minutes: float,
+    poll_interval_seconds: float,
+) -> list[str]:
+    """
+    Poll `nlm studio status <notebook_id> --json` until audio is ready.
+    Returns slugs that appear ready before timeout.
+    """
+    header("Waiting for NotebookLM studio audio readiness")
+    wait_s = max(0.0, max_wait_minutes * 60.0)
+    poll_s = max(1.0, poll_interval_seconds)
+    deadline = time.monotonic() + wait_s
+    ready: set[str] = set()
+
+    while time.monotonic() < deadline and len(ready) < len(notebooks):
+        for slug, notebook_id in notebooks.items():
+            if slug in ready:
+                continue
+            result = run_with_retries(
+                [NLM_CLI, "studio", "status", notebook_id, "--json"],
+                timeout_s=45,
+                retries=1,
+            )
+            if result.returncode != 0:
+                continue
+            try:
+                payload = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                continue
+            if _audio_completed_from_status_payload(payload):
+                ready.add(slug)
+                ok(f"Studio ready: {slug}")
+
+        if len(ready) < len(notebooks):
+            time.sleep(poll_s)
+
+    not_ready = [slug for slug in notebooks.keys() if slug not in ready]
+    if not_ready:
+        warn(f"Studio not ready before timeout: {', '.join(not_ready)}")
+    return list(ready)
+
+
 # ── NotebookLM: Find notebooks for date ────────────────────────────────────────
 
 def find_notebooks_for_date(target_date: str) -> dict:
@@ -316,6 +440,14 @@ Examples:
                         help="HTTP timeout in seconds (default: 30)")
     parser.add_argument("--audio-format", choices=["mp3", "m4a"], default=None,
                         help="Saved output format (default from config, fallback: mp3)")
+    parser.add_argument("--wait-for-audio", action="store_true",
+                        help="In upload-only mode, wait for new audio files to appear before uploading")
+    parser.add_argument("--wait-for-studio-status", action="store_true",
+                        help="In non-upload-only mode, poll `nlm studio status` before download")
+    parser.add_argument("--max-wait-minutes", type=float, default=15.0,
+                        help="Wait window in minutes (default: 15)")
+    parser.add_argument("--poll-interval-seconds", type=float, default=20.0,
+                        help="Polling interval while waiting (default: 20)")
     args = parser.parse_args()
 
     target_date = args.date
@@ -362,11 +494,35 @@ Examples:
         notebooks = find_notebooks_for_date(target_date)
         if not notebooks:
             sys.exit(1)
+        if args.wait_for_studio_status and not args.dry_run:
+            # Keep only notebooks whose studio artifacts are ready by timeout.
+            ready_slugs = set(
+                wait_for_studio_audio_ready(
+                    notebooks=notebooks,
+                    max_wait_minutes=args.max_wait_minutes,
+                    poll_interval_seconds=args.poll_interval_seconds,
+                )
+            )
+            notebooks = {slug: nb_id for slug, nb_id in notebooks.items() if slug in ready_slugs}
+            if not notebooks:
+                warn("No notebooks became ready within the wait window.")
+                sys.exit(1)
     else:
+        waited_found = []
+        if args.wait_for_audio:
+            waited_found = wait_for_audio_files(
+                audio_dir=audio_dir,
+                target_date=target_date,
+                slugs=slugs,
+                audio_format=audio_format,
+                max_wait_minutes=args.max_wait_minutes,
+                poll_interval_seconds=args.poll_interval_seconds,
+            )
+
         # In upload-only mode, infer from existing files
         for slug in slugs:
             audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
-            if audio_path.exists():
+            if slug in waited_found or audio_path.exists():
                 notebooks[slug] = None  # no notebook id needed
 
     # ── Step 2: Download audio ──────────────────────────────────────────────
@@ -396,6 +552,21 @@ Examples:
         print(f"  Downloaded: {', '.join(downloaded) or 'none'}")
         print(f"  Files in: {audio_dir}\n")
         return
+
+    # Optional second guard: after studio-status gating + download, apply rolling
+    # quiet-window file wait before upload to catch late-arriving files.
+    if args.wait_for_studio_status and args.wait_for_audio and not args.upload_only and not args.dry_run:
+        pre_upload_found = wait_for_audio_files(
+            audio_dir=audio_dir,
+            target_date=target_date,
+            slugs=slugs,
+            audio_format=audio_format,
+            max_wait_minutes=args.max_wait_minutes,
+            poll_interval_seconds=args.poll_interval_seconds,
+        )
+        for slug in pre_upload_found:
+            if slug not in downloaded:
+                downloaded.append(slug)
 
     # ── Step 3: Upload to element.fm ────────────────────────────────────────
     header("Uploading to element.fm — DHK Daily Brief")

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -219,6 +219,36 @@ def wait_for_notebooks_for_date(
     return {}
 
 
+def fetch_studio_titles(notebooks: dict[str, str]) -> dict[str, str]:
+    """
+    Fetch the renamed studio artifact titles set by Phase 1.
+    Returns {slug: rich_title} for slugs where a title was found.
+    """
+    header("Fetching studio artifact titles")
+    titles: dict[str, str] = {}
+    for slug, notebook_id in notebooks.items():
+        result = run_with_retries(
+            [NLM_CLI, "studio", "status", notebook_id, "--json"],
+            timeout_s=45,
+            retries=1,
+        )
+        if result.returncode != 0:
+            warn(f"Could not fetch studio status for {slug}")
+            continue
+        try:
+            payload = json.loads(result.stdout)
+            artifacts = payload if isinstance(payload, list) else payload.get("artifacts", [])
+            for artifact in artifacts if isinstance(artifacts, list) else []:
+                t = artifact.get("title") or artifact.get("name")
+                if t and t.strip():
+                    titles[slug] = t.strip()
+                    ok(f"{slug}: {t[:80]}")
+                    break
+        except (json.JSONDecodeError, AttributeError):
+            continue
+    return titles
+
+
 def _parse_iso_date(date_str: str) -> date:
     return datetime.strptime(date_str, "%Y-%m-%d").date()
 
@@ -496,7 +526,7 @@ def convert_to_mp3(input_path: Path, output_path: Path):
         sys.exit(1)
 
 
-def upload_to_elementfm(client: ElementFmClient, audio_path: Path, *, dry_run: bool, manifest: dict) -> bool:
+def upload_to_elementfm(client: ElementFmClient, audio_path: Path, *, dry_run: bool, manifest: dict, rich_description: str | None = None) -> bool:
     """Convert, upload, and publish one episode. Returns True on success."""
     title = parse_episode_title_from_filename(audio_path.name)
 
@@ -533,18 +563,18 @@ def upload_to_elementfm(client: ElementFmClient, audio_path: Path, *, dry_run: b
             convert_to_mp3(audio_path, mp3_path)
             print("✓")
 
-            return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry)
+            return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry, rich_description)
     else:
         mp3_path = audio_path
-        return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry)
+        return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry, rich_description)
 
-def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str, episode_number: int, entry: dict) -> bool:
+def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str, episode_number: int, entry: dict, rich_description: str | None = None) -> bool:
     episode_id = entry.get("episode_id")
 
     if not episode_id:
         # Create episode
         print(f"      Creating episode ...", end=" ", flush=True)
-        desc = elementfm_episode_description(title)
+        desc = elementfm_episode_description(title, rich_description)
         episode = client.create_episode(
             title=title,
             season_number=1,
@@ -580,7 +610,7 @@ def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str,
 
     # Publish (element.fm requires a non-empty episode description)
     if not entry.get("published"):
-        desc = elementfm_episode_description(title)
+        desc = elementfm_episode_description(title, rich_description)
         patch = client.patch_episode(episode_id=str(episode_id), data={"description": desc})
         if "error" in patch:
             warn(f"Set description failed: {patch['error']} — publish may still fail")
@@ -608,15 +638,12 @@ def main():
 Examples:
   python3 daily_brief.py                     # run full pipeline for today
   python3 daily_brief.py --date 2026-03-19   # run for a specific date
-  python3 daily_brief.py --download-only     # nlm download only, skip upload
   python3 daily_brief.py --upload-only       # element.fm upload only (files must exist)
   python3 daily_brief.py --dry-run           # preview without doing anything
         """
     )
     parser.add_argument("--date", default=date.today().strftime("%Y-%m-%d"),
                         help="Date to process (YYYY-MM-DD, default: today)")
-    parser.add_argument("--download-only", action="store_true",
-                        help="Download audio only, skip element.fm upload")
     parser.add_argument("--upload-only", action="store_true",
                         help="Upload to element.fm only (audio files must already exist)")
     parser.add_argument("--dry-run", action="store_true",
@@ -659,7 +686,7 @@ Examples:
 ║       From Inbox to Earbuds                     ║
 ╚══════════════════════════════════════════════════╝
   Date:     {target_date}
-  Mode:     {"dry-run" if args.dry_run else "download-only" if args.download_only else "upload-only" if args.upload_only else "full pipeline"}
+  Mode:     {"dry-run" if args.dry_run else "upload-only" if args.upload_only else "full pipeline"}
   Slugs:    {", ".join(slugs)}
   Format:   {audio_format}
   Audio dir: {audio_dir}
@@ -676,7 +703,7 @@ Examples:
             )
         )
 
-    if not args.dry_run and not args.download_only:
+    if not args.dry_run:
         if not API_KEY:
             fail("CLAUDE_ELEMENT_FM_KEY not set. Run: source ~/.zshrc")
             sys.exit(1)
@@ -694,10 +721,10 @@ Examples:
         except Exception:
             manifest = {"date": target_date, "episodes": {}}
 
-    # ── Step 1: Find notebooks ──────────────────────────────────────────────
+    # ── Step 1: Find notebooks + wait for studio readiness ─────────────────
     notebooks = {}
-    if not args.upload_only:
-        if args.wait_for_studio_status and not args.dry_run:
+    if not args.dry_run:
+        if args.wait_for_studio_status and not args.upload_only:
             notebooks = wait_for_notebooks_for_date(
                 target_date=target_date,
                 max_wait_minutes=args.max_wait_minutes,
@@ -706,7 +733,7 @@ Examples:
         else:
             notebooks = find_notebooks_for_date(target_date)
 
-        if not notebooks:
+        if not args.upload_only and not notebooks:
             warn("No notebooks found before timeout/discovery step.")
             sys.exit(1)
 
@@ -718,8 +745,7 @@ Examples:
                 + " (skill may have skipped an empty category, or the notebook title/category differs)."
             )
 
-        if args.wait_for_studio_status and not args.dry_run:
-            # Keep only notebooks whose studio artifacts are ready by timeout.
+        if args.wait_for_studio_status and notebooks:
             before_studio = dict(notebooks)
             ready_slugs = set(
                 wait_for_studio_audio_ready(
@@ -736,59 +762,21 @@ Examples:
                     "re-run with --no-wait-for-studio-status or increase --max-wait-minutes): "
                     + ", ".join(sorted(dropped))
                 )
-            if not notebooks:
+            if not args.upload_only and not notebooks:
                 warn("No notebooks became ready within the wait window.")
                 sys.exit(1)
-    else:
-        waited_found = []
-        if args.wait_for_audio:
-            waited_found = wait_for_audio_files(
-                audio_dir=audio_dir,
-                target_date=target_date,
-                slugs=slugs,
-                audio_format=audio_format,
-                max_wait_minutes=args.max_wait_minutes,
-                poll_interval_seconds=args.poll_interval_seconds,
-            )
 
-        # In upload-only mode, infer from existing files
-        for slug in slugs:
-            audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
-            if slug in waited_found or audio_path.exists():
-                notebooks[slug] = None  # no notebook id needed
+    # ── Step 2: Fetch rich titles from studio artifacts ─────────────────────
+    # Phase 1 renames each artifact with the NotebookLM title + bullets + sources.
+    # We use that as the Element.fm episode description.
+    rich_titles: dict[str, str] = {}
+    if notebooks and not args.dry_run:
+        rich_titles = fetch_studio_titles(notebooks)
 
-    # ── Step 2: Download audio ──────────────────────────────────────────────
-    downloaded = []
-    if not args.upload_only:
-        header("Downloading audio overviews")
-        for slug in slugs:
-            nb_id = notebooks.get(slug)
-            if not nb_id:
-                warn(f"No notebook found for slug: {slug} — skipping")
-                continue
-            output_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
-            success = download_audio(nb_id, output_path, args.dry_run, output_format=audio_format)
-            if success:
-                downloaded.append(slug)
-    else:
-        # Check which files exist
-        for slug in slugs:
-            audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
-            if audio_path.exists():
-                downloaded.append(slug)
-            else:
-                warn(f"File not found, skipping: {audio_path.name}")
-
-    if args.download_only:
-        header("Done (download-only mode)")
-        print(f"  Downloaded: {', '.join(downloaded) or 'none'}")
-        print(f"  Files in: {audio_dir}\n")
-        return
-
-    # Optional second guard: after studio-status gating + download, apply rolling
-    # quiet-window file wait before upload to catch late-arriving files.
-    if args.wait_for_studio_status and args.wait_for_audio and not args.upload_only and not args.dry_run:
-        pre_upload_found = wait_for_audio_files(
+    # ── Step 3: Wait for audio files then check what's available ────────────
+    # Phase 1 handles downloading to iCloud. We just wait for the files to appear.
+    if args.wait_for_audio and not args.dry_run:
+        wait_for_audio_files(
             audio_dir=audio_dir,
             target_date=target_date,
             slugs=slugs,
@@ -796,9 +784,14 @@ Examples:
             max_wait_minutes=args.max_wait_minutes,
             poll_interval_seconds=args.poll_interval_seconds,
         )
-        for slug in pre_upload_found:
-            if slug not in downloaded:
-                downloaded.append(slug)
+
+    available = []
+    for slug in slugs:
+        audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+        if audio_path.exists() or args.dry_run:
+            available.append(slug)
+        else:
+            warn(f"File not found, skipping: {audio_path.name}")
 
     # ── Step 3: Upload to element.fm ────────────────────────────────────────
     header("Uploading to element.fm — DHK Daily Brief")
@@ -816,13 +809,13 @@ Examples:
         upload_timeout_s=args.upload_timeout,
     )
 
-    for slug in downloaded:
+    for slug in available:
         audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
-        if not audio_path.exists():
-            warn(f"File not found after download: {audio_path.name}")
+        if not audio_path.exists() and not args.dry_run:
+            warn(f"File not found: {audio_path.name}")
             failed.append(slug)
             continue
-        success = upload_to_elementfm(client, audio_path, dry_run=args.dry_run, manifest=manifest)
+        success = upload_to_elementfm(client, audio_path, dry_run=args.dry_run, manifest=manifest, rich_description=rich_titles.get(slug))
         try:
             manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
         except Exception:
@@ -835,7 +828,7 @@ Examples:
     # ── Summary ─────────────────────────────────────────────────────────────
     header("Summary")
     print(f"  Date:       {target_date}")
-    print(f"  Downloaded: {len(downloaded)} — {', '.join(downloaded) or 'none'}")
+    print(f"  Available:  {len(available)} — {', '.join(available) or 'none'}")
     print(f"  Uploaded:   {len(uploaded)} — {', '.join(uploaded) or 'none'}")
     if failed:
         print(f"  Failed:     {len(failed)} — {', '.join(failed)}")

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -31,6 +31,7 @@ from elementfm_client import ElementFmClient, ElementFmConfig
 from podcast_config import (
     CATEGORY_SLUGS,
     CATEGORY_TITLES,
+    STATE_DIR,
     elementfm_episode_description,
     manifest_path_for_date,
     parse_audio_filename,
@@ -112,6 +113,9 @@ def wait_for_audio_files(
         if new_files:
             for slug in new_files:
                 ok(f"Detected: {target_date}-{slug}.{audio_format}")
+            if seen == set(expected.keys()):
+                ok("All expected files found.")
+                break
             deadline = time.monotonic() + wait_s
             continue
 
@@ -512,6 +516,21 @@ def download_audio(notebook_id: str, output_path: Path, dry_run: bool, *, output
 
 # ── element.fm API ─────────────────────────────────────────────────────────────
 
+def _is_real_mp3(path: Path) -> bool:
+    """Return True only if the file's magic bytes indicate actual MP3 content."""
+    try:
+        with open(path, "rb") as f:
+            header = f.read(12)
+        # ID3 tag (most MP3s) or sync word FF FB/FA/F3/F2 (raw MPEG frame)
+        if header[:3] == b"ID3":
+            return True
+        if len(header) >= 2 and header[0] == 0xFF and (header[1] & 0xE0) == 0xE0:
+            return True
+        return False
+    except OSError:
+        return False
+
+
 def convert_to_mp3(input_path: Path, output_path: Path):
     """Convert audio to MP3 via ffmpeg."""
     cmd = [
@@ -555,18 +574,18 @@ def upload_to_elementfm(client: ElementFmClient, audio_path: Path, *, dry_run: b
         print("      [dry-run] would upload and publish")
         return True
 
-    # Convert if needed
-    if audio_path.suffix.lower() != ".mp3":
+    # Convert if needed — check actual file content, not just extension
+    # (Phase 1 skill may save M4A files with a .mp3 extension)
+    needs_convert = audio_path.suffix.lower() != ".mp3" or not _is_real_mp3(audio_path)
+    if needs_convert:
         print(f"      Converting to mp3 ...", end=" ", flush=True)
         with tempfile.TemporaryDirectory() as td:
             mp3_path = Path(td) / (audio_path.stem + ".mp3")
             convert_to_mp3(audio_path, mp3_path)
             print("✓")
-
             return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry, rich_description)
     else:
-        mp3_path = audio_path
-        return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry, rich_description)
+        return _upload_and_publish_mp3(client, audio_path, title, episode_number, entry, rich_description)
 
 def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str, episode_number: int, entry: dict, rich_description: str | None = None) -> bool:
     episode_id = entry.get("episode_id")
@@ -628,6 +647,132 @@ def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str,
     return True
 
 
+# ── Status ─────────────────────────────────────────────────────────────────────
+
+SLUGS_ALL = ["news", "think", "professional"]
+
+
+def _manifest_status_line(slug: str, entry: dict) -> str:
+    if not entry:
+        return "  —  not started"
+    if entry.get("published"):
+        ep = entry.get("episode_number")
+        ep_str = f"  (#{ep})" if isinstance(ep, int) else ""
+        return f"  ✓  published{ep_str}"
+    if entry.get("upload_error") or entry.get("create_error"):
+        err = entry.get("upload_error") or entry.get("create_error")
+        return f"  ✗  error: {err}"
+    if entry.get("audio_uploaded"):
+        return "  ↑  uploaded (not yet published)"
+    if entry.get("episode_id"):
+        return "  …  episode created (not uploaded)"
+    return "  —  in progress"
+
+
+def _is_complete(manifest: dict) -> bool:
+    eps = manifest.get("episodes", {})
+    return all(eps.get(s, {}).get("published") for s in SLUGS_ALL)
+
+
+def _print_manifest(manifest: dict, audio_dir: Path, audio_format: str):
+    target_date = manifest.get("date", "?")
+    eps = manifest.get("episodes", {})
+    for slug in SLUGS_ALL:
+        entry = eps.get(slug, {})
+        audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+        file_str = "  📁 file ready" if audio_path.exists() else ""
+        print(f"  {slug:14s}{_manifest_status_line(slug, entry)}{file_str}")
+
+
+def show_status(target_date: str, audio_dir: Path, audio_format: str):
+    # ── Today ──────────────────────────────────────────────────────────────
+    header(f"Status — {target_date}")
+    today_path = manifest_path_for_date(target_date)
+    if today_path.exists():
+        try:
+            today_manifest = json.loads(today_path.read_text(encoding="utf-8"))
+        except Exception:
+            today_manifest = {}
+    else:
+        today_manifest = {}
+
+    files_on_disk: set[str] = set()
+    for slug in SLUGS_ALL:
+        for ext in (audio_format, "mp3", "m4a"):
+            if (audio_dir / f"{target_date}-{slug}.{ext}").exists():
+                files_on_disk.add(slug)
+                break
+
+    if today_manifest:
+        _print_manifest(today_manifest, audio_dir, audio_format)
+        all_published = _is_complete(today_manifest)
+        eps = today_manifest.get("episodes", {})
+        has_error = any(
+            eps.get(s, {}).get("upload_error") or eps.get(s, {}).get("create_error")
+            for s in SLUGS_ALL
+        )
+        any_unpublished = not all_published
+    else:
+        print("  No manifest yet — checking for audio files on disk:")
+        for slug in SLUGS_ALL:
+            if slug in files_on_disk:
+                path = next(
+                    audio_dir / f"{target_date}-{slug}.{ext}"
+                    for ext in (audio_format, "mp3", "m4a")
+                    if (audio_dir / f"{target_date}-{slug}.{ext}").exists()
+                )
+                size_mb = path.stat().st_size / 1_048_576
+                print(f"  {slug:14s}  📁 {path.name}  ({size_mb:.1f} MB)")
+            else:
+                print(f"  {slug:14s}  —  no file found")
+        all_published = False
+        has_error = False
+        any_unpublished = True
+
+    # ── Last completed ─────────────────────────────────────────────────────
+    header("Last completed run")
+    manifests = sorted(STATE_DIR.glob("manifest-*.json"), reverse=True)
+    last_complete = None
+    for path in manifests:
+        date_str = path.stem.replace("manifest-", "")
+        if date_str == target_date:
+            continue
+        try:
+            m = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if _is_complete(m):
+            last_complete = m
+            break
+
+    if last_complete:
+        print(f"  Date: {last_complete.get('date', '?')}")
+        _print_manifest(last_complete, audio_dir, audio_format)
+    else:
+        print("  No completed runs found in history.")
+
+    # ── Next step ──────────────────────────────────────────────────────────
+    header("Next step")
+    if all_published:
+        print("  ✓  All episodes published — nothing to do.")
+    elif has_error:
+        print("  ✗  Some episodes errored. Retry:")
+        print("     daily-brief --upload-only")
+    elif files_on_disk and not today_manifest:
+        print("  Files are ready but not uploaded. Run:")
+        print("     daily-brief --upload-only")
+    elif files_on_disk and any_unpublished:
+        print("  Some episodes not yet published. Run:")
+        print("     daily-brief --upload-only")
+    elif not files_on_disk:
+        print("  No audio files found. Run the full pipeline:")
+        print("     daily-brief")
+    else:
+        print("  Run the full pipeline:")
+        print("     daily-brief")
+    print()
+
+
 # ── Main ───────────────────────────────────────────────────────────────────────
 
 def main():
@@ -638,12 +783,17 @@ def main():
 Examples:
   python3 daily_brief.py                     # run full pipeline for today
   python3 daily_brief.py --date 2026-03-19   # run for a specific date
+  python3 daily_brief.py --download-only     # nlm download only, skip upload
   python3 daily_brief.py --upload-only       # element.fm upload only (files must exist)
   python3 daily_brief.py --dry-run           # preview without doing anything
         """
     )
     parser.add_argument("--date", default=date.today().strftime("%Y-%m-%d"),
                         help="Date to process (YYYY-MM-DD, default: today)")
+    parser.add_argument("--show-status", action="store_true",
+                        help="Show pipeline status for today and the last completed run, then exit")
+    parser.add_argument("--download-only", action="store_true",
+                        help="Download audio from NotebookLM only, skip element.fm upload")
     parser.add_argument("--upload-only", action="store_true",
                         help="Upload to element.fm only (audio files must already exist)")
     parser.add_argument("--dry-run", action="store_true",
@@ -686,7 +836,7 @@ Examples:
 ║       From Inbox to Earbuds                     ║
 ╚══════════════════════════════════════════════════╝
   Date:     {target_date}
-  Mode:     {"dry-run" if args.dry_run else "upload-only" if args.upload_only else "full pipeline"}
+  Mode:     {"dry-run" if args.dry_run else "download-only" if args.download_only else "upload-only" if args.upload_only else "full pipeline"}
   Slugs:    {", ".join(slugs)}
   Format:   {audio_format}
   Audio dir: {audio_dir}
@@ -694,6 +844,12 @@ Examples:
 """)
 
     # Validate
+    if args.show_status:
+        audio_dir = resolve_audio_dir(cli_audio_dir=args.audio_dir)
+        audio_format = resolve_audio_format(cli_audio_format=args.audio_format)
+        show_status(target_date, audio_dir, audio_format)
+        sys.exit(0)
+
     if args.cleanup_old:
         sys.exit(
             cleanup_old_items(
@@ -703,7 +859,7 @@ Examples:
             )
         )
 
-    if not args.dry_run:
+    if not args.dry_run and not args.download_only:
         if not API_KEY:
             fail("CLAUDE_ELEMENT_FM_KEY not set. Run: source ~/.zshrc")
             sys.exit(1)
@@ -724,7 +880,9 @@ Examples:
     # ── Step 1: Find notebooks + wait for studio readiness ─────────────────
     notebooks = {}
     if not args.dry_run:
-        if args.wait_for_studio_status and not args.upload_only:
+        if args.upload_only:
+            notebooks = {}  # audio files already on disk; no need to query nlm
+        elif args.wait_for_studio_status:
             notebooks = wait_for_notebooks_for_date(
                 target_date=target_date,
                 max_wait_minutes=args.max_wait_minutes,
@@ -773,8 +931,23 @@ Examples:
     if notebooks and not args.dry_run:
         rich_titles = fetch_studio_titles(notebooks)
 
-    # ── Step 3: Wait for audio files then check what's available ────────────
-    # Phase 1 handles downloading to iCloud. We just wait for the files to appear.
+    # ── Step 3: Download audio from NotebookLM (if not upload-only) ─────────
+    if not args.upload_only:
+        header("Downloading audio overviews")
+        for slug in slugs:
+            nb_id = notebooks.get(slug)
+            if not nb_id:
+                warn(f"No notebook found for slug: {slug} — skipping")
+                continue
+            output_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+            download_audio(nb_id, output_path, args.dry_run, output_format=audio_format)
+
+    if args.download_only:
+        header("Done (download-only mode)")
+        print(f"  Files in: {audio_dir}\n")
+        return
+
+    # ── Step 4: Wait for audio files then check what's available ────────────
     if args.wait_for_audio and not args.dry_run:
         wait_for_audio_files(
             audio_dir=audio_dir,

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -193,6 +193,29 @@ def wait_for_studio_audio_ready(
     return list(ready)
 
 
+def wait_for_notebooks_for_date(
+    *,
+    target_date: str,
+    max_wait_minutes: float,
+    poll_interval_seconds: float,
+) -> dict[str, str]:
+    """
+    Wait for reading-list notebooks for target date to appear.
+    """
+    header("Waiting for notebooks to appear")
+    wait_s = max(0.0, max_wait_minutes * 60.0)
+    poll_s = max(1.0, poll_interval_seconds)
+    deadline = time.monotonic() + wait_s
+
+    while time.monotonic() < deadline:
+        notebooks = find_notebooks_for_date(target_date)
+        if notebooks:
+            return notebooks
+        time.sleep(poll_s)
+
+    return {}
+
+
 # ── NotebookLM: Find notebooks for date ────────────────────────────────────────
 
 def find_notebooks_for_date(target_date: str) -> dict:
@@ -491,9 +514,19 @@ Examples:
     # ── Step 1: Find notebooks ──────────────────────────────────────────────
     notebooks = {}
     if not args.upload_only:
-        notebooks = find_notebooks_for_date(target_date)
+        if args.wait_for_studio_status and not args.dry_run:
+            notebooks = wait_for_notebooks_for_date(
+                target_date=target_date,
+                max_wait_minutes=args.max_wait_minutes,
+                poll_interval_seconds=args.poll_interval_seconds,
+            )
+        else:
+            notebooks = find_notebooks_for_date(target_date)
+
         if not notebooks:
+            warn("No notebooks found before timeout/discovery step.")
             sys.exit(1)
+
         if args.wait_for_studio_status and not args.dry_run:
             # Keep only notebooks whose studio artifacts are ready by timeout.
             ready_slugs = set(

--- a/dhk-daily-brief/scripts/daily_brief.py
+++ b/dhk-daily-brief/scripts/daily_brief.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+DHK Daily Brief — End-to-End Pipeline
+From Inbox to Earbuds in one command.
+
+Finds today's reading-list NotebookLM notebooks, downloads their audio
+overviews via the nlm CLI, and uploads them to element.fm.
+
+Usage:
+    python3 daily_brief.py                  # today
+    python3 daily_brief.py --date 2026-03-19
+    python3 daily_brief.py --download-only  # skip element.fm upload
+    python3 daily_brief.py --upload-only    # skip nlm download (files already exist)
+    python3 daily_brief.py --dry-run        # show what would happen, do nothing
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, date
+from pathlib import Path
+
+# Local imports (same directory)
+from elementfm_client import ElementFmClient, ElementFmConfig
+from podcast_config import (
+    CATEGORY_SLUGS,
+    CATEGORY_TITLES,
+    manifest_path_for_date,
+    parse_episode_title_from_filename,
+    parse_reading_list_notebook_title,
+    resolve_audio_dir,
+    resolve_audio_format,
+)
+from subprocess_utils import run_with_retries
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+SCRIPTS_DIR  = Path(__file__).parent
+NLM_CLI      = "nlm"
+
+API_KEY      = os.environ.get("CLAUDE_ELEMENT_FM_KEY")
+WORKSPACE_ID = "b08a0951-94a4-441d-a446-81cc7950749c"
+SHOW_ID      = "d5be8d71-5fe3-4d2c-b641-0cd7343e4e36"
+BASE_URL     = f"https://app.element.fm/api/workspaces/{WORKSPACE_ID}/shows/{SHOW_ID}"
+
+# ── Utilities ──────────────────────────────────────────────────────────────────
+
+def header(text):
+    print(f"\n{'─' * 50}")
+    print(f"  {text}")
+    print(f"{'─' * 50}")
+
+
+def ok(msg):
+    print(f"  ✓  {msg}")
+
+
+def warn(msg):
+    print(f"  ⚠️  {msg}")
+
+
+def fail(msg):
+    print(f"  ❌  {msg}")
+
+
+# ── NotebookLM: Find notebooks for date ────────────────────────────────────────
+
+def find_notebooks_for_date(target_date: str) -> dict:
+    """
+    Scan NotebookLM for reading-list notebooks matching the given date.
+    Returns {slug: notebook_id} e.g. {"news": "abc123", "think": "def456"}
+    """
+    header(f"Finding notebooks for {target_date}")
+
+    result = run_with_retries(
+        [NLM_CLI, "notebook", "list", "--json"],
+        timeout_s=45,
+        retries=2,
+    )
+    if result.returncode != 0:
+        fail(f"nlm notebook list failed: {result.stderr.strip() or result.stdout.strip()}")
+        sys.exit(1)
+
+    try:
+        notebooks = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        fail(f"Could not parse nlm output: {result.stdout[:200]}")
+        sys.exit(1)
+
+    # Handle both list and {"notebooks": [...]} formats
+    if isinstance(notebooks, dict):
+        notebooks = notebooks.get("notebooks", [])
+
+    prefix = f"reading-list-{target_date}"
+    best: dict[str, tuple[int, str]] = {}  # slug -> (nn, notebook_id)
+    best_titles: dict[str, str] = {}
+
+    for nb in notebooks:
+        title = nb.get("title", "")
+        nb_id = nb.get("id", "")
+        if not isinstance(title, str) or not title.startswith(prefix):
+            continue
+        parsed = parse_reading_list_notebook_title(title)
+        if not parsed:
+            continue
+        dt, nn, category_title = parsed
+        if dt != target_date:
+            continue
+
+        for expected_category, slug in CATEGORY_SLUGS.items():
+            if expected_category == category_title or expected_category in category_title:
+                prev = best.get(slug)
+                if prev is None or nn > prev[0]:
+                    best[slug] = (nn, nb_id)
+                    best_titles[slug] = title
+
+    found = {slug: nb_id for slug, (_nn, nb_id) in best.items()}
+    for slug, nb_id in found.items():
+        ok(f"{slug:15s} → {nb_id}  ({best_titles.get(slug,'')})")
+
+    if not found:
+        warn(f"No reading-list notebooks found for {target_date}")
+        warn("Has the reading-list-builder skill been run for this date?")
+
+    return found
+
+
+# ── NotebookLM: Download audio ─────────────────────────────────────────────────
+
+def download_audio(notebook_id: str, output_path: Path, dry_run: bool, *, output_format: str) -> bool:
+    """Download audio overview via nlm CLI. Returns True on success."""
+    if dry_run:
+        print(f"  [dry-run] nlm download audio {notebook_id} --output {output_path.name}")
+        return True
+
+    if output_path.exists():
+        ok(f"Already exists, skipping: {output_path.name}")
+        return True
+
+    print(f"  Downloading {output_path.name} ...", end=" ", flush=True)
+    # NotebookLM currently emits m4a; convert to mp3 when requested.
+    if output_format == "mp3":
+        with tempfile.TemporaryDirectory() as td:
+            m4a_tmp = Path(td) / f"{output_path.stem}.m4a"
+            result = run_with_retries(
+                [NLM_CLI, "download", "audio", notebook_id, "--output", str(m4a_tmp)],
+                timeout_s=180,
+                retries=3,
+                initial_backoff_s=2.0,
+            )
+            if result.returncode != 0:
+                print()
+                warn(f"Download failed (attempts={result.attempts}): {result.stderr.strip() or result.stdout.strip()}")
+                return False
+            convert_to_mp3(m4a_tmp, output_path)
+            ok(f"Saved to {output_path.name}")
+            return True
+    else:
+        result = run_with_retries(
+            [NLM_CLI, "download", "audio", notebook_id, "--output", str(output_path)],
+            timeout_s=180,
+            retries=3,
+            initial_backoff_s=2.0,
+        )
+    if result.returncode != 0:
+        print()
+        warn(f"Download failed (attempts={result.attempts}): {result.stderr.strip() or result.stdout.strip()}")
+        return False
+
+    ok(f"Saved to {output_path.name}")
+    return True
+
+
+# ── element.fm API ─────────────────────────────────────────────────────────────
+
+def convert_to_mp3(input_path: Path, output_path: Path):
+    """Convert audio to MP3 via ffmpeg."""
+    cmd = [
+        "ffmpeg", "-y", "-i", str(input_path),
+        "-codec:a", "libmp3lame", "-qscale:a", "3",
+        "-loglevel", "error",
+        str(output_path)
+    ]
+    result = run_with_retries(cmd, timeout_s=180, retries=0)
+    if result.returncode != 0:
+        fail(f"ffmpeg error: {result.stderr.strip()}")
+        sys.exit(1)
+
+
+def upload_to_elementfm(client: ElementFmClient, audio_path: Path, *, dry_run: bool, manifest: dict) -> bool:
+    """Convert, upload, and publish one episode. Returns True on success."""
+    title = parse_episode_title_from_filename(audio_path.name)
+
+    # Idempotency: if we already recorded an episode_id, reuse it; otherwise look up by title.
+    slug = audio_path.stem.split("-")[3] if len(audio_path.stem.split("-")) >= 4 else audio_path.stem
+    entry = manifest.setdefault("episodes", {}).setdefault(slug, {})
+    episode_id = entry.get("episode_id")
+    existing = None
+    if not episode_id:
+        existing = client.find_episode_by_title(title)
+        if existing and existing.get("id"):
+            episode_id = existing["id"]
+            entry["episode_id"] = episode_id
+            entry["found_existing_by_title"] = True
+
+    episode_number = entry.get("episode_number")
+    if not isinstance(episode_number, int):
+        episode_number = client.get_next_episode_number()
+        entry["episode_number"] = episode_number
+
+    print(f"\n  📤  {audio_path.name}")
+    print(f"      Title:   {title}")
+    print(f"      Episode: #{episode_number}")
+
+    if dry_run:
+        print("      [dry-run] would upload and publish")
+        return True
+
+    # Convert if needed
+    if audio_path.suffix.lower() != ".mp3":
+        print(f"      Converting to mp3 ...", end=" ", flush=True)
+        with tempfile.TemporaryDirectory() as td:
+            mp3_path = Path(td) / (audio_path.stem + ".mp3")
+            convert_to_mp3(audio_path, mp3_path)
+            print("✓")
+
+            return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry)
+    else:
+        mp3_path = audio_path
+        return _upload_and_publish_mp3(client, mp3_path, title, episode_number, entry)
+
+def _upload_and_publish_mp3(client: ElementFmClient, mp3_path: Path, title: str, episode_number: int, entry: dict) -> bool:
+    episode_id = entry.get("episode_id")
+
+    if not episode_id:
+        # Create episode
+        print(f"      Creating episode ...", end=" ", flush=True)
+        episode = client.create_episode(title=title, season_number=1, episode_number=episode_number)
+        if "error" in episode:
+            fail(f"Create failed: {episode['error']}")
+            entry["create_error"] = episode.get("error")
+            return False
+        episode_id = episode.get("id")
+        if not episode_id:
+            fail("Create failed: missing episode id")
+            entry["create_error"] = "missing episode id"
+            return False
+        entry["episode_id"] = episode_id
+        print(f"✓ ({str(episode_id)[:8]}...)")
+    else:
+        ok(f"Reusing existing episode_id: {str(episode_id)[:8]}...")
+
+    # Upload audio
+    if not entry.get("audio_uploaded"):
+        print(f"      Uploading audio ...", end=" ", flush=True)
+        result = client.upload_audio(episode_id=str(episode_id), mp3_path=mp3_path)
+        if "error" in result:
+            fail(f"Upload failed: {result['error']}")
+            entry["upload_error"] = result.get("error")
+            return False
+        entry["audio_uploaded"] = True
+        print("✓")
+    else:
+        ok("Audio already uploaded (per manifest), skipping upload")
+
+    # Publish
+    if not entry.get("published"):
+        print(f"      Publishing ...", end=" ", flush=True)
+        result = client.publish_episode(episode_id=str(episode_id))
+        if "error" in result:
+            warn(f"Publish failed: {result['error']} — publish manually in element.fm")
+            entry["publish_error"] = result.get("error")
+            return True
+        entry["published"] = True
+        print("✓")
+    else:
+        ok("Already published (per manifest), skipping publish")
+
+    return True
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="DHK Daily Brief — end-to-end pipeline",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 daily_brief.py                     # run full pipeline for today
+  python3 daily_brief.py --date 2026-03-19   # run for a specific date
+  python3 daily_brief.py --download-only     # nlm download only, skip upload
+  python3 daily_brief.py --upload-only       # element.fm upload only (files must exist)
+  python3 daily_brief.py --dry-run           # preview without doing anything
+        """
+    )
+    parser.add_argument("--date", default=date.today().strftime("%Y-%m-%d"),
+                        help="Date to process (YYYY-MM-DD, default: today)")
+    parser.add_argument("--download-only", action="store_true",
+                        help="Download audio only, skip element.fm upload")
+    parser.add_argument("--upload-only", action="store_true",
+                        help="Upload to element.fm only (audio files must already exist)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would happen without doing anything")
+    parser.add_argument("--slugs", default="news,think,professional",
+                        help="Comma-separated slugs to process (default: news,think,professional)")
+    parser.add_argument("--audio-dir", default=None,
+                        help="Audio directory (overrides config). Default: iCloud Personal Podcast")
+    parser.add_argument("--timeout", type=float, default=30.0,
+                        help="HTTP timeout in seconds (default: 30)")
+    parser.add_argument("--audio-format", choices=["mp3", "m4a"], default=None,
+                        help="Saved output format (default from config, fallback: mp3)")
+    args = parser.parse_args()
+
+    target_date = args.date
+    slugs = [s.strip() for s in args.slugs.split(",")]
+    audio_dir = resolve_audio_dir(cli_audio_dir=args.audio_dir)
+    audio_format = resolve_audio_format(cli_audio_format=args.audio_format)
+    manifest_path = manifest_path_for_date(target_date)
+
+    print(f"""
+╔══════════════════════════════════════════════════╗
+║       DHK Daily Brief Pipeline                  ║
+║       From Inbox to Earbuds                     ║
+╚══════════════════════════════════════════════════╝
+  Date:     {target_date}
+  Mode:     {"dry-run" if args.dry_run else "download-only" if args.download_only else "upload-only" if args.upload_only else "full pipeline"}
+  Slugs:    {", ".join(slugs)}
+  Format:   {audio_format}
+  Audio dir: {audio_dir}
+  Manifest:  {manifest_path}
+""")
+
+    # Validate
+    if not args.dry_run and not args.download_only:
+        if not API_KEY:
+            fail("CLAUDE_ELEMENT_FM_KEY not set. Run: source ~/.zshrc")
+            sys.exit(1)
+
+    if not audio_dir.exists():
+        fail(f"Audio directory not found: {audio_dir}")
+        fail("Create it, or set ~/.config/dhk-daily-brief/config.json audio_dir, or pass --audio-dir")
+        sys.exit(1)
+
+    # Load manifest (idempotency)
+    manifest = {"date": target_date, "episodes": {}}
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            manifest = {"date": target_date, "episodes": {}}
+
+    # ── Step 1: Find notebooks ──────────────────────────────────────────────
+    notebooks = {}
+    if not args.upload_only:
+        notebooks = find_notebooks_for_date(target_date)
+        if not notebooks:
+            sys.exit(1)
+    else:
+        # In upload-only mode, infer from existing files
+        for slug in slugs:
+            audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+            if audio_path.exists():
+                notebooks[slug] = None  # no notebook id needed
+
+    # ── Step 2: Download audio ──────────────────────────────────────────────
+    downloaded = []
+    if not args.upload_only:
+        header("Downloading audio overviews")
+        for slug in slugs:
+            nb_id = notebooks.get(slug)
+            if not nb_id:
+                warn(f"No notebook found for slug: {slug} — skipping")
+                continue
+            output_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+            success = download_audio(nb_id, output_path, args.dry_run, output_format=audio_format)
+            if success:
+                downloaded.append(slug)
+    else:
+        # Check which files exist
+        for slug in slugs:
+            audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+            if audio_path.exists():
+                downloaded.append(slug)
+            else:
+                warn(f"File not found, skipping: {audio_path.name}")
+
+    if args.download_only:
+        header("Done (download-only mode)")
+        print(f"  Downloaded: {', '.join(downloaded) or 'none'}")
+        print(f"  Files in: {audio_dir}\n")
+        return
+
+    # ── Step 3: Upload to element.fm ────────────────────────────────────────
+    header("Uploading to element.fm — DHK Daily Brief")
+    uploaded = []
+    failed = []
+
+    client = ElementFmClient(
+        ElementFmConfig(
+            api_key=API_KEY or "",
+            workspace_id=WORKSPACE_ID,
+            show_id=SHOW_ID,
+            base_url=BASE_URL,
+        ),
+        timeout_s=args.timeout,
+    )
+
+    for slug in downloaded:
+        audio_path = audio_dir / f"{target_date}-{slug}.{audio_format}"
+        if not audio_path.exists():
+            warn(f"File not found after download: {audio_path.name}")
+            failed.append(slug)
+            continue
+        success = upload_to_elementfm(client, audio_path, dry_run=args.dry_run, manifest=manifest)
+        try:
+            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+        except Exception:
+            pass
+        if success:
+            uploaded.append(slug)
+        else:
+            failed.append(slug)
+
+    # ── Summary ─────────────────────────────────────────────────────────────
+    header("Summary")
+    print(f"  Date:       {target_date}")
+    print(f"  Downloaded: {len(downloaded)} — {', '.join(downloaded) or 'none'}")
+    print(f"  Uploaded:   {len(uploaded)} — {', '.join(uploaded) or 'none'}")
+    if failed:
+        print(f"  Failed:     {len(failed)} — {', '.join(failed)}")
+    if not args.dry_run and uploaded:
+        print(f"\n  🎧 Episodes live in Overcast and Apple Podcasts")
+        print(f"  View show: https://app.element.fm/workspaces/{WORKSPACE_ID}/shows/{SHOW_ID}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/dhk-daily-brief/scripts/elementfm_client.py
+++ b/dhk-daily-brief/scripts/elementfm_client.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class ElementFmConfig:
+    api_key: str
+    workspace_id: str
+    show_id: str
+    base_url: str
+
+
+def _json_loads_safe(data: bytes) -> Any:
+    try:
+        return json.loads(data.decode("utf-8"))
+    except Exception:
+        return None
+
+
+class ElementFmClient:
+    def __init__(
+        self,
+        cfg: ElementFmConfig,
+        *,
+        timeout_s: float = 30.0,
+        retries: int = 3,
+        initial_backoff_s: float = 1.0,
+        backoff_mult: float = 2.0,
+    ):
+        self.cfg = cfg
+        self.timeout_s = timeout_s
+        self.retries = retries
+        self.initial_backoff_s = initial_backoff_s
+        self.backoff_mult = backoff_mult
+
+    def request(self, method: str, path: str, *, data: Any | None = None, files: dict[str, tuple[str, bytes, str]] | None = None) -> dict[str, Any]:
+        """
+        Make an authenticated request to element.fm API and return a dict.
+        Retries on transient errors (HTTP 5xx, 429, URLError).
+        """
+        url = self.cfg.base_url + path
+        headers = {"Authorization": f"Token {self.cfg.api_key}"}
+        body: bytes | None = None
+
+        if files:
+            boundary = "----ElementFMBoundary"
+            parts: list[bytes] = []
+            for name, (filename, filedata, content_type) in files.items():
+                parts.append(f"--{boundary}\r\n".encode())
+                parts.append(
+                    (
+                        f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+                        f"Content-Type: {content_type}\r\n\r\n"
+                    ).encode()
+                )
+                parts.append(filedata)
+                parts.append(b"\r\n")
+            parts.append(f"--{boundary}--\r\n".encode())
+            body = b"".join(parts)
+            headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+        elif data is not None:
+            body = json.dumps(data).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        backoff = self.initial_backoff_s
+        for i in range(self.retries + 1):
+            req = urllib.request.Request(url, data=body, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                    parsed = _json_loads_safe(resp.read())
+                    return parsed if isinstance(parsed, dict) else {"error": "Non-JSON response"}
+            except urllib.error.HTTPError as e:
+                raw = e.read()
+                parsed = _json_loads_safe(raw)
+                if isinstance(parsed, dict):
+                    # Handle rate limiting / transient failures with retries
+                    if e.code in (429,) or (500 <= e.code <= 599):
+                        if i < self.retries:
+                            time.sleep(backoff)
+                            backoff *= self.backoff_mult
+                            continue
+                    return parsed
+                msg = raw.decode("utf-8", errors="replace")
+                if e.code in (429,) or (500 <= e.code <= 599):
+                    if i < self.retries:
+                        time.sleep(backoff)
+                        backoff *= self.backoff_mult
+                        continue
+                return {"error": f"HTTP {e.code}: {msg[:500]}"}
+            except urllib.error.URLError as e:
+                if i < self.retries:
+                    time.sleep(backoff)
+                    backoff *= self.backoff_mult
+                    continue
+                return {"error": f"URL error: {e}"}
+            except Exception as e:
+                if i < self.retries:
+                    time.sleep(backoff)
+                    backoff *= self.backoff_mult
+                    continue
+                return {"error": f"Request error: {e}"}
+
+        return {"error": "Request failed after retries"}
+
+    def list_episodes(self) -> list[dict[str, Any]]:
+        """
+        Best-effort: returns a list of episodes. The API response shape may vary.
+        """
+        result = self.request("GET", "/episodes")
+        for key in ("episodes", "results", "items", "data"):
+            value = result.get(key)
+            if isinstance(value, list):
+                return [e for e in value if isinstance(e, dict)]
+        # Some responses include pagination metadata plus list nested differently.
+        if isinstance(result.get("episodes"), dict):
+            inner = result["episodes"].get("results")
+            if isinstance(inner, list):
+                return [e for e in inner if isinstance(e, dict)]
+        return []
+
+    def total_episodes(self) -> int:
+        result = self.request("GET", "/episodes")
+        val = result.get("total_episodes")
+        return int(val) if isinstance(val, int) else 0
+
+    def find_episode_by_title(self, title: str) -> Optional[dict[str, Any]]:
+        title_norm = title.strip()
+        for ep in self.list_episodes():
+            if str(ep.get("title", "")).strip() == title_norm:
+                return ep
+        return None
+
+    def get_next_episode_number(self) -> int:
+        # Best-effort: keep existing behavior if total_episodes is exposed.
+        return self.total_episodes() + 1
+
+    def create_episode(self, *, title: str, season_number: int, episode_number: int) -> dict[str, Any]:
+        return self.request(
+            "POST",
+            "/episodes",
+            data={
+                "title": title,
+                "season_number": season_number,
+                "episode_number": episode_number,
+            },
+        )
+
+    def upload_audio(self, *, episode_id: str, mp3_path: Path) -> dict[str, Any]:
+        audio_data = mp3_path.read_bytes()
+        return self.request(
+            "POST",
+            f"/episodes/{episode_id}/audio",
+            files={"audio": (mp3_path.name, audio_data, "audio/mpeg")},
+        )
+
+    def publish_episode(self, *, episode_id: str) -> dict[str, Any]:
+        return self.request("POST", f"/episodes/{episode_id}/publish")
+

--- a/dhk-daily-brief/scripts/elementfm_client.py
+++ b/dhk-daily-brief/scripts/elementfm_client.py
@@ -131,19 +131,31 @@ class ElementFmClient:
 
     def list_episodes(self) -> list[dict[str, Any]]:
         """
-        Best-effort: returns a list of episodes. The API response shape may vary.
+        Returns all episodes, handling pagination (API returns 10 per page).
         """
-        result = self.request("GET", "/episodes")
-        for key in ("episodes", "results", "items", "data"):
-            value = result.get(key)
-            if isinstance(value, list):
-                return [e for e in value if isinstance(e, dict)]
-        # Some responses include pagination metadata plus list nested differently.
-        if isinstance(result.get("episodes"), dict):
-            inner = result["episodes"].get("results")
-            if isinstance(inner, list):
-                return [e for e in inner if isinstance(e, dict)]
-        return []
+        all_episodes: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            result = self.request("GET", f"/episodes?page={page}")
+            batch: list[dict[str, Any]] = []
+            for key in ("episodes", "results", "items", "data"):
+                value = result.get(key)
+                if isinstance(value, list):
+                    batch = [e for e in value if isinstance(e, dict)]
+                    break
+            if not batch:
+                if isinstance(result.get("episodes"), dict):
+                    inner = result["episodes"].get("results")
+                    if isinstance(inner, list):
+                        batch = [e for e in inner if isinstance(e, dict)]
+            if not batch:
+                break
+            all_episodes.extend(batch)
+            total = result.get("total_episodes", 0)
+            if len(all_episodes) >= total:
+                break
+            page += 1
+        return all_episodes
 
     def total_episodes(self) -> int:
         result = self.request("GET", "/episodes")

--- a/dhk-daily-brief/scripts/elementfm_client.py
+++ b/dhk-daily-brief/scripts/elementfm_client.py
@@ -30,17 +30,28 @@ class ElementFmClient:
         cfg: ElementFmConfig,
         *,
         timeout_s: float = 30.0,
+        upload_timeout_s: float | None = None,
         retries: int = 3,
         initial_backoff_s: float = 1.0,
         backoff_mult: float = 2.0,
     ):
         self.cfg = cfg
         self.timeout_s = timeout_s
+        # Large MP3 multipart uploads need a much higher ceiling than JSON calls.
+        self.upload_timeout_s = upload_timeout_s if upload_timeout_s is not None else max(600.0, timeout_s * 5)
         self.retries = retries
         self.initial_backoff_s = initial_backoff_s
         self.backoff_mult = backoff_mult
 
-    def request(self, method: str, path: str, *, data: Any | None = None, files: dict[str, tuple[str, bytes, str]] | None = None) -> dict[str, Any]:
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        data: Any | None = None,
+        files: dict[str, tuple[str, bytes, str]] | None = None,
+        timeout_s: float | None = None,
+    ) -> dict[str, Any]:
         """
         Make an authenticated request to element.fm API and return a dict.
         Retries on transient errors (HTTP 5xx, 429, URLError).
@@ -69,11 +80,20 @@ class ElementFmClient:
             body = json.dumps(data).encode("utf-8")
             headers["Content-Type"] = "application/json"
 
+        if files:
+            effective_timeout = timeout_s if timeout_s is not None else self.upload_timeout_s
+        else:
+            effective_timeout = timeout_s if timeout_s is not None else self.timeout_s
+
+        max_attempts = self.retries + 1
+        if files:
+            max_attempts = max(max_attempts, 6)
+
         backoff = self.initial_backoff_s
-        for i in range(self.retries + 1):
+        for i in range(max_attempts):
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
             try:
-                with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                with urllib.request.urlopen(req, timeout=effective_timeout) as resp:
                     parsed = _json_loads_safe(resp.read())
                     return parsed if isinstance(parsed, dict) else {"error": "Non-JSON response"}
             except urllib.error.HTTPError as e:
@@ -82,26 +102,26 @@ class ElementFmClient:
                 if isinstance(parsed, dict):
                     # Handle rate limiting / transient failures with retries
                     if e.code in (429,) or (500 <= e.code <= 599):
-                        if i < self.retries:
+                        if i < max_attempts - 1:
                             time.sleep(backoff)
                             backoff *= self.backoff_mult
                             continue
                     return parsed
                 msg = raw.decode("utf-8", errors="replace")
                 if e.code in (429,) or (500 <= e.code <= 599):
-                    if i < self.retries:
+                    if i < max_attempts - 1:
                         time.sleep(backoff)
                         backoff *= self.backoff_mult
                         continue
                 return {"error": f"HTTP {e.code}: {msg[:500]}"}
             except urllib.error.URLError as e:
-                if i < self.retries:
+                if i < max_attempts - 1:
                     time.sleep(backoff)
                     backoff *= self.backoff_mult
                     continue
                 return {"error": f"URL error: {e}"}
             except Exception as e:
-                if i < self.retries:
+                if i < max_attempts - 1:
                     time.sleep(backoff)
                     backoff *= self.backoff_mult
                     continue
@@ -141,23 +161,37 @@ class ElementFmClient:
         # Best-effort: keep existing behavior if total_episodes is exposed.
         return self.total_episodes() + 1
 
-    def create_episode(self, *, title: str, season_number: int, episode_number: int) -> dict[str, Any]:
-        return self.request(
-            "POST",
-            "/episodes",
-            data={
-                "title": title,
-                "season_number": season_number,
-                "episode_number": episode_number,
-            },
-        )
+    def create_episode(
+        self,
+        *,
+        title: str,
+        season_number: int,
+        episode_number: int,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "title": title,
+            "season_number": season_number,
+            "episode_number": episode_number,
+        }
+        if description:
+            payload["description"] = description
+        return self.request("POST", "/episodes", data=payload)
+
+    def patch_episode(self, *, episode_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        return self.request("PATCH", f"/episodes/{episode_id}", data=data)
 
     def upload_audio(self, *, episode_id: str, mp3_path: Path) -> dict[str, Any]:
         audio_data = mp3_path.read_bytes()
+        size = len(audio_data)
+        # Rough floor from file size: assume ~200 KiB/s effective upload; cap 1 hour.
+        size_based = max(300.0, min(3600.0, (size / (200 * 1024)) * 8))
+        upload_timeout = max(self.upload_timeout_s, size_based)
         return self.request(
             "POST",
             f"/episodes/{episode_id}/audio",
             files={"audio": (mp3_path.name, audio_data, "audio/mpeg")},
+            timeout_s=upload_timeout,
         )
 
     def publish_episode(self, *, episode_id: str) -> dict[str, Any]:

--- a/dhk-daily-brief/scripts/personal_podcast_rss.py
+++ b/dhk-daily-brief/scripts/personal_podcast_rss.py
@@ -10,8 +10,8 @@ Usage:
 Then subscribe in Overcast to: http://<your-mac-ip>:8765/feed.rss
 """
 
+import argparse
 import os
-import glob
 import hashlib
 import mimetypes
 import socket
@@ -20,9 +20,13 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from email.utils import formatdate
 import time
+from urllib.parse import quote, unquote
+from xml.sax.saxutils import escape
 
-PODCAST_DIR = Path.home() / "Library" / "Mobile Documents" / "com~apple~CloudDocs" / "Personal Podcast"
-PORT = 8765
+from podcast_config import parse_episode_title_from_filename, resolve_audio_dir
+
+PODCAST_DIR: Path | None = None
+DEFAULT_PORT = 8765
 FEED_TITLE = "DHK Personal Podcast"
 FEED_DESCRIPTION = "NotebookLM audio overviews — personal reading list"
 FEED_AUTHOR = "DHK"
@@ -40,7 +44,7 @@ def get_local_ip():
 
 def slugify(name):
     """Make a URL-safe slug from a filename."""
-    return name.replace(" ", "%20")
+    return quote(name, safe="")
 
 def file_to_pub_date(path):
     """Convert file mtime to RFC 2822 date string."""
@@ -48,32 +52,12 @@ def file_to_pub_date(path):
     return formatdate(mtime, usegmt=True)
 
 def parse_episode_title(filename):
-    """
-    Turn filenames like '2026-03-21-news.m4a' into readable titles.
-    Falls back to the stem if pattern doesn't match.
-    """
-    stem = Path(filename).stem
-    parts = stem.split("-")
-    
-    # Try to parse YYYY-MM-DD-category pattern
-    if len(parts) >= 4:
-        try:
-            date_str = f"{parts[0]}-{parts[1]}-{parts[2]}"
-            date = datetime.strptime(date_str, "%Y-%m-%d")
-            category = " ".join(parts[3:]).title()
-            category_emoji = {
-                "news": "📰 News & Current Affairs",
-                "think": "🧠 Things to Think About", 
-                "professional": "💼 Professional Reading",
-            }.get(parts[3].lower(), category)
-            return f"{category_emoji} — {date.strftime('%b %d, %Y')}"
-        except ValueError:
-            pass
-    
-    return stem.replace("-", " ").replace("_", " ").title()
+    return parse_episode_title_from_filename(filename)
 
 def generate_rss(base_url):
     """Generate the RSS feed XML."""
+    if PODCAST_DIR is None:
+        raise RuntimeError("PODCAST_DIR not initialized")
     files = []
     for ext in AUDIO_EXTENSIONS:
         files.extend(PODCAST_DIR.glob(f"*{ext}"))
@@ -94,13 +78,13 @@ def generate_rss(base_url):
         
         items.append(f"""
     <item>
-      <title>{title}</title>
+      <title>{escape(title)}</title>
       <enclosure url="{url}" length="{size}" type="{mime}"/>
       <guid isPermaLink="false">{guid}</guid>
       <pubDate>{pub_date}</pubDate>
-      <description>{title}</description>
+      <description>{escape(title)}</description>
       <itunes:duration>0</itunes:duration>
-      <itunes:author>{FEED_AUTHOR}</itunes:author>
+      <itunes:author>{escape(FEED_AUTHOR)}</itunes:author>
     </item>""")
     
     now = formatdate(usegmt=True)
@@ -131,7 +115,8 @@ class FeedHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         local_ip = get_local_ip()
-        base_url = f"http://{local_ip}:{PORT}"
+        port = self.server.server_address[1]
+        base_url = f"http://{local_ip}:{port}"
 
         if self.path == "/feed.rss" or self.path == "/":
             rss = generate_rss(base_url)
@@ -143,7 +128,11 @@ class FeedHandler(BaseHTTPRequestHandler):
             self.wfile.write(data)
 
         elif self.path.startswith("/audio/"):
-            filename = self.path[7:].replace("%20", " ")
+            filename = unquote(self.path[7:])
+            if PODCAST_DIR is None:
+                self.send_response(500)
+                self.end_headers()
+                return
             filepath = PODCAST_DIR / filename
             if filepath.exists() and filepath.suffix.lower() in AUDIO_EXTENSIONS:
                 size = os.path.getsize(filepath)
@@ -154,7 +143,11 @@ class FeedHandler(BaseHTTPRequestHandler):
                 self.send_header("Accept-Ranges", "bytes")
                 self.end_headers()
                 with open(filepath, "rb") as f:
-                    self.wfile.write(f.read())
+                    while True:
+                        chunk = f.read(1024 * 256)
+                        if not chunk:
+                            break
+                        self.wfile.write(chunk)
             else:
                 self.send_response(404)
                 self.end_headers()
@@ -164,8 +157,16 @@ class FeedHandler(BaseHTTPRequestHandler):
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Serve a local RSS feed for your podcast folder")
+    parser.add_argument("--audio-dir", default=None, help="Audio directory (overrides config)")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Port to serve on (default: 8765)")
+    args = parser.parse_args()
+
+    global PODCAST_DIR
+    PODCAST_DIR = resolve_audio_dir(cli_audio_dir=args.audio_dir)
+
     local_ip = get_local_ip()
-    feed_url = f"http://{local_ip}:{PORT}/feed.rss"
+    feed_url = f"http://{local_ip}:{args.port}/feed.rss"
     
     if not PODCAST_DIR.exists():
         print(f"⚠️  Podcast folder not found: {PODCAST_DIR}")
@@ -197,7 +198,7 @@ Press Ctrl+C to stop.
 ─────────────────────────────────────────────────
 """)
 
-    server = HTTPServer(("0.0.0.0", PORT), FeedHandler)
+    server = HTTPServer(("0.0.0.0", args.port), FeedHandler)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/dhk-daily-brief/scripts/podcast_config.py
+++ b/dhk-daily-brief/scripts/podcast_config.py
@@ -112,17 +112,17 @@ def manifest_path_for_date(target_date: str) -> Path:
 
 def parse_episode_title_from_filename(filename: str) -> str:
     """
-    Turn '2026-03-21-news.m4a' into '📰 News & Current Affairs — Mar 21, 2026'.
+    Turn '2026-03-21-news.mp3' into 'reading list - news - 2026-03-21'.
     Falls back to a humanized stem.
     """
     stem = Path(filename).stem
     parts = stem.split("-")
     if len(parts) >= 4:
         try:
-            dt = datetime.strptime(f"{parts[0]}-{parts[1]}-{parts[2]}", "%Y-%m-%d")
+            datetime.strptime(f"{parts[0]}-{parts[1]}-{parts[2]}", "%Y-%m-%d")
+            date_str = f"{parts[0]}-{parts[1]}-{parts[2]}"
             slug = parts[3].lower()
-            category = CATEGORY_TITLES.get(slug, " ".join(parts[3:]).title())
-            return f"{category} — {dt.strftime('%b %d, %Y')}"
+            return f"reading list - {slug} - {date_str}"
         except ValueError:
             pass
     return stem.replace("-", " ").replace("_", " ").title()
@@ -162,14 +162,17 @@ def parse_audio_filename(filename: str) -> Optional[tuple[str, str, str]]:
     return (dt, slug, ext)
 
 
-def elementfm_episode_description(title: str) -> str:
+def elementfm_episode_description(title: str, rich_description: Optional[str] = None) -> str:
     """
-    Non-empty show notes / description text required by element.fm before publish.
+    Episode description for element.fm. Uses the rich Phase 1 description (NotebookLM
+    title + bullets + sources) if available; otherwise falls back to a simple string.
     """
+    if rich_description and rich_description.strip():
+        return rich_description.strip()
     t = (title or "").strip()
     if not t:
         return "DHK Daily Brief — personal reading-list audio overview."
-    return f"{t} Personal reading-list audio overview (DHK Daily Brief)."
+    return f"DHK Daily Brief — {t}"
 
 
 def _strip_leading_non_letters(s: str) -> str:

--- a/dhk-daily-brief/scripts/podcast_config.py
+++ b/dhk-daily-brief/scripts/podcast_config.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+
+DEFAULT_AUDIO_DIR = (
+    Path.home()
+    / "Library"
+    / "Mobile Documents"
+    / "com~apple~CloudDocs"
+    / "Personal Podcast"
+)
+
+AUDIO_FORMAT_DEFAULT = "mp3"
+ALLOWED_AUDIO_FORMATS = {"mp3", "m4a"}
+
+
+CONFIG_PATH = Path.home() / ".config" / "dhk-daily-brief" / "config.json"
+STATE_DIR = Path.home() / ".local" / "state" / "dhk-daily-brief"
+
+
+CATEGORY_SLUGS: dict[str, str] = {
+    "📰 News & Current Affairs": "news",
+    "🧠 Things to Think About": "think",
+    "💼 Professional Reading": "professional",
+}
+
+CATEGORY_TITLES: dict[str, str] = {v: k for k, v in CATEGORY_SLUGS.items()}
+
+
+FILENAME_RE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})-(?P<slug>[a-z0-9_-]+)\.(?P<ext>[A-Za-z0-9]+)$"
+)
+
+
+READING_LIST_NOTEBOOK_RE = re.compile(
+    r"^reading-list-(?P<date>\d{4}-\d{2}-\d{2})-(?P<nn>\d{2})\s+(?P<category>.+)$"
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    try:
+        parsed = json.loads(data)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def ensure_dirs() -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def resolve_audio_dir(*, cli_audio_dir: Optional[str] = None) -> Path:
+    """
+    Resolve audio directory precedence:
+      1) CLI override
+      2) ~/.config/dhk-daily-brief/config.json (audio_dir)
+      3) DEFAULT_AUDIO_DIR (iCloud Personal Podcast)
+    """
+    if cli_audio_dir:
+        return Path(cli_audio_dir).expanduser()
+
+    cfg = _read_json(CONFIG_PATH)
+    audio_dir = cfg.get("audio_dir")
+    if isinstance(audio_dir, str) and audio_dir.strip():
+        return Path(audio_dir).expanduser()
+
+    env_audio_dir = os.environ.get("DHK_DAILY_BRIEF_AUDIO_DIR")
+    if isinstance(env_audio_dir, str) and env_audio_dir.strip():
+        return Path(env_audio_dir).expanduser()
+
+    return DEFAULT_AUDIO_DIR
+
+
+def resolve_audio_format(*, cli_audio_format: Optional[str] = None) -> str:
+    """
+    Resolve output audio format precedence:
+      1) CLI override (--audio-format)
+      2) ~/.config/dhk-daily-brief/config.json (audio_format)
+      3) default 'mp3'
+    """
+    candidate = (cli_audio_format or "").strip().lower()
+    if candidate:
+        if candidate in ALLOWED_AUDIO_FORMATS:
+            return candidate
+        return AUDIO_FORMAT_DEFAULT
+
+    cfg = _read_json(CONFIG_PATH)
+    cfg_format = str(cfg.get("audio_format", "")).strip().lower()
+    if cfg_format in ALLOWED_AUDIO_FORMATS:
+        return cfg_format
+
+    return AUDIO_FORMAT_DEFAULT
+
+
+def manifest_path_for_date(target_date: str) -> Path:
+    ensure_dirs()
+    return STATE_DIR / f"manifest-{target_date}.json"
+
+
+def parse_episode_title_from_filename(filename: str) -> str:
+    """
+    Turn '2026-03-21-news.m4a' into '📰 News & Current Affairs — Mar 21, 2026'.
+    Falls back to a humanized stem.
+    """
+    stem = Path(filename).stem
+    parts = stem.split("-")
+    if len(parts) >= 4:
+        try:
+            dt = datetime.strptime(f"{parts[0]}-{parts[1]}-{parts[2]}", "%Y-%m-%d")
+            slug = parts[3].lower()
+            category = CATEGORY_TITLES.get(slug, " ".join(parts[3:]).title())
+            return f"{category} — {dt.strftime('%b %d, %Y')}"
+        except ValueError:
+            pass
+    return stem.replace("-", " ").replace("_", " ").title()
+
+
+@dataclass(frozen=True)
+class NotebookMatch:
+    notebook_id: str
+    date: str
+    nn: int
+    title: str
+    category_title: str
+
+
+def parse_reading_list_notebook_title(title: str) -> Optional[tuple[str, int, str]]:
+    """
+    Parse 'reading-list-YYYY-MM-DD-NN <CATEGORY>' into (date, nn, category).
+    Returns None if not matched.
+    """
+    m = READING_LIST_NOTEBOOK_RE.match(title.strip())
+    if not m:
+        return None
+    return (m.group("date"), int(m.group("nn")), m.group("category"))
+

--- a/dhk-daily-brief/scripts/podcast_config.py
+++ b/dhk-daily-brief/scripts/podcast_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import unicodedata
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -145,4 +146,84 @@ def parse_reading_list_notebook_title(title: str) -> Optional[tuple[str, int, st
     if not m:
         return None
     return (m.group("date"), int(m.group("nn")), m.group("category"))
+
+
+def parse_audio_filename(filename: str) -> Optional[tuple[str, str, str]]:
+    """
+    Parse '<YYYY-MM-DD>-<slug>.<ext>' into (date, slug, ext).
+    Returns None if the filename doesn't match the expected pattern.
+    """
+    m = FILENAME_RE.match(Path(filename).name)
+    if not m:
+        return None
+    dt = m.group("date")
+    slug = m.group("slug")
+    ext = m.group("ext").lower()
+    return (dt, slug, ext)
+
+
+def elementfm_episode_description(title: str) -> str:
+    """
+    Non-empty show notes / description text required by element.fm before publish.
+    """
+    t = (title or "").strip()
+    if not t:
+        return "DHK Daily Brief — personal reading-list audio overview."
+    return f"{t} Personal reading-list audio overview (DHK Daily Brief)."
+
+
+def _strip_leading_non_letters(s: str) -> str:
+    """Strip leading emoji / punctuation until first letter or digit (category labels)."""
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch.isspace():
+            i += 1
+            continue
+        cat = unicodedata.category(ch)
+        if cat.startswith("L") or cat.startswith("N"):
+            break
+        i += 1
+    return s[i:].strip()
+
+
+def _normalize_category_label(s: str) -> str:
+    t = unicodedata.normalize("NFKC", s).strip()
+    t = _strip_leading_non_letters(t)
+    t = t.lower().replace(" and ", " & ")
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def category_title_to_slug(category_title: str) -> Optional[str]:
+    """
+    Map NotebookLM notebook category segment (after date/nn) to news | think | professional.
+    Handles minor title variations (e.g. 'and' vs '&', missing emoji).
+    """
+    if not category_title:
+        return None
+    ct = category_title.strip()
+    if ct in CATEGORY_SLUGS:
+        return CATEGORY_SLUGS[ct]
+    for expected_title, slug in CATEGORY_SLUGS.items():
+        if expected_title in ct or ct in expected_title:
+            return slug
+    norm = _normalize_category_label(ct)
+    for expected_title, slug in CATEGORY_SLUGS.items():
+        exp = _normalize_category_label(expected_title)
+        if norm == exp or exp in norm or norm in exp:
+            return slug
+    # Conservative keyword fallbacks (only for our three fixed categories)
+    if "professional" in norm and "reading" in norm:
+        return "professional"
+    if "things to think" in norm:
+        return "think"
+    if "news" in norm and ("current" in norm or "affairs" in norm):
+        return "news"
+    return None
+
+
+def slug_for_category_title(category_title: str) -> Optional[str]:
+    """Backward-compatible name; use category_title_to_slug."""
+    return category_title_to_slug(category_title)
 

--- a/dhk-daily-brief/scripts/subprocess_utils.py
+++ b/dhk-daily-brief/scripts/subprocess_utils.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class RunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    attempts: int
+    elapsed_s: float
+
+
+def run_with_retries(
+    args: Sequence[str],
+    *,
+    timeout_s: float | None = None,
+    retries: int = 2,
+    initial_backoff_s: float = 1.0,
+    backoff_mult: float = 2.0,
+) -> RunResult:
+    """
+    Run a subprocess with timeout and retry/backoff.
+    Retries on non-zero exit OR TimeoutExpired.
+    """
+    attempts = 0
+    start = time.monotonic()
+    backoff = initial_backoff_s
+    last: subprocess.CompletedProcess[str] | None = None
+    last_stderr = ""
+    last_stdout = ""
+    last_rc = 1
+
+    for i in range(retries + 1):
+        attempts = i + 1
+        try:
+            cp = subprocess.run(
+                list(args),
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+            last = cp
+            last_rc = cp.returncode
+            last_stdout = cp.stdout or ""
+            last_stderr = cp.stderr or ""
+            if cp.returncode == 0:
+                break
+        except subprocess.TimeoutExpired as e:
+            last_rc = 124
+            last_stdout = (e.stdout or "") if isinstance(e.stdout, str) else ""
+            last_stderr = (e.stderr or "") if isinstance(e.stderr, str) else ""
+
+        if i < retries:
+            time.sleep(backoff)
+            backoff *= backoff_mult
+
+    elapsed_s = time.monotonic() - start
+    if last is not None:
+        return RunResult(
+            returncode=last.returncode,
+            stdout=last_stdout,
+            stderr=last_stderr,
+            attempts=attempts,
+            elapsed_s=elapsed_s,
+        )
+    return RunResult(
+        returncode=last_rc,
+        stdout=last_stdout,
+        stderr=last_stderr,
+        attempts=attempts,
+        elapsed_s=elapsed_s,
+    )
+

--- a/dhk-daily-brief/scripts/suggest_gmail_label_filters.py
+++ b/dhk-daily-brief/scripts/suggest_gmail_label_filters.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Suggest Gmail label-migration filters from newsletter sender registry.
+
+Reads:
+  dhk-daily-brief/data/newsletter_sender_registry.json
+
+Outputs:
+  - Top senders by score
+  - Suggested Gmail filter query snippets
+  - Optional full OR query for bulk testing in Gmail search
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_REGISTRY = (
+    Path(__file__).resolve().parents[1] / "data" / "newsletter_sender_registry.json"
+)
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": 1, "updated_at": None, "senders": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"version": 1, "updated_at": None, "senders": {}}
+    if not isinstance(data, dict):
+        return {"version": 1, "updated_at": None, "senders": {}}
+    if not isinstance(data.get("senders"), dict):
+        data["senders"] = {}
+    return data
+
+
+def sender_score(entry: dict[str, Any], preferred_category: str | None) -> float:
+    count = int(entry.get("count", 0) or 0)
+    categories = entry.get("categories", {}) if isinstance(entry.get("categories"), dict) else {}
+    category_bonus = 0.0
+    if preferred_category:
+        category_bonus = float(categories.get(preferred_category, 0) or 0) * 0.5
+    diversity_bonus = 0.2 * len([k for k, v in categories.items() if int(v or 0) > 0])
+    return float(count) + category_bonus + diversity_bonus
+
+
+def build_from_clause(entry: dict[str, Any], key: str) -> str:
+    email = str(entry.get("email", "") or "").strip()
+    name = str(entry.get("name", "") or "").strip()
+    if email:
+        return f"from:{email}"
+    if name:
+        # Quote sender names with spaces for Gmail query compatibility.
+        if " " in name:
+            return f'from:"{name}"'
+        return f"from:{name}"
+    return f'from:"{key}"'
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Suggest Gmail label filters from newsletter sender registry")
+    parser.add_argument("--registry", default=str(DEFAULT_REGISTRY), help="Path to sender registry JSON")
+    parser.add_argument("--top", type=int, default=25, help="How many sender suggestions to print (default: 25)")
+    parser.add_argument(
+        "--min-count",
+        type=int,
+        default=2,
+        help="Minimum seen count required for suggestions (default: 2)",
+    )
+    parser.add_argument(
+        "--preferred-category",
+        choices=["news", "think", "professional"],
+        default=None,
+        help="Optional category preference to boost ranking",
+    )
+    parser.add_argument(
+        "--emit-or-query",
+        action="store_true",
+        help="Also print one combined OR Gmail query for all suggested senders",
+    )
+    args = parser.parse_args()
+
+    registry_path = Path(args.registry).expanduser()
+    data = load_registry(registry_path)
+    senders = data.get("senders", {})
+    if not senders:
+        print(f"No senders found in: {registry_path}")
+        return
+
+    ranked: list[tuple[str, dict[str, Any], float]] = []
+    for key, entry in senders.items():
+        if not isinstance(entry, dict):
+            continue
+        count = int(entry.get("count", 0) or 0)
+        if count < args.min_count:
+            continue
+        ranked.append((key, entry, sender_score(entry, args.preferred_category)))
+
+    if not ranked:
+        print("No senders match your min-count threshold.")
+        return
+
+    ranked.sort(key=lambda x: x[2], reverse=True)
+    top = ranked[: max(args.top, 1)]
+
+    print("Suggested Gmail label filters")
+    print(f"Registry: {registry_path}")
+    print(f"Updated:  {data.get('updated_at')}")
+    print("")
+    print("Use these in Gmail filter creation (Create filter -> From):")
+    print("")
+
+    clauses: list[str] = []
+    for idx, (key, entry, score) in enumerate(top, start=1):
+        name = str(entry.get("name", "") or "").strip()
+        email = str(entry.get("email", "") or "").strip()
+        count = int(entry.get("count", 0) or 0)
+        categories = entry.get("categories", {}) if isinstance(entry.get("categories"), dict) else {}
+        clause = build_from_clause(entry, key)
+        clauses.append(clause)
+        ident = email if email else (name if name else key)
+        print(f"{idx:2d}. {ident}")
+        print(f"    filter: {clause}")
+        print(f"    count: {count}  categories: {categories}  score: {score:.1f}")
+
+    if args.emit_or_query:
+        print("")
+        print("Combined OR query for Gmail search testing:")
+        # Gmail accepts OR operator; wrapping each clause is robust with quoted names.
+        or_query = " OR ".join(f"({c})" for c in clauses)
+        print(or_query)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/dhk-daily-brief/scripts/upload_to_elementfm.py
+++ b/dhk-daily-brief/scripts/upload_to_elementfm.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 # Local imports (same directory)
 from elementfm_client import ElementFmClient, ElementFmConfig
-from podcast_config import parse_episode_title_from_filename
+from podcast_config import elementfm_episode_description, parse_episode_title_from_filename
 from subprocess_utils import run_with_retries
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -52,7 +52,8 @@ def main():
     parser.add_argument("audio_file", help="Path to audio file (.m4a or .mp3)")
     parser.add_argument("--title", help="Episode title (auto-generated from filename if not set)")
     parser.add_argument("--dry-run", action="store_true", help="Show what would happen, don't upload")
-    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout in seconds (default: 30)")
+    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout for JSON calls in seconds (default: 30)")
+    parser.add_argument("--upload-timeout", type=float, default=900.0, help="Minimum upload timeout in seconds (default: 900)")
     args = parser.parse_args()
 
     if not API_KEY:
@@ -73,6 +74,7 @@ def main():
             base_url=BASE_URL,
         ),
         timeout_s=args.timeout,
+        upload_timeout_s=args.upload_timeout,
     )
     episode_number = client.get_next_episode_number()
 
@@ -107,7 +109,13 @@ def main():
 def _create_upload_publish(client: ElementFmClient, title: str, episode_number: int, mp3_path: Path) -> None:
     # Step 2: Create episode
     print("  Creating episode ...", end=" ", flush=True)
-    episode = client.create_episode(title=title, season_number=1, episode_number=episode_number)
+    desc = elementfm_episode_description(title)
+    episode = client.create_episode(
+        title=title,
+        season_number=1,
+        episode_number=episode_number,
+        description=desc,
+    )
     if "error" in episode:
         print(f"\n  ❌ Create failed: {episode['error']}")
         sys.exit(1)
@@ -125,7 +133,11 @@ def _create_upload_publish(client: ElementFmClient, title: str, episode_number: 
         sys.exit(1)
     print("✓")
 
-    # Step 4: Publish
+    # Step 4: Description + publish (element.fm requires description)
+    patch = client.patch_episode(episode_id=episode_id, data={"description": desc})
+    if "error" in patch:
+        print(f"\n  ⚠️  Could not set description: {patch['error']}")
+
     print("  Publishing ...", end=" ", flush=True)
     result = client.publish_episode(episode_id=episode_id)
     if "error" in result:

--- a/dhk-daily-brief/scripts/upload_to_elementfm.py
+++ b/dhk-daily-brief/scripts/upload_to_elementfm.py
@@ -12,13 +12,15 @@ Examples:
 """
 
 import argparse
-import json
 import os
-import subprocess
 import sys
 import tempfile
-from datetime import datetime
 from pathlib import Path
+
+# Local imports (same directory)
+from elementfm_client import ElementFmClient, ElementFmConfig
+from podcast_config import parse_episode_title_from_filename
+from subprocess_utils import run_with_retries
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -29,82 +31,6 @@ BASE_URL     = f"https://app.element.fm/api/workspaces/{WORKSPACE_ID}/shows/{SHO
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def api(method, path, **kwargs):
-    """Make an authenticated API call, return parsed JSON."""
-    import urllib.request, urllib.error
-    url = BASE_URL + path
-    data = kwargs.get("data")
-    files = kwargs.get("files")
-
-    if files:
-        # Multipart upload
-        boundary = "----ElementFMBoundary"
-        body_parts = []
-        for name, (filename, filedata, content_type) in files.items():
-            body_parts.append(
-                f'--{boundary}\r\n'
-                f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
-                f'Content-Type: {content_type}\r\n\r\n'.encode() +
-                filedata +
-                b'\r\n'
-            )
-        body = b''.join(
-            p if isinstance(p, bytes) else p.encode()
-            for p in body_parts
-        ) + f'--{boundary}--\r\n'.encode()
-        headers = {
-            "Authorization": f"Token {API_KEY}",
-            "Content-Type": f"multipart/form-data; boundary={boundary}",
-        }
-    elif data:
-        body = json.dumps(data).encode()
-        headers = {
-            "Authorization": f"Token {API_KEY}",
-            "Content-Type": "application/json",
-        }
-    else:
-        body = None
-        headers = {"Authorization": f"Token {API_KEY}"}
-
-    req = urllib.request.Request(url, data=body, headers=headers, method=method)
-    try:
-        with urllib.request.urlopen(req) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        err = e.read().decode()
-        try:
-            return json.loads(err)
-        except Exception:
-            print(f"  HTTP {e.code}: {err[:200]}")
-            sys.exit(1)
-
-
-def parse_title(filename):
-    """Turn '2026-03-21-news.m4a' into a readable episode title."""
-    stem = Path(filename).stem
-    parts = stem.split("-")
-    category_map = {
-        "news":         "📰 News & Current Affairs",
-        "think":        "🧠 Things to Think About",
-        "professional": "💼 Professional Reading",
-    }
-    if len(parts) >= 4:
-        try:
-            date = datetime.strptime(f"{parts[0]}-{parts[1]}-{parts[2]}", "%Y-%m-%d")
-            slug = parts[3].lower()
-            category = category_map.get(slug, " ".join(parts[3:]).title())
-            return f"{category} — {date.strftime('%b %d, %Y')}"
-        except ValueError:
-            pass
-    return stem.replace("-", " ").replace("_", " ").title()
-
-
-def get_next_episode_number():
-    """Get current episode count and return next number."""
-    result = api("GET", "/episodes")
-    return result.get("total_episodes", 0) + 1
-
-
 def convert_to_mp3(input_path, output_path):
     """Convert audio file to MP3 using ffmpeg."""
     cmd = [
@@ -113,9 +39,9 @@ def convert_to_mp3(input_path, output_path):
         "-loglevel", "error",
         str(output_path)
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = run_with_retries(cmd, timeout_s=180, retries=0)
     if result.returncode != 0:
-        print(f"  ffmpeg error: {result.stderr}")
+        print(f"  ffmpeg error: {result.stderr.strip()}")
         sys.exit(1)
 
 
@@ -126,6 +52,7 @@ def main():
     parser.add_argument("audio_file", help="Path to audio file (.m4a or .mp3)")
     parser.add_argument("--title", help="Episode title (auto-generated from filename if not set)")
     parser.add_argument("--dry-run", action="store_true", help="Show what would happen, don't upload")
+    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout in seconds (default: 30)")
     args = parser.parse_args()
 
     if not API_KEY:
@@ -137,8 +64,17 @@ def main():
         print(f"❌ File not found: {audio_path}")
         sys.exit(1)
 
-    title = args.title or parse_title(audio_path.name)
-    episode_number = get_next_episode_number()
+    title = args.title or parse_episode_title_from_filename(audio_path.name)
+    client = ElementFmClient(
+        ElementFmConfig(
+            api_key=API_KEY,
+            workspace_id=WORKSPACE_ID,
+            show_id=SHOW_ID,
+            base_url=BASE_URL,
+        ),
+        timeout_s=args.timeout,
+    )
+    episode_number = client.get_next_episode_number()
 
     print(f"""
 ┌─────────────────────────────────────────────┐
@@ -157,30 +93,33 @@ def main():
     # Step 1: Convert to MP3 if needed
     if audio_path.suffix.lower() != ".mp3":
         print(f"  Converting {audio_path.suffix} → .mp3 ...", end=" ", flush=True)
-        mp3_path = Path(tempfile.mkdtemp()) / (audio_path.stem + ".mp3")
-        convert_to_mp3(audio_path, mp3_path)
-        print("✓")
+        with tempfile.TemporaryDirectory() as td:
+            mp3_path = Path(td) / (audio_path.stem + ".mp3")
+            convert_to_mp3(audio_path, mp3_path)
+            print("✓")
+            _create_upload_publish(client, title, episode_number, mp3_path)
+            return
     else:
         mp3_path = audio_path
+        _create_upload_publish(client, title, episode_number, mp3_path)
 
+
+def _create_upload_publish(client: ElementFmClient, title: str, episode_number: int, mp3_path: Path) -> None:
     # Step 2: Create episode
     print("  Creating episode ...", end=" ", flush=True)
-    episode = api("POST", "/episodes", data={
-        "title": title,
-        "season_number": 1,
-        "episode_number": episode_number,
-    })
-    episode_id = episode["id"]
+    episode = client.create_episode(title=title, season_number=1, episode_number=episode_number)
+    if "error" in episode:
+        print(f"\n  ❌ Create failed: {episode['error']}")
+        sys.exit(1)
+    episode_id = episode.get("id")
+    if not episode_id:
+        print("\n  ❌ Create failed: missing episode id")
+        sys.exit(1)
     print(f"✓ ({episode_id})")
 
     # Step 3: Upload audio
     print("  Uploading audio ...", end=" ", flush=True)
-    with open(mp3_path, "rb") as f:
-        audio_data = f.read()
-
-    result = api("POST", f"/episodes/{episode_id}/audio", files={
-        "audio": (mp3_path.name, audio_data, "audio/mpeg")
-    })
+    result = client.upload_audio(episode_id=episode_id, mp3_path=mp3_path)
     if "error" in result:
         print(f"\n  ❌ Upload failed: {result['error']}")
         sys.exit(1)
@@ -188,7 +127,7 @@ def main():
 
     # Step 4: Publish
     print("  Publishing ...", end=" ", flush=True)
-    result = api("POST", f"/episodes/{episode_id}/publish")
+    result = client.publish_episode(episode_id=episode_id)
     if "error" in result:
         print(f"\n  ⚠️  Publish failed: {result['error']}")
         print("     Episode created and audio uploaded — publish manually in element.fm")
@@ -200,10 +139,6 @@ def main():
   Episode: {title}
   View at: https://app.element.fm/workspaces/{WORKSPACE_ID}/shows/{SHOW_ID}/episodes/{episode_id}
 """)
-
-    # Cleanup temp mp3 if we created one
-    if audio_path.suffix.lower() != ".mp3" and mp3_path.exists():
-        mp3_path.unlink()
 
 
 if __name__ == "__main__":

--- a/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md
+++ b/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md
@@ -48,6 +48,13 @@ gmail_read_message(messageId=<id>)
 **Fetch ALL emails before doing anything else.** This keeps tool calls front-loaded
 and avoids hitting the per-turn tool call limit mid-workflow.
 
+While fetching each email, also capture sender metadata for tracking:
+- sender display name (if available)
+- sender email (if available)
+- subject
+- message id
+- date
+
 **HTML-only emails**: Some emails (e.g. JournalClub.io) return an empty plain-text
 body with a note to view the HTML version. When this happens:
 - Use the subject line and snippet to create a minimal source entry
@@ -72,6 +79,42 @@ Classify every email as one of:
 
 ### Ambiguity rule:
 Default to **to-do** if any action is implied, even loosely.
+
+### Newsletter sender tracking (for migration to Gmail labels)
+
+Maintain a running sender registry at:
+
+`dhk-daily-brief/data/newsletter_sender_registry.json`
+
+For every non-to-do newsletter item seen in starred triage, update sender stats:
+- increment `count`
+- update `last_seen`
+- preserve `first_seen`
+- append category usage counters (`news`, `think`, `professional`)
+- store `last_subject`
+- maintain a small set/list of representative `subjects` (cap at 20)
+
+If sender email is unavailable, use sender display name as fallback key.
+
+Schema guidance:
+```
+{
+  "version": 1,
+  "updated_at": "ISO-8601",
+  "senders": {
+    "sender_key": {
+      "name": "...",
+      "email": "...",
+      "first_seen": "YYYY-MM-DD",
+      "last_seen": "YYYY-MM-DD",
+      "count": 12,
+      "categories": {"news": 7, "think": 4, "professional": 1},
+      "last_subject": "...",
+      "subjects": ["...", "..."]
+    }
+  }
+}
+```
 
 ### Show triage table before acting:
 
@@ -247,6 +290,10 @@ and remind the user the files will be available once the overviews complete (typ
 
 📋 Todoist — Today Pile:
   → 1 grouped task added with 3 to-dos
+
+🧾 Sender registry:
+  • `dhk-daily-brief/data/newsletter_sender_registry.json` updated
+  • Include top senders touched today (name/email + count)
 
 Nothing was deleted or archived in Gmail.
 Files saved to ~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast

--- a/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md
+++ b/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reading-list-builder
 description: >
-  Triages starred Gmail emails into to-reads and to-dos. To-reads go into dated
+  Triages labeled Gmail newsletters into to-reads and to-dos. To-reads go into dated
   NotebookLM notebooks (split by category) each with an audio overview. To-dos get
   added to the "Today Pile" project in Todoist as a single grouped task. Use this
   skill whenever the user says anything like "process my starred emails", "triage my
@@ -9,32 +9,61 @@ description: >
   emails", "run my email triage", "what do I need to do from my emails", or "check my
   starred emails from the last few days". Triggers any time starred emails need to be
   sorted, routed, or acted on — including multi-day ranges.
-compatibility: "Requires: Gmail MCP (gmail_search_messages, gmail_read_message), notebooklm MCP (notebook_create, source_add, studio_create, studio_status), Todoist MCP (search, add-projects, add-tasks)"
+compatibility: "Requires: Gmail MCP (gmail_search_messages, gmail_read_message), notebooklm MCP (notebook_create, source_add, studio_create, studio_status, notebook_describe), Todoist MCP (search, add-projects, add-tasks)"
 ---
 
 # Reading List Builder & Email Triage
 
-Fetches starred Gmail emails (today or a date range), classifies them, shows a triage
+Fetches labeled Gmail newsletters (today or a date range), classifies them, shows a triage
 table for user approval, then routes to-reads into categorised NotebookLM notebooks with
-audio overviews, and to-dos into the Today Pile in Todoist.
+audio overviews, and to-dos into the Today Pile in Todoist. After audio is generated,
+fetches the notebook summary and renames each episode with a bullet-point description
+and sources list.
 
 ---
 
-## Step 1: Determine Date Range
+## Newsletter Label System
 
-If the user says "today" or gives no date, use today only:
+Known newsletters are tagged in Gmail with one of three labels. These labels serve as
+an eligibility gate — only labeled emails are treated as newsletter reads.
+Starred emails without a newsletter label (receipts, event invites, personal emails)
+are classified as **To-Do** regardless of content.
+
+| Label | Sender addresses covered |
+|---|---|
+| `newsletter/news` | sanfrancisco@axios.com, email@washingtonpost.com, dailydigest@email.join1440.com, hello@newsletter.thedispatch.com, newsletters@theatlantic.com |
+| `newsletter/think` | noahpinion@substack.com, yaschamounk@substack.com, persuasion1+francis-fukuyama@substack.com, opinionatedintelligence@substack.com, post+the-weekender@substack.com |
+| `newsletter/pro` | ai.plus@axios.com, dan@tldrnewsletter.com, pragmaticengineer+deepdives@substack.com, lenny@substack.com, newsletter@towardsdatascience.com, hello@mindstream.news, thecode@mail.joinsuperhuman.ai, marketing-team@motherduck.com, info@theinformation.com, marcussawyerr@substack.com |
+
+**Label hint for classification:** If an email has a `newsletter/news` label, default
+its category to 📰 News & Current Affairs. If `newsletter/think`, default to 🧠 Things
+to Think About. If `newsletter/pro`, default to 💼 Professional Reading. These are
+defaults — the content-based classifier can still override if the issue is clearly
+better suited to a different category (e.g. a longform Dispatch essay may fit better
+in 🧠 even though the sender is in `newsletter/news`).
+
+---
+
+## Step 1: Determine Date Range & Fetch Emails
+
+If the user says "today" or gives no date, use today only. If the user gives a range
+("back to 3/15", "last few days", "this week"), use the earliest day as the start.
+
+**Primary search — labeled newsletters (no star required):**
+```
+gmail_search_messages(q="(label:newsletter/news OR label:newsletter/think OR label:newsletter/pro) after:YYYY/MM/DD")
+```
+
+**Fallback — catch unlabeled starred emails (for to-do triage):**
 ```
 gmail_search_messages(q="is:starred after:YYYY/MM/DD")
 ```
 
-If the user gives a range ("back to 3/15", "last few days", "this week"), use:
-```
-gmail_search_messages(q="is:starred after:YYYY/MM/DD")
-```
-where the date is the earliest day requested. The search returns all starred emails
-from that date forward.
+Run both searches. Deduplicate by messageId. Any starred email that does NOT have a
+newsletter label should be treated as a potential **To-Do** — don't route it to
+NotebookLM unless the content clearly warrants it and you flag the exception to the user.
 
-If no starred emails are found, tell the user and stop.
+If no emails are found at all, tell the user and stop.
 
 ---
 
@@ -48,15 +77,8 @@ gmail_read_message(messageId=<id>)
 **Fetch ALL emails before doing anything else.** This keeps tool calls front-loaded
 and avoids hitting the per-turn tool call limit mid-workflow.
 
-While fetching each email, also capture sender metadata for tracking:
-- sender display name (if available)
-- sender email (if available)
-- subject
-- message id
-- date
-
-**HTML-only emails**: Some emails (e.g. JournalClub.io) return an empty plain-text
-body with a note to view the HTML version. When this happens:
+**HTML-only emails**: Some emails return an empty plain-text body with a note to view
+the HTML version. When this happens:
 - Use the subject line and snippet to create a minimal source entry
 - Note in the title that the body was not accessible: `"<subject> — <sender> [body unavailable]"`
 - Include whatever context is available from the snippet
@@ -72,49 +94,15 @@ Classify every email as one of:
 - 📋 **To-Do** — anything requiring action, reply, decision, or follow-up
 
 ### To-Do signals:
+- Email does NOT have a newsletter label (`newsletter/news`, `newsletter/think`, `newsletter/pro`)
 - Someone is waiting for a reply or decision
 - Contains an action request, question, or deadline
 - Sent emails (SENT label) that you starred to track — treat as follow-up items
 - Subject patterns: "Re:", "Action required", "Please", "Can you", "Following up", receipts/invoices
 
 ### Ambiguity rule:
-Default to **to-do** if any action is implied, even loosely.
-
-### Newsletter sender tracking (for migration to Gmail labels)
-
-Maintain a running sender registry at:
-
-`dhk-daily-brief/data/newsletter_sender_registry.json`
-
-For every non-to-do newsletter item seen in starred triage, update sender stats:
-- increment `count`
-- update `last_seen`
-- preserve `first_seen`
-- append category usage counters (`news`, `think`, `professional`)
-- store `last_subject`
-- maintain a small set/list of representative `subjects` (cap at 20)
-
-If sender email is unavailable, use sender display name as fallback key.
-
-Schema guidance:
-```
-{
-  "version": 1,
-  "updated_at": "ISO-8601",
-  "senders": {
-    "sender_key": {
-      "name": "...",
-      "email": "...",
-      "first_seen": "YYYY-MM-DD",
-      "last_seen": "YYYY-MM-DD",
-      "count": 12,
-      "categories": {"news": 7, "think": 4, "professional": 1},
-      "last_subject": "...",
-      "subjects": ["...", "..."]
-    }
-  }
-}
-```
+Default to **to-do** if any action is implied, even loosely. Unlabeled starred emails
+default to **to-do** unless content is unambiguously a newsletter read.
 
 ### Show triage table before acting:
 
@@ -131,7 +119,6 @@ Schema guidance:
 
 💼 Professional Reading (→ NotebookLM):
   • "Are AI agents actually slowing us down?" — The Pragmatic Engineer
-  • "Tiny Machine Learning (TinyML)" — JournalClub.io
 
 📋 To-Do (→ Today Pile):
   • "Re: Resume: Dave Holmes-Kinsella" — follow up with Olivier @ Ramp
@@ -213,7 +200,7 @@ studio_create(
   artifact_type="audio",
   audio_format="deep_dive",
   audio_length="long",
-  focus_prompt="Open with the 3-5 most important ideas or takeaways across all the sources — give me the signal first. Then go deeper on each piece in turn. Close with any commentary, opinions, or open questions raised in the material. Prioritize insight over summary. Target roughly 12 minutes of content.",
+  focus_prompt="This episode should run approximately 12 minutes. Open with the 3-5 most important ideas or takeaways across all the sources — give me the signal first. Then go deeper on each piece in turn. Close with any commentary, opinions, or open questions raised in the material. Prioritize insight over summary.",
   confirm=True
 )
 ```
@@ -224,93 +211,116 @@ This workflow is tool-call-intensive. To stay within per-turn limits:
 - Create all notebooks before adding any sources
 - Add sources notebook by notebook (all sources for notebook 1, then notebook 2, etc.)
 - Start all audio generations last
+- Run Step 6 (episode titling) after all audio is confirmed generated
+- Run Step 7 (download) after all episodes are titled
 - If the budget runs out mid-workflow, report exactly what was completed and what
   remains, so the user can continue in the next turn
 
 ---
 
-## Step 6: Download Audio Overviews to iCloud
+## Step 6: Title & Describe Each Audio Episode
 
-After audio generation is confirmed complete (via `studio_status`), download each
-audio file to the Personal Podcast iCloud folder.
+After firing all audio generations, call studio_status on each notebook to confirm
+completion, then call notebook_describe to get the AI-generated summary. Use this
+to rename each artifact with a rich title, bullet-point key ideas, and sources line.
 
-**Poll for completion first:**
+**For each notebook:**
 ```
-studio_status(notebook_id=<id>)
+studio_status(notebook_id=<id>)       # get artifact_id and confirm completed
+notebook_describe(notebook_id=<id>)   # get AI summary to distill into bullets
 ```
-Wait until status is `completed` before downloading. If still `in_progress`, note it
-in the report and tell the user they can re-run the download step once ready.
 
-**Download each audio artifact:**
+Then rename:
 ```
-download_artifact(
+studio_status(
   notebook_id=<id>,
-  artifact_type="audio",
-  output_path="~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/<filename>.mp3"
+  action="rename",
+  artifact_id=<artifact_id>,
+  new_title="<NotebookLM-generated title>\n\n• <key idea 1>\n• <key idea 2>\n• <key idea 3>\n\nSources: <Newsletter (topic)> · <Newsletter (topic)> · ..."
 )
 ```
 
-**Filename convention:**
-```
-<YYYY-MM-DD>-<category-slug>.mp3
-```
-Examples:
-- `2026-03-21-news.mp3`
-- `2026-03-21-think.mp3`
-- `2026-03-21-professional.mp3`
+### Titling rules:
+- Keep NotebookLM's auto-generated title — it's usually excellent; don't replace it
+- Bullets should be punchy and insight-first, not just descriptive ("X covers Y")
+- Sources line format: `Newsletter Name (topic shorthand) · Newsletter Name (topic) · ...`
+- 3 bullets minimum, 5 maximum — don't pad
+- If audio is still in_progress when Step 6 runs, poll studio_status until completed
 
-Category slugs:
-- 📰 News & Current Affairs → `news`
-- 🧠 Things to Think About → `think`
-- 💼 Professional Reading → `professional`
+### Example finished episode title:
+```
+How Power Profits From Manufactured Chaos
 
-**If download fails** (audio not yet ready): note which notebooks are still generating
-and remind the user the files will be available once the overviews complete (typically
-2–3 minutes after generation starts).
+• AI companies are uniquely selling a product framed around existential risk and job displacement — yet people are buying it anyway
+• The Iran war is functioning as a massive regressive global tax, hitting import-dependent nations hardest while the US gets off relatively easy
+• Trump's second-term economic instability is self-generated, not inherited — a structural shift from his first term
+• The White House governs through a repeating pattern: manufacture crisis → demand concessions → claim victory
+
+Sources: Noahpinion (AI's worst sales pitch; Iran war economics) · Jonah Goldberg / The Dispatch (Two Trump economies) · The Atlantic Daily (Trump's bailout pattern)
+```
 
 ---
 
-## Step 7: Report Back
+## Step 7: Download Audio Files
+
+After all episodes are titled, download each completed audio file to the iCloud Personal
+Podcast folder so Phase 2 (Element.fm upload) can pick them up.
+
+```
+download_artifact(
+  notebook_id=<id>,
+  artifact_id=<artifact_id>,
+  output_path="~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast/YYYY-MM-DD-<slug>.mp3"
+)
+```
+
+### Slug mapping:
+| Category | Slug | Filename |
+|---|---|---|
+| 📰 News & Current Affairs | `news` | `YYYY-MM-DD-news.mp3` |
+| 🧠 Things to Think About | `think` | `YYYY-MM-DD-think.mp3` |
+| 💼 Professional Reading | `professional` | `YYYY-MM-DD-professional.mp3` |
+
+- Skip download if the file already exists at that path (idempotency)
+- If download fails, report the error and continue — Phase 2 will retry via manifest
+
+---
+
+## Step 8: Report Back
 
 ```
 ✅ Done — [date range]
 
 📚 NotebookLM — 3 notebooks created:
-  • "reading-list-2026-03-18-01 📰 News & Current Affairs" → 3 sources
-    [link]
-  • "reading-list-2026-03-18-02 🧠 Things to Think About" → 3 sources
-    [link]
-  • "reading-list-2026-03-18-03 💼 Professional Reading" → 2 sources
-    [link]
-
-🎧 Personal Podcast (iCloud):
-  • 2026-03-18-news.mp3 ✅
-  • 2026-03-18-think.mp3 ✅
-  • 2026-03-18-professional.mp3 ⏳ still generating — download when ready
+  • "reading-list-2026-03-26-01 📰 News & Current Affairs" → 4 sources
+    🎧 "How Algorithms Lost Their Legal Shield" → 📥 2026-03-26-news.mp3
+  • "reading-list-2026-03-26-02 🧠 Things to Think About" → 2 sources
+    🎧 "How Power Profits From Manufactured Chaos" → 📥 2026-03-26-think.mp3
+  • "reading-list-2026-03-26-03 💼 Professional Reading" → 5 sources
+    🎧 "Uber AI Minions and the Liability Sponge" → 📥 2026-03-26-professional.mp3
 
 📋 Todoist — Today Pile:
   → 1 grouped task added with 3 to-dos
 
-🧾 Sender registry:
-  • `dhk-daily-brief/data/newsletter_sender_registry.json` updated
-  • Include top senders touched today (name/email + count)
-
 Nothing was deleted or archived in Gmail.
-Files saved to ~/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast
+Audio files downloaded to iCloud Personal Podcast — ready for Phase 2 (Element.fm upload).
 ```
 
 ---
 
 ## Edge Cases
 
-- **No starred emails in range**: Tell user, offer to widen the date range
+- **No labeled emails in range**: Fall back to starred search; tell user labels aren't set up if both return nothing
 - **All to-reads, no to-dos**: Skip Todoist, mention it
 - **All to-dos, no to-reads**: Skip NotebookLM, mention it
 - **HTML-only email body**: Use subject + snippet, note body was unavailable
+- **Unlabeled starred email looks like a newsletter**: Flag it in the triage table with a note, let user decide
 - **Gmail MCP unavailable**: Tell user to check Settings → Connectors
 - **Today Pile missing**: Create it automatically (orange, favorited), note in summary
 - **Duplicate notebook name**: Increment nn suffix (01 → 02 → 03)
 - **User reclassifies**: Re-show full triage table with changes, re-confirm before acting
 - **Tool call limit hit mid-run**: Report what's done, what's pending, continue next turn
-- **Audio still generating at download time**: Note which files are pending, remind user they can ask "download my reading list audio" once ready
-- **iCloud folder missing**: Remind user to run `mkdir -p ~/Library/Mobile\ Documents/com\~apple\~CloudDocs/Personal\ Podcast` before retrying
+- **Audio still in_progress at Step 6**: Poll studio_status until completed, then rename
+- **Audio file already exists at download path**: Skip download, note it in report-back
+- **Download fails**: Report error, continue with remaining notebooks — Phase 2 will retry
+- **New newsletter not yet labeled**: Add it to the label system table above and note the gap to the user

--- a/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md
+++ b/dhk-daily-brief/skills/user/reading-list-builder/SKILL.md
@@ -212,8 +212,8 @@ studio_create(
   notebook_id=<id>,
   artifact_type="audio",
   audio_format="deep_dive",
-  audio_length="default",
-  focus_prompt="Open with the 3-5 most important ideas or takeaways across all the sources — give me the signal first. Then go deeper on each piece in turn. Close with any commentary, opinions, or open questions raised in the material. Prioritize insight over summary.",
+  audio_length="long",
+  focus_prompt="Open with the 3-5 most important ideas or takeaways across all the sources — give me the signal first. Then go deeper on each piece in turn. Close with any commentary, opinions, or open questions raised in the material. Prioritize insight over summary. Target roughly 12 minutes of content.",
   confirm=True
 )
 ```

--- a/dhk-daily-brief/tests/dhk_daily_brief_imports.py
+++ b/dhk-daily-brief/tests/dhk_daily_brief_imports.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import podcast_config  # noqa: E402
+

--- a/dhk-daily-brief/tests/test_podcast_config.py
+++ b/dhk-daily-brief/tests/test_podcast_config.py
@@ -20,6 +20,32 @@ class TestPodcastConfig(unittest.TestCase):
         )
         self.assertEqual(parsed, ("2026-03-21", 3, "🧠 Things to Think About"))
 
+    def test_parse_audio_filename(self):
+        parsed = podcast_config.parse_audio_filename("2026-03-21-news.mp3")
+        self.assertEqual(parsed, ("2026-03-21", "news", "mp3"))
+
+    def test_slug_for_category_title(self):
+        slug = podcast_config.slug_for_category_title("📰 News & Current Affairs")
+        self.assertEqual(slug, "news")
+
+    def test_elementfm_episode_description_nonempty(self):
+        d = podcast_config.elementfm_episode_description("🧠 Things — Mar 24, 2026")
+        self.assertTrue(len(d) > 10)
+
+    def test_category_title_to_slug_variants(self):
+        self.assertEqual(
+            podcast_config.category_title_to_slug("📰 News & Current Affairs"),
+            "news",
+        )
+        self.assertEqual(
+            podcast_config.category_title_to_slug("News and Current Affairs"),
+            "news",
+        )
+        self.assertEqual(
+            podcast_config.category_title_to_slug("🧠 Things to Think About"),
+            "think",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dhk-daily-brief/tests/test_podcast_config.py
+++ b/dhk-daily-brief/tests/test_podcast_config.py
@@ -6,9 +6,11 @@ from dhk_daily_brief_imports import podcast_config
 class TestPodcastConfig(unittest.TestCase):
     def test_parse_episode_title_from_filename_known_slug(self):
         title = podcast_config.parse_episode_title_from_filename("2026-03-21-news.m4a")
-        self.assertIn("📰 News & Current Affairs", title)
-        self.assertIn("Mar", title)
-        self.assertIn("2026", title)
+        self.assertEqual(title, "reading list - news - 2026-03-21")
+
+    def test_parse_episode_title_from_filename_professional(self):
+        title = podcast_config.parse_episode_title_from_filename("2026-03-01-professional.mp3")
+        self.assertEqual(title, "reading list - professional - 2026-03-01")
 
     def test_parse_episode_title_from_filename_fallback(self):
         title = podcast_config.parse_episode_title_from_filename("weird_name-file.m4a")
@@ -28,9 +30,15 @@ class TestPodcastConfig(unittest.TestCase):
         slug = podcast_config.slug_for_category_title("📰 News & Current Affairs")
         self.assertEqual(slug, "news")
 
-    def test_elementfm_episode_description_nonempty(self):
-        d = podcast_config.elementfm_episode_description("🧠 Things — Mar 24, 2026")
-        self.assertTrue(len(d) > 10)
+    def test_elementfm_episode_description_fallback(self):
+        d = podcast_config.elementfm_episode_description("reading list - think - 2026-03-24")
+        self.assertIn("DHK Daily Brief", d)
+        self.assertIn("think", d)
+
+    def test_elementfm_episode_description_rich(self):
+        rich = "How Power Profits From Chaos\n\n• Idea one\n• Idea two\n\nSources: Noahpinion"
+        d = podcast_config.elementfm_episode_description("reading list - think - 2026-03-24", rich)
+        self.assertEqual(d, rich)
 
     def test_category_title_to_slug_variants(self):
         self.assertEqual(

--- a/dhk-daily-brief/tests/test_podcast_config.py
+++ b/dhk-daily-brief/tests/test_podcast_config.py
@@ -1,0 +1,26 @@
+import unittest
+
+from dhk_daily_brief_imports import podcast_config
+
+
+class TestPodcastConfig(unittest.TestCase):
+    def test_parse_episode_title_from_filename_known_slug(self):
+        title = podcast_config.parse_episode_title_from_filename("2026-03-21-news.m4a")
+        self.assertIn("📰 News & Current Affairs", title)
+        self.assertIn("Mar", title)
+        self.assertIn("2026", title)
+
+    def test_parse_episode_title_from_filename_fallback(self):
+        title = podcast_config.parse_episode_title_from_filename("weird_name-file.m4a")
+        self.assertEqual(title, "Weird Name File")
+
+    def test_parse_reading_list_notebook_title(self):
+        parsed = podcast_config.parse_reading_list_notebook_title(
+            "reading-list-2026-03-21-03 🧠 Things to Think About"
+        )
+        self.assertEqual(parsed, ("2026-03-21", 3, "🧠 Things to Think About"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/dhk-daily-brief/tests/test_rss_xml_escape.py
+++ b/dhk-daily-brief/tests/test_rss_xml_escape.py
@@ -1,0 +1,16 @@
+import unittest
+from xml.sax.saxutils import escape
+
+
+class TestRssXmlEscape(unittest.TestCase):
+    def test_escape(self):
+        s = 'A & B < C > D "E"'
+        out = escape(s)
+        self.assertIn("&amp;", out)
+        self.assertIn("&lt;", out)
+        self.assertIn("&gt;", out)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/skills/user/git-push-handoff/SKILL.md
+++ b/skills/user/git-push-handoff/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: git-push-handoff
+description: Run the end-of-phase git ritual: stage, commit, push, and generate a structured handoff note for the next session. Use this skill whenever the user says anything like "commit and push", "wrap up this phase", "end of phase", "push my changes", "generate a handoff note", "write a handoff", "close out this session", "ready to push", or "/push". Triggers any time a development phase is ending and work needs to be committed, pushed, and handed off cleanly.
+---
+
+# Git Push + Handoff
+
+You are acting as the end-of-phase operator for a development session.
+
+Your job is to walk through the push ritual one step at a time, offering to perform each action before proceeding. Do not chain steps together without confirmation.
+
+---
+
+## Step 1: Orient
+
+Before doing anything, run:
+
+```bash
+git status
+git diff --stat
+```
+
+Summarize what you see: which files are changed, staged, or untracked. Present this to the user before proceeding.
+
+---
+
+## Step 2: Stage
+
+Ask:
+
+> "Ready to stage all changes (`git add -A`)? Or would you like to stage selectively?"
+
+Wait for confirmation. Then stage as directed.
+
+If selectively staging, list the changed files and ask which to include.
+
+---
+
+## Step 3: Commit
+
+Ask the user:
+
+> "What's the commit message? I'll suggest one if you'd like."
+
+If suggesting, use this format:
+- First line: imperative, max 72 chars (`Fix null handling in cohort join`)
+- Optional second line blank
+- Optional body: 1–2 lines of *why*, not what
+
+Wait for the user to confirm or provide their own message. Then run:
+
+```bash
+git commit -m "<message>"
+```
+
+---
+
+## Step 4: Push
+
+Ask:
+
+> "Ready to push to `<current branch>` on `<remote>`?"
+
+Run `git branch --show-current` and `git remote -v` first so you can name them accurately.
+
+Wait for confirmation. Then:
+
+```bash
+git push
+```
+
+Report the result. If the push fails (e.g. upstream not set, auth issue), surface the error clearly and suggest the fix.
+
+---
+
+## Step 5: Handoff Note
+
+Ask:
+
+> "Want me to generate a handoff note for the next session?"
+
+If yes, gather context from the conversation and the diff, then produce the note in this format:
+
+---
+
+**Handoff Note — [date] — [branch name]**
+
+**What was done**
+[Functional summary of what changed and why — 2–4 sentences. Not a file list — meaning and intent.]
+
+**Key decisions**
+[Decisions made that aren't obvious from the code. Tradeoffs, choices rejected, constraints accepted.]
+
+**Loose ends**
+[Anything unfinished, deferred, or flagged for follow-up. Be specific.]
+
+**Gotchas**
+[Constraints, quirks, or pitfalls that won't survive in the diff alone. The things that will bite the next session if not carried forward.]
+
+**Next step**
+[Single most important thing to do at the start of the next phase.]
+
+---
+
+After generating, ask:
+
+> "Where should this live? Options:
+> 1. **PR description** — paste it as the body of your pull request
+> 2. **Commit message body** — append it to the commit you just made
+> 3. **Todoist task note** — attach it to the next-step task
+> 4. **Local notes file** — save outside the repo (e.g. `~/dev-notes/handoffs/`)
+> 5. **Just here in chat** — use it to open the next session manually
+>
+> Not sure? I can walk you through the tradeoffs."
+
+If they ask for tradeoffs, use the guidance in the **Handoff Placement Tradeoffs** section below.
+
+Act on their choice.
+
+---
+
+## Behavior Rules
+
+- Offer each step individually — never skip ahead without confirmation
+- Be specific when naming branches, remotes, and files — run the git commands to find out, don't guess
+- If something fails, stop and explain clearly before offering next steps
+- Keep the handoff note tight — substance over length
+- The note should make the next session productive in under 60 seconds of reading
+
+---
+
+## Handoff Placement Tradeoffs
+
+Only share this if the user asks. Keep it conversational — don't dump the whole table unprompted.
+
+**PR description**
+Best option for collaborative or PR-based workflows. The reasoning lives exactly where the work lives, it's visible to reviewers without extra steps, and it's durable in repo history without polluting the file tree. Limitation: only works if you open a PR. Doesn't help for direct-to-main pushes or long-running branches where PRs come late.
+
+**Commit message body**
+Lightweight and always present — every push gets a why, not just a what. Good for solo work or frequent pushers. Limitation: commit messages are hard to read in bulk and don't surface naturally when starting a new session. Better as a micro-level complement to a fuller PR note than as a standalone solution.
+
+**Todoist task note**
+The context lives right where the next action lives — good if you're disciplined about task-first orientation at the start of a session. Limitation: only works if the next step maps cleanly to a single task, and requires Todoist to be part of your opening ritual.
+
+**Local notes file**
+Keeps handoffs entirely out of the repo — no noise, no accidental commits. Good for solo practitioners who want a running history. Limitation: one more place to remember to look, and it doesn't travel with the code if someone else picks up the work.
+
+**Just in chat**
+Lowest friction — use it to open the next session and don't persist it anywhere. Fine for short phases or low-stakes work. Limitation: it's gone when the session is gone. No trail, no history, nothing for collaborators.
+
+**The hybrid that works best for most workflows:**
+Commit message body for push-level micro-notes + PR description for the full phase-level handoff. One artifact at each natural boundary, both doing double duty.


### PR DESCRIPTION
## Why

Reading newsletters every morning was a good habit that kept breaking under time pressure. This pipeline removes the friction entirely: labeled newsletters get triaged, loaded into NotebookLM, and published as podcast episodes overnight — ready to listen to during a commute or workout, with no manual steps.

The goal was zero-touch: run at 6am via launchd, handle authentication, convert and upload audio, and publish to Element.fm so episodes appear in Apple Podcasts automatically.

## What changed

### Phase 1 — Inbox to NotebookLM (Claude skill)
- Fetches newsletters via Gmail labels (`newsletter/news`, `newsletter/think`, `newsletter/pro`) — no more relying on starred emails
- Triages into reading categories; creates one dated NotebookLM notebook per category
- Generates a 12-minute audio overview per notebook, insight-first with 3–5 key ideas
- Renames each artifact with an AI-generated title, bullet points, and sources line
- Downloads audio to iCloud Personal Podcast for Phase 2

### Phase 2 — NotebookLM to Element.fm (`daily_brief.py`)
- Polls for notebook/studio readiness, downloads if needed
- Detects M4A-disguised-as-MP3 by magic bytes and converts via ffmpeg before upload
- Publishes to Element.fm with rich descriptions from `notebook_describe`
- Idempotent: per-date manifest means re-runs are safe

### Infrastructure
- `~/bin/run-reading-list.sh` — launchd entry point with full logging, TCC workaround (caches skill + scripts outside `~/Documents`), and automation mode for `claude -p`
- `~/bin/daily-brief` — wrapper for ad-hoc Phase 2 runs (`--show-status`, `--upload-only`, `--dry-run`)
- Gmail/Todoist MCPs registered at user scope so OAuth tokens work in non-interactive mode

### New files
`daily_brief.py`, `elementfm_client.py`, `podcast_config.py`, `subprocess_utils.py`, updated `SKILL.md`, `process-overview.md`

## Test plan
- [x] Full pipeline ran for 2026-03-27: 2 notebooks, audio generated, converted, uploaded, published
- [x] `test_podcast_config.py`, `test_rss_xml_escape.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)