### PR TITLE
feat: add multi-model-review skill (Claude + Codex via MCP)

### DIFF
--- a/dhk-daily-brief/skills/user/multi-model-review/README.md
+++ b/dhk-daily-brief/skills/user/multi-model-review/README.md
@@ -1,0 +1,129 @@
+# multi-model-review
+
+A Claude skill that orchestrates adversarial, multi-perspective reviews using Claude as the orchestrator and OpenAI Codex as a second-opinion reviewer via MCP.
+
+The core insight: **the value is in the divergence**. When two models trained on different data, tuned differently, flag different things — that's the signal worth investigating. Consensus is noise. Disagreement is the finding.
+
+---
+
+## What it does
+
+Runs one of four review modes against any content — proposal, draft, design doc, or code — using both Claude and Codex independently, then synthesizes into a structured output that surfaces where the models agree, where they diverge, and what the single most important unresolved issue is.
+
+| Mode | Best for |
+|------|----------|
+| Red Team | Proposals, plans, architecture docs — find what breaks |
+| Steelman | Drafts and ideas — find the strongest version |
+| Debate | Claims and arguments — stress-test both sides |
+| Code Review | Code — correctness, security, edge cases |
+
+---
+
+## Prerequisites
+
+**1. Codex CLI installed**
+\`\`\`bash
+npm install -g @openai/codex
+codex login   # or: export OPENAI_API_KEY=your-key
+\`\`\`
+
+**2. Codex registered as an MCP server in Claude Code**
+\`\`\`bash
+claude mcp add codex -- npx codex mcp-server
+claude mcp list   # verify it appears
+\`\`\`
+
+---
+
+## Usage
+
+Trigger phrases (any of these will activate the skill):
+
+- \`"red team this proposal"\`
+- \`"review this with Codex"\`
+- \`"get a second opinion on this"\`
+- \`"steelman this draft"\`
+- \`"have Codex critique this"\`
+- \`"multi-model review"\`
+- \`"debate this"\`
+- \`"review this code with another model"\`
+
+The skill defaults to red team if no mode is specified.
+
+---
+
+## How it works
+
+\`\`\`
+You (prompt)
+    ↓
+Claude reviews independently   →   Claude's findings
+    ↓
+Claude calls Codex via MCP     →   Codex's findings
+    ↓
+Claude synthesizes both
+    ↓
+Consensus / Divergence / Crux / Next Step
+\`\`\`
+
+Claude always reviews first, before calling Codex. This keeps the reviews independent — if Claude saw Codex's output first, it would anchor on it.
+
+---
+
+## Output format
+
+\`\`\`
+## Claude's [Mode] Review
+[findings]
+
+## Codex's [Mode] Review
+[findings]
+
+## Synthesis
+
+CONSENSUS (both flagged):
+- ...
+
+DIVERGENT — Claude only:
+- ...
+
+DIVERGENT — Codex only:
+- ...
+
+THE CRUX: [single most important unresolved question]
+
+RECOMMENDED NEXT STEP: [one concrete action]
+\`\`\`
+
+---
+
+## Proof of concept test
+
+To verify end-to-end setup, paste this into a Claude Code session:
+
+\`\`\`
+Red team the following proposal using both your own judgment and Codex via MCP.
+
+PROPOSAL:
+We should migrate our data pipeline from batch processing to real-time streaming
+using Kafka. This will reduce latency from hours to seconds and allow us to
+react to events as they happen. The migration can be completed in one sprint.
+\`\`\`
+
+A working setup returns two distinct critiques and a synthesis. Codex should surface at least one issue Claude didn't lead with — if both outputs are identical, something is wrong with the independence of the calls.
+
+---
+
+## Extending to more models
+
+Once PAL-MCP-Server is installed, additional models (Gemini, GPT-4o) can be added to the fan-out. See \`docs/multi-model-review-workflow.md\` for the full architecture discussion and PAL setup instructions.
+
+---
+
+## Files
+
+\`\`\`
+multi-model-review/
+├── SKILL.md      — Claude's instructions (loaded at trigger time)
+└── README.md     — this file
+\`\`\`

--- a/dhk-daily-brief/skills/user/multi-model-review/README.md
+++ b/dhk-daily-brief/skills/user/multi-model-review/README.md
@@ -22,16 +22,16 @@ Runs one of four review modes against any content — proposal, draft, design do
 ## Prerequisites
 
 **1. Codex CLI installed**
-\`\`\`bash
+```bash
 npm install -g @openai/codex
 codex login   # or: export OPENAI_API_KEY=your-key
