### PR TITLE
feat: add handoff Claude Code skill

### DIFF
--- a/skills/handoff/INSTALL.md
+++ b/skills/handoff/INSTALL.md
@@ -1,0 +1,66 @@
+# Handoff — Install Guide
+
+Handoff generates a self-contained context snapshot so you can continue
+work in a new Claude Code session when you hit a repo scope wall. Instead
+of losing thread mid-task, you get a paste-ready prompt that a fresh
+session can receive and act on immediately — no clarifying questions.
+
+## One-shot install
+
+```bash
+mkdir -p ~/.claude/skills/handoff && \
+  curl -fsSL https://raw.githubusercontent.com/dhk/adventures-in-ai/main/skills/handoff/SKILL.md \
+    -o ~/.claude/skills/handoff/SKILL.md
+```
+
+Claude Code picks up skills from `~/.claude/skills/` automatically.
+
+## Manual install
+
+1. Create the directory:
+   ```bash
+   mkdir -p ~/.claude/skills/handoff
+   ```
+
+2. Download the skill:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/dhk/adventures-in-ai/main/skills/handoff/SKILL.md \
+     -o ~/.claude/skills/handoff/SKILL.md
+   ```
+
+3. Verify:
+   ```bash
+   ls -lh ~/.claude/skills/handoff/SKILL.md
+   ```
+
+## Usage
+
+Trigger it in any Claude Code session when you need to hand off to a
+different repo:
+
+```
+/handoff
+/continue-in-new-session   # alias — same skill
+```
+
+The skill will:
+
+1. Review the current conversation and git state
+2. Produce a "Open this session" one-liner (which repo to open next)
+3. Produce a fenced handoff prompt to paste as the first message in the
+   new session — includes what's done, what's pending, exact next steps,
+   and guard rails
+
+## When to use it
+
+- You're mid-task and realise you need to push to a repo that isn't in
+  scope for the current session
+- Context is getting long and you want a clean resume point
+- You're handing work to another person or a scheduled agent
+
+## Updating
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dhk/adventures-in-ai/main/skills/handoff/SKILL.md \
+  -o ~/.claude/skills/handoff/SKILL.md
+```

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: handoff
+aliases:
+  - continue-in-new-session
+description: >
+  Generates a self-contained handoff prompt for continuing the current
+  session's work in a new Claude Code session — typically because the
+  work requires a repo that isn't in scope for the current session.
+  Produces a context snapshot + first-message you can paste directly
+  into the new session. Use when you hit a scope wall and need to
+  switch repos without losing thread.
+---
+
+# Continue in New Session
+
+You are generating a **handoff prompt** — a self-contained message that
+a new Claude Code session (with no memory of this conversation) can
+receive and immediately act on, without asking clarifying questions.
+
+## What to produce
+
+Output two clearly labelled blocks:
+
+---
+
+### 1. Open this session
+
+A one-liner telling the user which repo to open and how:
+
+```
+Open a Claude Code session scoped to: <owner>/<repo>
+```
+
+---
+
+### 2. Paste this as your first message
+
+A single fenced code block (so the user can copy it cleanly) containing
+the complete handoff prompt. The prompt must be self-contained — the
+receiving agent will have zero context from this conversation.
+
+Structure the prompt as follows:
+
+```
+## Context handoff from previous session
+
+**What we were working on:**
+<1–3 sentences: the task, the goal, why it matters>
+
+**What's already done:**
+<bullet list of completed work — be specific: file paths, commit SHAs,
+issue numbers, branch names, PR URLs. Anything the new agent needs to
+not repeat work>
+
+**The specific blocker that caused this handoff:**
+<one sentence: which repo was needed but out of scope, and why>
+
+**What to do next — in order:**
+<numbered steps, specific enough that the agent can execute without
+asking questions. Include exact file paths, target branches, source
+locations, URL patterns, commit message formats>
+
+**Files to carry over / reference:**
+<list any files the new agent should read first, with their locations
+and what they contain>
+
+**Constraints and guard rails:**
+<anything the new agent must NOT do — don't overwrite X, don't touch Y,
+stay on branch Z, cap at N issues, etc.>
+
+**Done when:**
+<one sentence describing the terminal state — what "finished" looks like>
+```
+
+---
+
+## How to gather the context
+
+Before writing the handoff, review:
+
+1. **This conversation** — what was asked, what was built, what's pending
+2. **Git state** — run `git log --oneline -10` and `git status` in any
+   repos that were modified; include branch names and recent commit SHAs
+3. **Open issues / PRs** — note any issue numbers or PR URLs created
+4. **Blocked work** — identify exactly what couldn't be done and why
+   (usually: repo X not in session scope)
+
+Do not ask the user for any of this — derive it from the conversation
+and tool call history. If something is genuinely ambiguous, make the
+most reasonable assumption and note it in the handoff.
+
+---
+
+## Standing defaults
+
+These apply to every handoff unless the user has explicitly said otherwise
+in this session:
+
+- **Always work on a branch** — never commit directly to `main`. The branch
+  name should follow the pattern `claude/<short-slug>`. Include the target
+  branch name explicitly in the "What to do next" steps.
+
+---
+
+## Tone
+
+The handoff prompt is written to another Claude instance, not to the
+user. Be precise and dense — no pleasantries, no hedging. The receiving
+agent should be able to read it once and start working.


### PR DESCRIPTION
## What this is

**Handoff** is a Claude Code skill that generates a self-contained context snapshot when you hit a repo scope wall mid-task — typically because the next step needs a repo that isn't in the current session.

The problem it solves: Claude Code sessions are scoped to a single repo. When you're working in `repo-a` and realise the next step requires pushing to `repo-b`, you either lose thread or try to reconstruct context from scratch in the new session. Handoff eliminates that by generating a structured prompt you can paste directly into the new session — complete with what's done, what's pending, exact next steps, and guard rails.

## What it produces

Two blocks:

1. **"Open this session"** — a one-liner telling you which repo to open
2. **A fenced handoff prompt** — structured context the receiving agent can act on immediately, covering:
   - What was being worked on and why
   - Completed work (file paths, commit SHAs, branch names, PR URLs)
   - The specific blocker that triggered the handoff
   - Numbered next steps specific enough to execute without clarifying questions
   - Files to read first
   - Guard rails (don't touch X, stay on branch Y, cap at N issues)
   - Done-when terminal condition

## Install

One-shot:

```bash
mkdir -p ~/.claude/skills/handoff && \
  curl -fsSL https://raw.githubusercontent.com/dhk/adventures-in-ai/main/skills/handoff/SKILL.md \
    -o ~/.claude/skills/handoff/SKILL.md
```

Full install guide: [`skills/handoff/INSTALL.md`](skills/handoff/INSTALL.md)

## Usage

```
/handoff
/continue-in-new-session   # alias
```

## Files

- `skills/handoff/SKILL.md` — full skill definition (109 lines), sourced verbatim from `dhk/woven`
- `skills/handoff/INSTALL.md` — install guide with curl one-shot, manual steps, and usage examples