### PR TITLE
feat: Vital Signs (healthcare) feed

### DIFF
--- a/reading-with-ears/config/feeds.json
+++ b/reading-with-ears/config/feeds.json
@@ -50,6 +50,18 @@
       "notebook_emoji": "🎙️",
       "notebook_order": 4,
       "audio_focus_prompt": "This episode should run approximately 12 minutes. Explain the week's AI ideas for a smart non-specialist. Open with why this matters in plain language, then unpack the core concepts without jargon walls, then close with what listeners should watch for next. Be accurate, calm, and concrete."
+    },
+    {
+      "slug": "vital-signs",
+      "enabled": true,
+      "show_name": "Vital Signs",
+      "show_description": "Healthcare, medicine, and science that affects bodies and systems — curated for listening.",
+      "elementfm_show_id": "7d9202b5-58fe-4761-8fc6-2003abc00728",
+      "gmail_labels": ["newsletter/healthcare"],
+      "notebook_category": "🏥 Healthcare Reading",
+      "notebook_emoji": "🏥",
+      "notebook_order": 5,
+      "audio_focus_prompt": "This episode should run approximately 12 minutes. Your job is to make healthcare and biomedical developments intelligible and consequential. Open with the 2-3 most important developments: what changed, for whom, and why it matters clinically, scientifically, or for public health. Then walk through each source: claims, evidence, limits, and what is still uncertain. Close with a sober through-line: what a thoughtful listener should watch or ask their clinician about — without giving personal medical advice. Be precise; distinguish consensus from speculation."
     }
   ]
 }

--- a/reading-with-ears/scripts/podcast_config.py
+++ b/reading-with-ears/scripts/podcast_config.py
@@ -31,6 +31,7 @@ CATEGORY_SLUGS: dict[str, str] = {
     "📰 News & Current Affairs": "news",
     "🧠 Things to Think About": "think",
     "💼 Professional Reading": "professional",
+    "🏥 Healthcare Reading": "vital-signs",
 }
 
 CATEGORY_TITLES: dict[str, str] = {v: k for k, v in CATEGORY_SLUGS.items()}
@@ -239,9 +240,13 @@ def category_title_to_slug(category_title: str) -> Optional[str]:
         return "think"
     if "💼" in ct:
         return "professional"
+    if "🏥" in ct:
+        return "vital-signs"
     if "🎙️" in ct:
         return "ai-everybody"
     # Keyword fallbacks
+    if "healthcare" in norm and "reading" in norm:
+        return "vital-signs"
     if "professional" in norm and "reading" in norm:
         return "professional"
     if "things to think" in norm:

--- a/reading-with-ears/scripts/suggest_gmail_label_filters.py
+++ b/reading-with-ears/scripts/suggest_gmail_label_filters.py
@@ -73,7 +73,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--preferred-category",
-        choices=["news", "think", "professional"],
+        choices=["news", "think", "professional", "vital-signs"],
         default=None,
         help="Optional category preference to boost ranking",
     )