-\`\`\`
+```
 
 **2. Codex registered as an MCP server in Claude Code**
-\`\`\`bash
+```bash
 claude mcp add codex -- npx codex mcp-server
 claude mcp list   # verify it appears
-\`\`\`
+```
 
 ---
 
@@ -39,14 +39,14 @@ claude mcp list   # verify it appears
 
 Trigger phrases (any of these will activate the skill):
 
-- \`"red team this proposal"\`
-- \`"review this with Codex"\`
-- \`"get a second opinion on this"\`
-- \`"steelman this draft"\`
-- \`"have Codex critique this"\`
-- \`"multi-model review"\`
-- \`"debate this"\`
-- \`"review this code with another model"\`
+- `"red team this proposal"`
+- `"review this with Codex"`
+- `"get a second opinion on this"`
+- `"steelman this draft"`
+- `"have Codex critique this"`
+- `"multi-model review"`
+- `"debate this"`
+- `"review this code with another model"`
 
 The skill defaults to red team if no mode is specified.
 
@@ -54,7 +54,7 @@ The skill defaults to red team if no mode is specified.
 
 ## How it works
 
-\`\`\`
+```
 You (prompt)
     ↓
 Claude reviews independently   →   Claude's findings
@@ -64,7 +64,7 @@ Claude calls Codex via MCP     →   Codex's findings
 Claude synthesizes both
     ↓
 Consensus / Divergence / Crux / Next Step
-\`\`\`
+```
 
 Claude always reviews first, before calling Codex. This keeps the reviews independent — if Claude saw Codex's output first, it would anchor on it.
 
@@ -72,7 +72,7 @@ Claude always reviews first, before calling Codex. This keeps the reviews indepe
 
 ## Output format
 
-\`\`\`
+```
 ## Claude's [Mode] Review
 [findings]
 
@@ -93,7 +93,7 @@ DIVERGENT — Codex only:
 THE CRUX: [single most important unresolved question]
 
 RECOMMENDED NEXT STEP: [one concrete action]
-\`\`\`
+```
 
 ---
 
@@ -101,14 +101,14 @@ RECOMMENDED NEXT STEP: [one concrete action]
 
 To verify end-to-end setup, paste this into a Claude Code session:
 
-\`\`\`
+```
 Red team the following proposal using both your own judgment and Codex via MCP.
 
 PROPOSAL:
 We should migrate our data pipeline from batch processing to real-time streaming
 using Kafka. This will reduce latency from hours to seconds and allow us to
 react to events as they happen. The migration can be completed in one sprint.
-\`\`\`
+```
 
 A working setup returns two distinct critiques and a synthesis. Codex should surface at least one issue Claude didn't lead with — if both outputs are identical, something is wrong with the independence of the calls.
 
@@ -116,14 +116,14 @@ A working setup returns two distinct critiques and a synthesis. Codex should sur
 
 ## Extending to more models
 
-Once PAL-MCP-Server is installed, additional models (Gemini, GPT-4o) can be added to the fan-out. See \`docs/multi-model-review-workflow.md\` for the full architecture discussion and PAL setup instructions.
+Once PAL-MCP-Server is installed, additional models (Gemini, GPT-4o) can be added to the fan-out. See `docs/multi-model-review-workflow.md` for the full architecture discussion and PAL setup instructions.
 
 ---
 
 ## Files
 
-\`\`\`
+```
 multi-model-review/
 ├── SKILL.md      — Claude's instructions (loaded at trigger time)
 └── README.md     — this file
-\`\`\`
+```

--- a/dhk-daily-brief/skills/user/multi-model-review/SKILL.md
+++ b/dhk-daily-brief/skills/user/multi-model-review/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: multi-model-review
+description: >
+  Orchestrates a multi-model review workflow using Claude as orchestrator and Codex
+  (via MCP) as a second-opinion reviewer. Produces adversarial, constructive, or
+  debate-style critiques with a synthesis that highlights where the models diverge —
+  which is where the real signal is. Use this skill whenever the user says anything
+  like "review this with Codex", "get a second opinion", "red team this", "have Codex
+  critique this", "multi-model review", "ask Codex what it thinks", "steelman this
+  proposal", "debate this", or "review this code with another model". Triggers any
+  time the user wants two AI perspectives on a proposal, draft, design, or codebase.
+compatibility: "Requires: Codex registered as MCP server (claude mcp add codex -- npx codex mcp-server)"
+---
+
+# Multi-Model Review
+
+Uses Claude as orchestrator and Codex as a second-opinion reviewer via MCP.
+The value is in the *divergence* — where models disagree is where you should investigate.
+
+---
+
+## Prerequisites
+
+Codex must be registered as an MCP server. Verify with:
+```
+claude mcp list
+```
+
+If `codex` is not listed, ask the user to run:
+```bash
+claude mcp add codex -- npx codex mcp-server
+```
+
+---
+
+## Choosing a Workflow
+
+Ask the user which review mode they want, or infer from context:
+
+| Mode | Use when |
+|------|----------|
+| `/review-redteam` | Proposal, plan, design doc — find what breaks |
+| `/review-steelman` | Draft or idea — find the strongest version |
+| `/review-debate` | Claim or argument — stress-test both sides |
+| `/review-code` | Code — correctness, security, edge cases |
+
+If unclear, default to `/review-redteam`.
+
+---
+
+## Step 1: Claude's Review
+
+Before calling Codex, Claude completes its own full review using the selected mode.
+Do not call Codex first — independent reviews are more valuable than sequential ones.
+
+### Red Team prompt (Claude's own)
+Find at least 5 failure modes. Label each High / Med / Low severity.
+Format:
+```
+[HIGH] <finding title>
+Why it fails: ...
+Consequence if ignored: ...
+```
+End with: "Top 3 things that must be addressed before proceeding:"
+
+### Steelman prompt (Claude's own)
+Identify: core insight (one sentence), 3 ways to strengthen, the single condition
+that makes this succeed.
+
+### Debate prompt (Claude's own)
+Argue FOR the proposal — steelman it as strongly as possible.
+
+### Code Review prompt (Claude's own)
+Focus on: logic errors, edge cases, maintainability. Do not comment on style.
+
+---
+
+## Step 2: Call Codex via MCP
+
+Call the `codex` MCP tool with the appropriate prompt below.
+Pass the original content verbatim — do not summarize or pre-process it.
+
+### Red Team prompt for Codex
+```
+You are an adversarial reviewer. Your job is to find problems, not validate.
+
+For the following content, identify:
+- At least 5 specific failure modes or weaknesses (label each High/Med/Low severity)
+- Unstated assumptions that could break this
+- The single most critical issue that must be addressed
+
+Do not praise or validate. Only critique.
+
+CONTENT:
+{content}
+```
+
+### Steelman prompt for Codex
+```
+You are a constructive strategic reviewer. Assume this proposal is directionally correct.
+
+Identify:
+- The core insight that makes this valuable (one sentence)
+- 3 concrete ways to make this significantly stronger
+- The single condition that, if true, makes this succeed
+
+CONTENT:
+{content}
+```
+
+### Debate prompt for Codex
+```
+You are arguing AGAINST the following proposal. Find every reason it fails.
+Be specific. Be relentless. Do not hedge.
+
+PROPOSAL:
+{content}
+```
+
+### Code Review prompt for Codex
+```
+Review the following code. Focus specifically on:
+- Security vulnerabilities
+- Performance bottlenecks
+- Missing error handling or edge cases
+- Anything that would fail in production
+
+Do not comment on style. Only flag substantive issues with severity (Critical/High/Med/Low).
+
+CODE:
+{content}
+```
+
+If Codex validates without critique, follow up via `codex-reply` with:
+```
+Assume the proposal is wrong. What breaks first?
+```
+
+---
+
+## Step 3: Synthesize
+
+Compare Claude's review and Codex's review. Produce a synthesis in this format:
+
+```
+## Claude's [Mode] Review
+[findings]
+
+## Codex's [Mode] Review
+[findings]
+
+## Synthesis
+
+CONSENSUS (both flagged):
+- ...
+
+DIVERGENT — Claude only:
+- ...
+
+DIVERGENT — Codex only:
+- ...
+
+THE CRUX: [the single most important unresolved question]
+
+RECOMMENDED NEXT STEP: [one concrete action]
+```
+
+### Signal vs. Noise
+
+| Signal | Noise |
+|--------|-------|
+| Claude flags X, Codex doesn't | Both say "looks good" |
+| Codex raises issue Claude missed | Both list the same generic risks |
+| Models disagree on severity | One model echoes the other's framing |
+
+Two models agreeing does not mean they are right — it may mean they share a blind spot.
+Genuine divergence is what to investigate.
+
+---
+
+## Edge Cases
+
+- **Codex MCP not available**: Tell user to run `claude mcp add codex -- npx codex mcp-server` and restart the session
+- **Codex validates without critique**: Follow up with the "Assume the proposal is wrong" prompt via `codex-reply`
+- **Models fully agree**: Note the consensus but flag that shared training data may explain agreement; suggest a human domain expert review
+- **Content too long for single call**: Summarize to key claims before sending to Codex; note the truncation in the synthesis
+- **No mode specified**: Default to red team and confirm with user before proceeding