--- a/reading-with-ears/scripts/tidy_elementfm_shows.py
+++ b/reading-with-ears/scripts/tidy_elementfm_shows.py
@@ -2,7 +2,7 @@
 """
 Tidy Element.fm shows: normalize episode titles (drop legacy "reading list - " and
 NotebookLM-style labels) and move episodes to the show that matches their category
-(news / think / professional).
+(all enabled slugs in feeds.json, e.g. news / think / professional / vital-signs).
 
 Uses the same API + feeds.json mapping as publish_episodes.py.
 
@@ -24,7 +24,12 @@ from datetime import datetime
 from typing import Any, Optional
 
 from elementfm_client import ElementFmClient, ElementFmConfig
-from podcast_config import elementfm_base_url, elementfm_episode_description, load_feeds_publish_config
+from podcast_config import (
+    elementfm_base_url,
+    elementfm_episode_description,
+    enabled_slugs_ordered,
+    load_feeds_publish_config,
+)
 
 
 TITLE_RE = re.compile(
@@ -70,6 +75,8 @@ def slug_date_from_title(title: str) -> Optional[tuple[str, str]]:
             return None
         if "Professional Reading" in raw:
             return "professional", date_iso
+        if "Healthcare Reading" in raw:
+            return "vital-signs", date_iso
         if "Things to Think About" in raw:
             return "think", date_iso
         if "News & Current Affairs" in raw:
@@ -150,9 +157,9 @@ def main() -> int:
         return 1
 
     workspace_id, slug_to_show = load_feeds_publish_config()
-    feed_slugs = [s for s in ("news", "think", "professional") if s in slug_to_show]
+    feed_slugs = [s for s in enabled_slugs_ordered() if s in slug_to_show]
     if not feed_slugs:
-        print("No news/think/professional slugs with elementfm_show_id in feeds config.", file=sys.stderr)
+        print("No enabled feed slugs with elementfm_show_id in feeds config.", file=sys.stderr)
         return 1
 
     moves_ok = 0

--- a/reading-with-ears/scripts/upload_to_elementfm.py
+++ b/reading-with-ears/scripts/upload_to_elementfm.py
@@ -56,7 +56,7 @@ def main():
     parser.add_argument(
         "--slug",
         default=None,
-        help="Feed slug (news, think, professional, …) — selects Element.fm show from feeds.json; "
+        help="Feed slug (news, think, professional, vital-signs, …) — selects Element.fm show from feeds.json; "
         "default: infer from filename YYYY-MM-DD-<slug>.<ext>",
     )
     parser.add_argument("--title", help="Episode title (auto-generated from filename if not set)")

--- a/reading-with-ears/skills/user/personal-podcast/SKILL.md
+++ b/reading-with-ears/skills/user/personal-podcast/SKILL.md
@@ -59,6 +59,7 @@ Downloaded audio files follow this naming pattern:
 | `YYYY-MM-DD-news.m4a` | 📰 News & Current Affairs | "📰 News & Current Affairs — Mon DD, YYYY" |
 | `YYYY-MM-DD-think.m4a` | 🧠 Things to Think About | "🧠 Things to Think About — Mon DD, YYYY" |
 | `YYYY-MM-DD-professional.m4a` | 💼 Professional Reading | "💼 Professional Reading — Mon DD, YYYY" |
+| `YYYY-MM-DD-vital-signs.m4a` | 🏥 Healthcare Reading | "🏥 Healthcare Reading — Mon DD, YYYY" |
 
 ---
 
@@ -116,13 +117,13 @@ requirements. Use the `nlm` CLI directly from Terminal instead.
 
 ---
 
-## Full Day Upload (all three categories)
+## Full Day Upload (all enabled category slugs)
 
 ```bash
 DATE="2026-03-21"
 BASE="/Users/dhk/Library/Mobile Documents/com~apple~CloudDocs/Personal Podcast"
 
-for cat in news think professional; do
+for cat in news think professional vital-signs; do
   python3 ~/scripts/upload_to_elementfm.py "$BASE/${DATE}-${cat}.m4a"
 done
 ```

--- a/reading-with-ears/skills/user/reading-with-ears/SKILL.md
+++ b/reading-with-ears/skills/user/reading-with-ears/SKILL.md
@@ -41,9 +41,9 @@ an empty `gmail_labels` list for the OR query only — they still get notebooks 
 classified into them another way, e.g. manual triage):
 
 - Build `label:foo OR label:bar OR …` for every distinct label across enabled feeds.
-- Example when news / think / pro / ai-everybody are all enabled:
+- Example when news / think / pro / healthcare / ai-everybody are all enabled:
 ```
-gmail_search_messages(q="(label:newsletter/news OR label:newsletter/think OR label:newsletter/pro OR label:newsletter/ai-everybody) after:YYYY/MM/DD")
+gmail_search_messages(q="(label:newsletter/news OR label:newsletter/think OR label:newsletter/pro OR label:newsletter/healthcare OR label:newsletter/ai-everybody) after:YYYY/MM/DD")
 ```
 
 **Classification hint:** If an email carries a label that appears in feed `gmail_labels`,
@@ -274,7 +274,7 @@ download_artifact(
 ### Slug mapping (from `feeds.json`)
 
 Use each feed’s **`slug`** field for the filename: `YYYY-MM-DD-<slug>.mp3`
-(e.g. `news`, `think`, `professional`, `ai-everybody`). Phase 2 (`publish_episodes.py`) uses the
+(e.g. `news`, `think`, `professional`, `vital-signs`, `ai-everybody`). Phase 2 (`publish_episodes.py`) uses the
 same slugs for enabled feeds.
 
 - Skip download if the file already exists at that path (idempotency)

--- a/reading-with-ears/tests/test_podcast_config.py
+++ b/reading-with-ears/tests/test_podcast_config.py
@@ -26,6 +26,10 @@ class TestPodcastConfig(unittest.TestCase):
             slug_map.get("professional"),
             "01a6981c-6888-4d51-9471-f3258a98b13e",
         )
+        self.assertEqual(
+            slug_map.get("vital-signs"),
+            "7d9202b5-58fe-4761-8fc6-2003abc00728",
+        )
         self.assertNotIn("ai-everybody", slug_map)
 
     def test_parse_episode_title_from_filename_known_slug(self):
@@ -93,6 +97,10 @@ class TestPodcastConfig(unittest.TestCase):
         self.assertEqual(
             podcast_config.category_title_to_slug("💼 Tech & Career"),
             "professional",
+        )
+        self.assertEqual(
+            podcast_config.category_title_to_slug("🏥 Healthcare Reading"),
+            "vital-signs",
         )
 
 


### PR DESCRIPTION
Adds **Vital Signs** (`vital-signs`): `newsletter/healthcare`, 🏥 Healthcare Reading, Element.fm show in `config/feeds.json`. Updates `podcast_config`, tests, `tidy_elementfm_shows`, label-filter helper, and personal-podcast / upload docs.