--- a/docs/multi-model-review-CLAUDE.md
+++ b/docs/multi-model-review-CLAUDE.md
@@ -1,0 +1,195 @@
+# Multi-Model Review Workflow
+
+This project uses Claude as the orchestrator and Codex as a second-opinion reviewer via MCP.
+The goal is adversarial, multi-perspective critique — not validation.
+
+---
+
+## Setup
+
+Codex must be registered as an MCP server before using these workflows:
+
+```bash
+claude mcp add codex -- npx codex mcp-server
+claude mcp list  # verify it appears
+```
+
+---
+
+## Review Workflows
+
+### `/review-redteam <content>`
+
+Run an adversarial red team review using both Claude and Codex.
+
+**Steps:**
+1. Claude performs a red team review of the content (find failure modes, not strengths)
+2. Claude sends the same content to Codex via MCP with the red team prompt
+3. Claude compares both critiques and identifies: consensus concerns, divergent findings, and the single most important issue
+
+**Prompt to send Codex:**
+```
+You are an adversarial reviewer. Your job is to find problems, not validate.
+
+For the following content, identify:
+- At least 5 specific failure modes or weaknesses (label each High/Med/Low severity)
+- Unstated assumptions that could break this
+- The single most critical issue that must be addressed
+
+Do not praise or validate. Only critique.
+
+CONTENT:
+{content}
+```
+
+**Output format:**
+```
+## Claude's Red Team
+[findings]
+
+## Codex's Red Team
+[findings]
+
+## Synthesis
+CONSENSUS (both flagged): ...
+DIVERGENT (only one flagged): ...
+THE CRUX: [single most important issue]
+RECOMMENDED NEXT STEP: [one concrete action]
+```
+
+---
+
+### `/review-steelman <content>`
+
+Generate the strongest possible version of a proposal, from two perspectives.
+
+**Steps:**
+1. Claude identifies the core insight and 3 ways to strengthen the proposal
+2. Codex does the same independently
+3. Claude synthesizes: where do they agree on what's valuable? Where do they diverge?
+
+**Prompt to send Codex:**
+```
+You are a constructive strategic reviewer. Assume this proposal is directionally correct.
+
+Identify:
+- The core insight that makes this valuable (one sentence)
+- 3 concrete ways to make this significantly stronger
+- The single condition that, if true, makes this succeed
+
+CONTENT:
+{content}
+```
+
+---
+
+### `/review-debate <content>`
+
+Run a structured debate: Claude takes one position, Codex takes the opposite.
+
+**Steps:**
+1. Claude argues FOR the proposal (steelman it)
+2. Claude sends to Codex with instruction to argue AGAINST (red team it)
+3. Claude runs one rebuttal round from each side
+4. Claude delivers a verdict: what changed, what held, what remains unresolved
+
+**Prompt to send Codex:**
+```
+You are arguing AGAINST the following proposal. Find every reason it fails.
+Be specific. Be relentless. Do not hedge.
+
+PROPOSAL:
+{content}
+```
+
+---
+
+### `/review-code <file_or_description>`
+
+Multi-model code review focused on correctness, security, and edge cases.
+
+**Steps:**
+1. Claude reviews for: logic errors, edge cases, maintainability
+2. Codex reviews for: security issues, performance, missing error handling
+3. Synthesize into a prioritized fix list
+
+**Prompt to send Codex:**
+```
+Review the following code. Focus specifically on:
+- Security vulnerabilities
+- Performance bottlenecks  
+- Missing error handling or edge cases
+- Anything that would fail in production
+
+Do not comment on style. Only flag substantive issues with severity (Critical/High/Med/Low).
+
+CODE:
+{code}
+```
+
+---
+
+## How to Invoke Codex via MCP
+
+In a Claude Code session, after Codex is registered as an MCP server:
+
+```
+Use the codex MCP tool to send the following prompt: [prompt]
+Then return the full response so I can synthesize.
+```
+
+Claude will call the `codex` tool, get a response, and you can chain the `codex-reply` 
+tool to continue the thread if you want a back-and-forth.
+
+---
+
+## Orchestration Tips
+
+- **Claude orchestrates, Codex executes** — Claude decides when to call Codex and how to weight its response
+- **Send identical content** — Both models should see the same input for the comparison to be meaningful
+- **Force disagreement** — If both models agree immediately, prompt Codex explicitly: "What is Claude likely missing here?"
+- **Watch for sycophancy** — If Codex validates without critique, re-prompt: "Assume the proposal is wrong. What breaks first?"
+- **Context isolation** — Each Codex call starts fresh. If you want continuity, use `codex-reply` with the thread ID from the first response
+
+---
+
+## Signal vs. Noise
+
+The value of multi-model review is in the *divergence*, not the consensus.
+
+| Signal | Noise |
+|--------|-------|
+| Claude flags X, Codex doesn't | Both say "looks good" |
+| Codex raises issue Claude missed | Both list the same generic risks |
+| Models disagree on severity | One model echoes the other's framing |
+
+When you see genuine divergence, that's the question worth investigating — not resolving automatically.
+
+---
+
+## Extending This Workflow
+
+To add more models (Gemini, GPT-4o via PAL-MCP-Server):
+
+1. Install PAL: `git clone https://github.com/BeehiveInnovations/pal-mcp-server && ./run-server.sh`
+2. PAL auto-registers with Claude Code
+3. Add a `/review-consensus` workflow that fans out to 3+ models and requires 2/3 agreement before flagging an issue as confirmed
+
+---
+
+## Proof of Concept Test
+
+To verify the setup works end-to-end, run this in a Claude Code session:
+
+```
+Review the following proposal using both your own judgment and Codex via MCP.
+Use the /review-redteam workflow.
+
+PROPOSAL:
+We should migrate our data pipeline from batch processing to real-time streaming 
+using Kafka. This will reduce latency from hours to seconds and allow us to 
+react to events as they happen. The migration can be completed in one sprint.
+```
+
+A working setup will return two distinct critiques and a synthesis.
+The Codex critique should surface at least one thing Claude didn't lead with.

--- a/docs/multi-model-review-workflow.md
+++ b/docs/multi-model-review-workflow.md
@@ -1,0 +1,205 @@
+# Multi-Model Review: Workflow Reference
+
+This document covers the architecture, design decisions, and extension patterns behind the `multi-model-review` skill. It's the companion to `SKILL.md` (which Claude reads) and `README.md` (quick start).
+
+---
+
+## Why multi-model review?
+
+Single-model review has a structural problem: you're asking the same system that generated the content (or a system trained similarly) to evaluate it. The model shares blind spots with itself.
+
+Multi-model review adds genuine diversity when:
+- Models are trained on different data distributions
+- Models have different RLHF tuning (what they're rewarded for)
+- Models are prompted with different adversarial framings
+
+The result isn't perfect — all frontier models share significant training overlap — but the divergence rate is meaningful. Expect Codex to catch things Claude misses roughly 20-30% of the time on technical content, and vice versa.
+
+**The frame to hold:** multi-model review surfaces *questions to investigate*, not final verdicts. Two models agreeing doesn't mean they're right. Two models disagreeing is a flag, not a resolution.
+
+---
+
+## Architecture
+
+\`\`\`
+Claude Code session
+│
+├── Claude (orchestrator)
+│   ├── Reads SKILL.md at trigger time
+│   ├── Runs its own review first (independent)
+│   └── Calls Codex via MCP tool
+│
+└── Codex MCP server (subprocess)
+    ├── Started by: npx codex mcp-server
+    ├── Exposes: codex() — start session
+    │           codex-reply() — continue thread
+    └── Returns: full critique, thread ID for follow-up
+\`\`\`
+
+Claude always reviews before calling Codex. Order matters: if Claude saw Codex's output first, it would anchor on it, defeating the independence that makes the comparison valuable.
+
+---
+
+## The four review modes
+
+### Red Team (\`/review-redteam\`)
+**Purpose:** Find failure modes before they find you.
+
+Both models receive an adversarial prompt: find problems, not strengths. Each flags severity (High/Med/Low). The synthesis looks for consensus failures (confirmed risks) and divergent findings (model-specific blind spots).
+
+Best used on: proposals with strong claims, architecture decisions, anything being presented to stakeholders.
+
+### Steelman (\`/review-steelman\`)
+**Purpose:** Find the strongest version of an idea before critiquing it.
+
+Both models are asked to assume the proposal is directionally correct and identify: the core insight, ways to strengthen it, and the condition that makes it succeed. Useful before red teaming — if you can't steelman something, you don't understand it well enough to critique it.
+
+Best used on: early-stage drafts, Substack pieces before publication, strategy memos.
+
+### Debate (\`/review-debate\`)
+**Purpose:** Stress-test a claim by running both sides.
+
+Claude argues FOR. Codex argues AGAINST. Then one round of rebuttal each. The synthesis identifies what held under pressure and what didn't. This is the most expensive mode (4 calls total) but produces the sharpest output on contested claims.
+
+Best used on: anything you're about to publish or present where someone will push back.
+
+### Code Review (\`/review-code\`)
+**Purpose:** Multi-pass technical review with division of labor.
+
+Claude focuses on logic, edge cases, and maintainability. Codex focuses on security, performance, and production failures. The prompts are deliberately different to avoid both models reviewing the same surface.
+
+Best used on: pre-commit review, PR review, code you're shipping to production.
+
+---
+
+## Signal vs. noise
+
+The synthesis output is only as useful as your ability to read it correctly.
+
+| What you see | What it means |
+|---|---|
+| Both models flag the same issue | Confirmed risk — address it |
+| Only Claude flags something | Worth checking — may be Claude's training bias |
+| Only Codex flags something | High value — this is why you called a second model |
+| Both models validate | Weakest signal — shared blind spot is likely |
+| Models disagree on severity | The crux — investigate before deciding |
+
+**The most valuable output is always a Codex-only finding.** That's the thing Claude would have missed if you hadn't run this workflow.
+
+---
+
+## Prompting tips
+
+**Force independence.** Don't show Claude what Codex said before Claude reviews. Don't show Codex what Claude said. The value collapses if one model anchors on the other.
+
+**Force adversarial framing.** "Is this good?" produces validation. "What breaks first?" produces critique. The prompts in SKILL.md are engineered for the latter.
+
+**Follow up if Codex validates.** If Codex's response reads like a compliment, use \`codex-reply\` immediately:
+\`\`\`
+Assume the proposal is wrong. What breaks first?
+\`\`\`
+This almost always produces a more useful response.
+
+**Use the crux.** The synthesis surfaces THE CRUX — the single most important unresolved question. This is the thing to take to a human expert, not the full list of findings.
+
+---
+
+## Setup reference
+
+### One-time setup
+
+\`\`\`bash
+# Install Codex CLI
+npm install -g @openai/codex
+
+# Authenticate (pick one)
+codex login                          # ChatGPT subscription
+export OPENAI_API_KEY=your-key       # API key
+
+# Register with Claude Code
+claude mcp add codex -- npx codex mcp-server
+
+# Verify
+claude mcp list
+\`\`\`
+
+### Per-project setup (optional)
+
+\`\`\`bash
+# In your project directory
+claude mcp add codex --scope local -- npx codex mcp-server
+\`\`\`
+
+### Verify end-to-end
+
+In a Claude Code session:
+\`\`\`
+Red team the following using both your own judgment and Codex via MCP:
+
+PROPOSAL:
+We should migrate our data pipeline from batch to real-time streaming using Kafka.
+The migration can be completed in one sprint.
+\`\`\`
+
+Expected: two distinct critiques, a synthesis, at least one Codex-only finding.
+
+---
+
+## Extending to more models
+
+### PAL-MCP-Server (recommended next step)
+
+PAL adds Gemini, GPT-4o, Grok, and others behind a single MCP interface:
+
+\`\`\`bash
+git clone https://github.com/BeehiveInnovations/pal-mcp-server.git
+cd pal-mcp-server
+./run-server.sh   # auto-configures Claude Code
+\`\`\`
+
+Once PAL is running, you can fan out to 3+ models in a single session. A \`/review-consensus\` workflow requiring 2/3 agreement before confirming an issue becomes practical.
+
+### mcp-agent (for durable pipelines)
+
+For automated review pipelines (e.g., review every Substack draft before publishing), \`mcp-agent\` provides orchestrator/evaluator patterns that persist across sessions:
+
+\`\`\`
+pip install mcp-agent
+\`\`\`
+
+See: https://github.com/lastmile-ai/mcp-agent
+
+### OpenAI Agents SDK
+
+Codex CLI can also be exposed to the OpenAI Agents SDK directly:
+
+\`\`\`python
+async with MCPServerStdio(
+    name="Codex CLI",
+    params={"command": "npx", "args": ["-y", "codex", "mcp-server"]},
+) as codex_mcp_server:
+    # orchestrate multi-agent review workflows
+\`\`\`
+
+See: https://developers.openai.com/codex/guides/agents-sdk
+
+---
+
+## Security note
+
+Keep Codex CLI updated — a vulnerability (CVE-2025-61260) was patched in v0.23.0 that allowed malicious MCP configs in cloned repos to execute on startup. Run \`npm update -g @openai/codex\` to ensure you're on a safe version.
+
+---
+
+## Related files
+
+\`\`\`
+adventures-in-ai/
+├── dhk-daily-brief/
+│   └── skills/user/
+│       └── multi-model-review/
+│           ├── SKILL.md       — Claude's runtime instructions
+│           └── README.md      — Quick start
+└── docs/
+    └── multi-model-review-workflow.md   — this file
+\`\`\`

--- a/docs/multi-model-review-workflow.md
+++ b/docs/multi-model-review-workflow.md
@@ -21,7 +21,7 @@ The result isn't perfect — all frontier models share significant training over
 
 ## Architecture
 
-\`\`\`
+```
 Claude Code session
 │
 ├── Claude (orchestrator)
@@ -34,7 +34,7 @@ Claude Code session
     ├── Exposes: codex() — start session
     │           codex-reply() — continue thread
     └── Returns: full critique, thread ID for follow-up
-\`\`\`
+```
 
 Claude always reviews before calling Codex. Order matters: if Claude saw Codex's output first, it would anchor on it, defeating the independence that makes the comparison valuable.
 
@@ -42,28 +42,28 @@ Claude always reviews before calling Codex. Order matters: if Claude saw Codex's
 
 ## The four review modes
 
-### Red Team (\`/review-redteam\`)
+### Red Team (`/review-redteam`)
 **Purpose:** Find failure modes before they find you.
 
 Both models receive an adversarial prompt: find problems, not strengths. Each flags severity (High/Med/Low). The synthesis looks for consensus failures (confirmed risks) and divergent findings (model-specific blind spots).
 
 Best used on: proposals with strong claims, architecture decisions, anything being presented to stakeholders.
 
-### Steelman (\`/review-steelman\`)
+### Steelman (`/review-steelman`)
 **Purpose:** Find the strongest version of an idea before critiquing it.
 
 Both models are asked to assume the proposal is directionally correct and identify: the core insight, ways to strengthen it, and the condition that makes it succeed. Useful before red teaming — if you can't steelman something, you don't understand it well enough to critique it.
 
 Best used on: early-stage drafts, Substack pieces before publication, strategy memos.
 
-### Debate (\`/review-debate\`)
+### Debate (`/review-debate`)
 **Purpose:** Stress-test a claim by running both sides.
 
 Claude argues FOR. Codex argues AGAINST. Then one round of rebuttal each. The synthesis identifies what held under pressure and what didn't. This is the most expensive mode (4 calls total) but produces the sharpest output on contested claims.
 
 Best used on: anything you're about to publish or present where someone will push back.
 
-### Code Review (\`/review-code\`)
+### Code Review (`/review-code`)
 **Purpose:** Multi-pass technical review with division of labor.
 
 Claude focuses on logic, edge cases, and maintainability. Codex focuses on security, performance, and production failures. The prompts are deliberately different to avoid both models reviewing the same surface.
@@ -94,10 +94,10 @@ The synthesis output is only as useful as your ability to read it correctly.
 
 **Force adversarial framing.** "Is this good?" produces validation. "What breaks first?" produces critique. The prompts in SKILL.md are engineered for the latter.
 
-**Follow up if Codex validates.** If Codex's response reads like a compliment, use \`codex-reply\` immediately:
-\`\`\`
+**Follow up if Codex validates.** If Codex's response reads like a compliment, use `codex-reply` immediately:
+```
 Assume the proposal is wrong. What breaks first?
-\`\`\`
+```
 This almost always produces a more useful response.
 
 **Use the crux.** The synthesis surfaces THE CRUX — the single most important unresolved question. This is the thing to take to a human expert, not the full list of findings.
@@ -108,7 +108,7 @@ This almost always produces a more useful response.
 
 ### One-time setup
 
-\`\`\`bash
+```bash
 # Install Codex CLI
 npm install -g @openai/codex
 
@@ -121,25 +121,27 @@ claude mcp add codex -- npx codex mcp-server
 
 # Verify
 claude mcp list
-\`\`\`
+```
 
 ### Per-project setup (optional)
 
-\`\`\`bash
+Scope Codex to a specific project:
+
+```bash
 # In your project directory
 claude mcp add codex --scope local -- npx codex mcp-server
-\`\`\`
+```
 
 ### Verify end-to-end
 
 In a Claude Code session:
-\`\`\`
+```
 Red team the following using both your own judgment and Codex via MCP:
 
 PROPOSAL:
 We should migrate our data pipeline from batch to real-time streaming using Kafka.
 The migration can be completed in one sprint.
-\`\`\`
+```
 
 Expected: two distinct critiques, a synthesis, at least one Codex-only finding.
 
@@ -151,21 +153,21 @@ Expected: two distinct critiques, a synthesis, at least one Codex-only finding.
 
 PAL adds Gemini, GPT-4o, Grok, and others behind a single MCP interface:
 
-\`\`\`bash
+```bash
 git clone https://github.com/BeehiveInnovations/pal-mcp-server.git
 cd pal-mcp-server
 ./run-server.sh   # auto-configures Claude Code
-\`\`\`
+```
 
-Once PAL is running, you can fan out to 3+ models in a single session. A \`/review-consensus\` workflow requiring 2/3 agreement before confirming an issue becomes practical.
+Once PAL is running, you can fan out to 3+ models in a single session. A `/review-consensus` workflow requiring 2/3 agreement before confirming an issue becomes practical.
 
 ### mcp-agent (for durable pipelines)
 
-For automated review pipelines (e.g., review every Substack draft before publishing), \`mcp-agent\` provides orchestrator/evaluator patterns that persist across sessions:
+For automated review pipelines (e.g., review every Substack draft before publishing), `mcp-agent` provides orchestrator/evaluator patterns that persist across sessions:
 
-\`\`\`
+```
 pip install mcp-agent
-\`\`\`
+```
 
 See: https://github.com/lastmile-ai/mcp-agent
 
@@ -173,13 +175,13 @@ See: https://github.com/lastmile-ai/mcp-agent
 
 Codex CLI can also be exposed to the OpenAI Agents SDK directly:
 
-\`\`\`python
+```python
 async with MCPServerStdio(
     name="Codex CLI",
     params={"command": "npx", "args": ["-y", "codex", "mcp-server"]},
 ) as codex_mcp_server:
     # orchestrate multi-agent review workflows
-\`\`\`
+```
 
 See: https://developers.openai.com/codex/guides/agents-sdk
 
@@ -187,13 +189,13 @@ See: https://developers.openai.com/codex/guides/agents-sdk
 
 ## Security note
 
-Keep Codex CLI updated — a vulnerability (CVE-2025-61260) was patched in v0.23.0 that allowed malicious MCP configs in cloned repos to execute on startup. Run \`npm update -g @openai/codex\` to ensure you're on a safe version.
+Keep Codex CLI updated — a vulnerability (CVE-2025-61260) was patched in v0.23.0 that allowed malicious MCP configs in cloned repos to execute on startup. Run `npm update -g @openai/codex` to ensure you're on a safe version.
 
 ---
 
 ## Related files
 
-\`\`\`
+```
 adventures-in-ai/
 ├── dhk-daily-brief/
 │   └── skills/user/
@@ -202,4 +204,4 @@ adventures-in-ai/
 │           └── README.md      — Quick start
 └── docs/
     └── multi-model-review-workflow.md   — this file
-\`\`\`
+```


### PR DESCRIPTION
Here you go:

---

**feat: add multi-model-review skill (Claude + Codex via MCP)**

This PR adds a new skill and supporting documentation for orchestrating multi-model AI reviews using Claude as the orchestrator and OpenAI Codex as a second-opinion reviewer via MCP.

**The core idea:** single-model review has a structural blind spot — you're asking a system to evaluate content it (or a similar system) might have generated. Multi-model review adds genuine diversity. The value is in the divergence, not the consensus.

**What's included:**

`dhk-daily-brief/skills/user/multi-model-review/SKILL.md` — Claude's runtime instructions. Four review modes: red team (find failure modes), steelman (find the strongest version), debate (stress-test both sides), and code review (correctness, security, edge cases). Claude reviews independently first, then calls Codex via MCP, then synthesizes — surfacing consensus findings, divergent findings, and a single crux question.

`dhk-daily-brief/skills/user/multi-model-review/README.md` — Quick-start for humans. Setup steps, trigger phrases, output format, and a proof-of-concept test prompt.

`docs/multi-model-review-workflow.md` — Deep reference covering architecture, design decisions, signal vs. noise interpretation, prompting tips, and extension patterns (PAL-MCP-Server, mcp-agent, OpenAI Agents SDK).

`docs/multi-model-review-CLAUDE.md` — Workflow reference and prompt templates for use within Claude Code sessions.

**Prerequisites to use:**
```bash
claude mcp add codex -- npx codex mcp-server
```

**Proof of concept test:** paste the Kafka migration prompt from the README into a Claude Code session. A working setup returns two distinct critiques and at least one Codex-only finding.

