### PR TITLE
Add Claude auth preflight for headless rwe scripts

### DIFF
--- a/.scratch/session-context-2026-07-02-auth-debug.md
+++ b/.scratch/session-context-2026-07-02-auth-debug.md
@@ -1,25 +1,21 @@
 ## Context handoff — auth debugging (updated 2026-07-03)
 
-**Status:** Root cause narrowed; diagnostic tooling added on branch `cursor/rwe-auth-diagnostics-001e`.
+**Status:** Root cause confirmed on laptop (2026-07-03).
 
-### Most likely remaining blocker (never inspected on laptop)
+### Confirmed root cause
 
-The debug log from the prior session showed:
+Two **different** `ANTHROPIC_API_KEY` values:
 
-```
-settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY
-```
+| Source | Fingerprint | API test |
+|--------|-------------|----------|
+| Shell / keychain (`.zshrc`) | `sk-a…nQAA` | **valid** |
+| `~/.claude/settings.json` env | `sk-a…HgAA` | **rejected** |
 
-`settingsEnv` comes from **`~/.claude/settings.json`**, not `~/.claude.json` (which was
-already cleaned). The user removed the dead key from `~/.claude.json` only — if
-`~/.claude/settings.json` still has `env.ANTHROPIC_API_KEY`, `claude -p` will keep
-injecting it regardless of `env -u ANTHROPIC_API_KEY` in the shell scripts.
+`rwe-catchup.sh` scrubs the shell key with `env -u`, but Claude Code still injects the
+**dead** key from `~/.claude/settings.json`. That produces `Invalid API key · Fix external
+API key`. Shell/.zshrc warnings are benign — keep keychain for `week_that_was.py`.
 
-The exact error `Invalid API key · Fix external API key` is **Claude Code OAuth vs.
-API-key conflict** (GitHub anthropics/claude-code#11587), not NotebookLM or Gmail MCP.
-MCP auth failures show `[MCP]` / `AxiosError` / `401` lines in the debug log instead.
-
-### Run on laptop (in order)
+### Fix (run on laptop)
 
 ```bash
 # 1. New audit (replaces the four manual cat commands)

--- a/.scratch/session-context-2026-07-02-auth-debug.md
+++ b/.scratch/session-context-2026-07-02-auth-debug.md
@@ -1,138 +1,67 @@
-## Context handoff from previous session
+## Context handoff — auth debugging (updated 2026-07-03)
 
-**What we were working on:**
-Testing the `reading-list-builder` skill's v3.0 migration (weekly notebook
-accumulation + separate weekly audio flow, replacing the old daily-audio
-scheme — see `docs/weekly-cadence-migration.md`) by running a catch-up
-backfill for the week of 2026-06-22 on the user's laptop:
-`bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22`. This is the first
-live exercise of the new weekly-notebook/reconciliation logic in
-`reading-list-builder` v3.0 — nothing in that logic has been verified
-against real Gmail/NotebookLM MCP yet.
+**Status:** Root cause narrowed; diagnostic tooling added on branch `cursor/rwe-auth-diagnostics-001e`.
 
-**Branch:** `claude/reading-list-pipeline-ahpsE` on `dhk/adventures-in-ai`
-(this is the branch for PR #25, not yet merged). Latest relevant commits:
-- `616527a` — scrub `ANTHROPIC_API_KEY` via `env -u` before every `claude -p`
-  invocation in `bin/rwe-run.sh`, `bin/rwe-catchup.sh`, `bin/rwe-weekly-audio`
-- `29adca1` — capture `claude`'s full `--debug`/`--debug-file` output on
-  failure in all three scripts, tail the last 40 lines to console on failure
-- `53730dd` — print the first 20 chars of `$ANTHROPIC_API_KEY` (shell-level)
-  right before scrubbing it, as a diagnostic
+### Most likely remaining blocker (never inspected on laptop)
 
-**What's already done — ruled in/out, in order discovered:**
+The debug log from the prior session showed:
 
-1. Every catch-up attempt fails identically with the exact same one-line
-   banner: `Invalid API key · Fix external API key`, then
-   `[2026-06-22] Pipeline failed — sentinel not written`.
-2. Confirmed the daily flow's actual work never happens: no
-   `dhkondata/reading-db/runs/2026-06-22.yaml` gets written. This is a real
-   failure, not a spurious/benign exit code on top of successful work.
-3. First hypothesis (WRONG on its own, but real and now fixed): a claude.ai
-   token + `ANTHROPIC_API_KEY` auth conflict. User ran `claude /logout` —
-   identical error persisted even before re-login, ruling this out as the
-   *sole* cause.
-4. Manually confirmed via `echo "ANTHROPIC_API_KEY is: ${ANTHROPIC_API_KEY:-<unset>}"`
-   that the *shell* genuinely has nothing exported — yet Claude Code's
-   startup banner still showed "API Usage Billing" mode and the auth-conflict
-   warning. This proved the key wasn't coming from the shell environment at
-   all.
-5. Full `--debug`/`--debug-file` capture (added this session, commit
-   `29adca1`) revealed the real signal:
-   ```
-   CA certs: Config fallback - globalEnv keys: , settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY
-   ```
-   — confirming `ANTHROPIC_API_KEY` was being force-injected from a
-   **settings file**, not the process environment, which is why `/logout`
-   and shell `unset` never touched it.
-6. Found the source: `~/.claude.json`'s top-level `"env"` block had
-   `ANTHROPIC_API_KEY` and `VERCEL_TOKEN` both set globally (applies to
-   *every* Claude Code session on the machine, not just this repo).
-   `/Library/Application Support/ClaudeCode/managed-settings.json` does
-   **not exist** on this machine (ruled out — it's not an MDM/managed
-   setting).
-7. Directly tested the exact key value against Anthropic's API:
-   ```bash
-   curl -s https://api.anthropic.com/v1/models \
-     -H "x-api-key: $(jq -r '.env.ANTHROPIC_API_KEY' ~/.claude.json)" \
-     -H "anthropic-version: 2023-06-01"
-   ```
-   → `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`.
-   **Confirmed fact:** this specific key is dead/rejected by Anthropic's API.
-   (Earlier claim that the key was "malformed" was walked back — we don't
-   actually know *why* it's invalid, just that it is. A separate JSON-parse
-   error seen nearby in the debug log — `Unexpected token '/', "/Users/dhk"...
-   is not valid JSON` at `Object.assign.cache` — was never confirmed to be
-   related; may be a red herring from an unrelated cache file.)
-8. User removed it: backed up (`~/.claude.json.bak`), then
-   ```bash
-   jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude.json > /tmp/claude.json.new && mv /tmp/claude.json.new ~/.claude.json
-   ```
-   Unexpectedly, `jq '.env' ~/.claude.json` now returns `null` entirely —
-   `VERCEL_TOKEN` is gone too, not just the one key (still recoverable from
-   the `.bak` file if needed for something unrelated).
+```
+settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY
+```
 
-**The specific blocker that caused this handoff:**
-**Despite removing `ANTHROPIC_API_KEY` from `~/.claude.json` and confirming
-the shell itself has nothing exported (the new diagnostic print showed a
-blank value), the exact same `Invalid API key · Fix external API key`
-failure still occurs on re-run.** This means the dead key we found and
-removed was NOT the sole or even necessarily the correct source — there
-must be another place Claude Code is picking up a bad credential from, or
-this error was never actually about `ANTHROPIC_API_KEY` at all (it could be
-a completely different "external API key" — e.g. the `notebooklm` MCP
-server's own separate credential, unrelated to Anthropic auth).
+`settingsEnv` comes from **`~/.claude/settings.json`**, not `~/.claude.json` (which was
+already cleaned). The user removed the dead key from `~/.claude.json` only — if
+`~/.claude/settings.json` still has `env.ANTHROPIC_API_KEY`, `claude -p` will keep
+injecting it regardless of `env -u ANTHROPIC_API_KEY` in the shell scripts.
 
-On the most recent run, the debug log tail (`tail -40`) printed **nothing**
-— either the debug file is empty, wasn't created, or the failure now
-happens even earlier than before. This is unconfirmed — the following
-commands were requested but their output was never received before this
-handoff:
+The exact error `Invalid API key · Fix external API key` is **Claude Code OAuth vs.
+API-key conflict** (GitHub anthropics/claude-code#11587), not NotebookLM or Gmail MCP.
+MCP auth failures show `[MCP]` / `AxiosError` / `401` lines in the debug log instead.
+
+### Run on laptop (in order)
+
+```bash
+# 1. New audit (replaces the four manual cat commands)
+bin/rwe-auth-check.sh --test-api --doctor
+
+# 2. If blockers found in ~/.claude/settings.json:
+jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json \
+  && mv /tmp/s.json ~/.claude/settings.json
+
+# 3. Re-check, then single-day catch-up
+bin/rwe-auth-check.sh --test-api
+bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22
+
+# 4. Confirm sentinel + run YAML written
+ls -la ~/.local/state/reading-with-ears/done-2026-06-22
+ls -la ~/dhkondata/reading-db/runs/2026-06-22.yaml   # or path from config
+```
+
+If auth check passes but catch-up still fails, inspect the full debug log (not just tail):
 
 ```bash
 wc -l ~/logs/reading-with-ears/catchup-debug-2026-06-22.log
-cat ~/logs/reading-with-ears/catchup-debug-2026-06-22.log
-cat ~/.claude/settings.json 2>/dev/null       # NOTE: different file from ~/.claude.json, never actually checked
-cat .claude/settings.json 2>/dev/null
-cat .claude/settings.local.json 2>/dev/null
+cat ~/logs/reading-with-ears/catchup-debug-2026-06-22.log | rg -i 'mcp|axios|401|invalid'
 ```
 
-**What to do next — in order:**
+### MCP isolation test (only if auth check is clean)
 
-1. Get the output of the four commands above. In particular, `~/.claude/settings.json`
-   (global Claude Code settings — distinct from `~/.claude.json`, the config file
-   already fixed) was flagged as a candidate early on and never actually inspected.
-2. If the debug log is genuinely empty, re-run with the instrumented script
-   (`bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22` on branch
-   `claude/reading-list-pipeline-ahpsE`, already pulled) and get the fresh debug
-   file content — look specifically for `[MCP]`-tagged lines and any `AxiosError`/
-   `401`/`invalid x-api-key` occurrences, and note what immediately precedes them
-   (which server, Gmail vs. `notebooklm`, was active at that point).
-3. Consider directly testing the `notebooklm` MCP server in isolation, since it's
-   never been ruled in or out as the actual source of "invalid API key" (all
-   investigation so far has focused on Anthropic account auth, not the
-   third-party `notebooklm-mcp-cli` tool's own credential):
-   ```bash
-   cd reading-with-ears
-   claude --mcp-config automation/mcp-headless.json --strict-mcp-config
-   # ask: "list my notebooklm notebooks" and separately "search gmail for label:newsletter/news after:2026/06/22"
-   ```
-   Whichever one fails in isolation is the real answer.
-4. Once the actual root cause is found and fixed, re-run the single-day test
-   (`--from 2026-06-22 --to 2026-06-22`), confirm
-   `dhkondata/reading-db/runs/2026-06-22.yaml` gets written with real content,
-   *then* proceed to the remaining 9 days of catch-up
-   (`--from 2026-06-23 --to 2026-07-01`), watching closely for the STEP 3
-   reconciliation logic (untested live) if any pre-migration daily notebooks
-   exist for this week.
-5. Only after the daily flow is confirmed working: test the weekly audio flow
-   (`bin/rwe-weekly-audio`), which depends on the `--notebook-week` flag added
-   to `publish_episodes.py` this session (also unverified live).
+```bash
+cd reading-with-ears
+claude --mcp-config automation/mcp-headless.json --strict-mcp-config
+# "list my notebooklm notebooks"  — tests notebooklm
+# "search gmail for label:newsletter/news after:2026/06/22"  — tests gmail
+```
 
-**Other context, likely not relevant to this specific blocker but useful if asked:**
-- Two other PRs opened this session, unrelated to this auth issue: PR #26
-  (`handoff` skill, rebuilt cleanly on `main`) and PR #27 (three design-doc
-  clarifications for `week-that-was-design.md`, recovered from an uncommitted
-  local review). Both already merged-ready, no action needed.
-- Filed issue #28 for a separate, minor install friction (`rwe-catchup.sh:
-  command not found` when `~/bin` isn't on `PATH`) — unrelated to this auth
-  investigation.
+### After daily flow works
+
+1. Remaining catch-up: `--from 2026-06-23 --to 2026-07-01` (watch STEP 3 reconciliation)
+2. Weekly audio: `bin/rwe-weekly-audio` (unverified live)
+
+### What changed in repo (this session)
+
+- `bin/rwe-auth-check.sh` — audits all credential sources + optional API test + `claude doctor`
+- `rwe-run.sh`, `rwe-catchup.sh`, `rwe-weekly-audio` — preflight auth check before `claude -p`
+- `verify-reading-with-ears-setup.sh` — includes auth preflight when `claude` is on PATH
+- `docs/install.md` — troubleshooting section for this error

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -51,7 +51,76 @@ AUTH_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH
 BLOCKER_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
 
 issues = []
+warnings = []
 notes = []
+key_sources: dict[str, list[str]] = {}  # fingerprint -> labels
+
+
+def fingerprint(value: str) -> str:
+    value = (value or "").strip()
+    if len(value) < 12:
+        return value
+    return f"{value[:8]}…{value[-4:]}"
+
+
+def record_key(value: str, label: str) -> None:
+    fp = fingerprint(value)
+    if fp:
+        key_sources.setdefault(fp, [])
+        if label not in key_sources[fp]:
+            key_sources[fp].append(label)
+
+
+def test_api_key(key: str, label: str) -> str | None:
+    """Return 'valid', 'invalid', or None if not tested."""
+    if not TEST_API or not key.strip():
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-sS",
+                "https://api.anthropic.com/v1/models",
+                "-H", f"x-api-key: {key.strip()}",
+                "-H", "anthropic-version: 2023-06-01",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        body = (proc.stdout or proc.stderr or "").strip()
+        if "authentication_error" in body or "invalid x-api-key" in body:
+            return "invalid"
+        if proc.returncode == 0 and '"data"' in body:
+            return "valid"
+        notes.append(f"{label}: API test inconclusive ({body[:120]})")
+    except Exception as exc:  # noqa: BLE001
+        notes.append(f"{label}: API test failed ({exc})")
+    return None
+
+
+def audit_env_block(data: dict, label: str, *, critical: bool) -> None:
+    env = data.get("env")
+    if not isinstance(env, dict) or not env:
+        return
+    keys = sorted(env.keys())
+    print(f"  env keys: {', '.join(keys)}")
+    for key in BLOCKER_ENV_KEYS:
+        if key in env and str(env.get(key) or "").strip():
+            val = str(env[key])
+            record_key(val, label)
+            msg = (
+                f"{label}: {key} in settings env block ({mask_key(val)}) — "
+                "Claude Code injects this; env -u in rwe scripts cannot remove it"
+            )
+            if critical:
+                issues.append(msg)
+            else:
+                warnings.append(msg)
+            result = test_api_key(val, f"{label} env.{key}")
+            if result == "valid":
+                notes.append(f"{label} env.{key}: Anthropic API accepts this key")
+            elif result == "invalid":
+                issues.append(f"{label} env.{key}: Anthropic API rejects this key (authentication_error)")
 
 
 def mask_key(value: str) -> str:
@@ -72,49 +141,7 @@ def load_json(path: Path):
         return None, f"invalid JSON: {exc}"
 
 
-def test_api_key(key: str, label: str) -> None:
-    if not TEST_API or not key.strip():
-        return
-    try:
-        proc = subprocess.run(
-            [
-                "curl", "-sS",
-                "https://api.anthropic.com/v1/models",
-                "-H", f"x-api-key: {key.strip()}",
-                "-H", "anthropic-version: 2023-06-01",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=20,
-        )
-        body = (proc.stdout or proc.stderr or "").strip()
-        if "authentication_error" in body or "invalid x-api-key" in body:
-            issues.append(f"{label}: Anthropic API rejects this key (authentication_error)")
-        elif proc.returncode == 0 and '"data"' in body:
-            notes.append(f"{label}: Anthropic API accepts this key")
-        else:
-            notes.append(f"{label}: API test inconclusive ({body[:120]})")
-    except Exception as exc:  # noqa: BLE001
-        notes.append(f"{label}: API test failed ({exc})")
-
-
-def audit_env_block(data: dict, label: str) -> None:
-    env = data.get("env")
-    if not isinstance(env, dict) or not env:
-        return
-    keys = sorted(env.keys())
-    print(f"  env keys: {', '.join(keys)}")
-    for key in BLOCKER_ENV_KEYS:
-        if key in env and str(env.get(key) or "").strip():
-            val = str(env[key])
-            issues.append(
-                f"{label}: {key} is set in settings env block ({mask_key(val)}) — "
-                "overrides OAuth in claude -p and causes auth failures when invalid"
-            )
-            test_api_key(val, f"{label} env.{key}")
-
-
-def audit_file(path: Path, label: str) -> None:
+def audit_file(path: Path, label: str, *, critical: bool = True) -> None:
     print(f"\n{label}")
     print(f"  path: {path}")
     data, err = load_json(path)
@@ -124,7 +151,7 @@ def audit_file(path: Path, label: str) -> None:
             issues.append(f"{label}: {err}")
         return
     print("  status: present")
-    audit_env_block(data, label)
+    audit_env_block(data, label, critical=critical)
     helper = data.get("apiKeyHelper")
     if helper:
         issues.append(
@@ -141,10 +168,16 @@ def audit_shell_env() -> None:
         if val:
             print(f"  {key}: {mask_key(val)}")
             if key in BLOCKER_ENV_KEYS:
-                issues.append(
-                    f"Shell exports {key} ({mask_key(val)}) — scrub with env -u before claude -p"
+                record_key(val, "shell")
+                warnings.append(
+                    f"Shell exports {key} ({mask_key(val)}) — rwe scripts scrub with env -u; "
+                    "safe to keep for week_that_was.py / rwe-weekly"
                 )
-                test_api_key(val, f"shell {key}")
+                result = test_api_key(val, f"shell {key}")
+                if result == "valid":
+                    notes.append(f"shell {key}: Anthropic API accepts this key")
+                elif result == "invalid":
+                    warnings.append(f"shell {key}: Anthropic API rejects this key")
         else:
             print(f"  {key}: (unset)")
 
@@ -167,8 +200,9 @@ def audit_shell_profiles() -> None:
             print(f"  {path}: {len(hits)} non-comment line(s)")
             for hit in hits[:3]:
                 print(f"    {hit[:100]}")
-            issues.append(
-                f"{path} exports ANTHROPIC_API_KEY — remove or comment out for OAuth headless runs"
+            warnings.append(
+                f"{path} exports ANTHROPIC_API_KEY — OK for week_that_was; "
+                "rwe-run/catchup scrub it with env -u"
             )
     if not found:
         print("  (no ANTHROPIC_API_KEY exports found in common profile files)")
@@ -189,11 +223,14 @@ def audit_claude_json() -> None:
         for key in BLOCKER_ENV_KEYS:
             if key in env and str(env.get(key) or "").strip():
                 val = str(env[key])
+                record_key(val, "~/.claude.json")
                 issues.append(
                     f"~/.claude.json env.{key} is set ({mask_key(val)}) — "
-                    "Claude Code injects this into every session (settingsEnv/globalEnv)"
+                    "Claude Code injects this into every session"
                 )
-                test_api_key(val, f"~/.claude.json env.{key}")
+                result = test_api_key(val, f"~/.claude.json env.{key}")
+                if result == "invalid":
+                    issues.append(f"~/.claude.json env.{key}: Anthropic API rejects this key")
     helper = data.get("apiKeyHelper")
     if helper:
         issues.append(f"~/.claude.json apiKeyHelper is set ({helper!r})")
@@ -218,10 +255,32 @@ audit_file(managed, "Managed settings (MDM)")
 
 audit_shell_profiles()
 
+# Detect multiple distinct keys — classic cause of "Invalid API key" after env -u
+print("\n=== Key fingerprint check ===")
+if len(key_sources) > 1:
+    print("MISMATCH: multiple distinct ANTHROPIC_API_KEY values found:")
+    for fp, labels in key_sources.items():
+        print(f"  {fp}: {', '.join(labels)}")
+    print(
+        "\nDiagnosis: rwe scripts scrub the shell key (env -u), but Claude Code still "
+        "injects keys from settings files. If the settings key is dead, you get "
+        "'Invalid API key · Fix external API key' even when your keychain key is valid."
+    )
+elif len(key_sources) == 1:
+    fp, labels = next(iter(key_sources.items()))
+    print(f"Single key fingerprint ({fp}) from: {', '.join(labels)}")
+else:
+    print("No ANTHROPIC_API_KEY values found in audited sources.")
+
 print("\n=== Summary ===")
 if notes:
     for n in notes:
         print(f"NOTE: {n}")
+
+if warnings:
+    print(f"\n{len(warnings)} warning(s) (scrubbed by rwe scripts — not blockers for catch-up):\n")
+    for i, item in enumerate(warnings, 1):
+        print(f"  {i}. {item}")
 
 if issues:
     print(f"\n{len(issues)} blocker(s) found:\n")
@@ -229,16 +288,19 @@ if issues:
         print(f"  {i}. {item}")
     print(
         "\nFix (OAuth headless — rwe-run / rwe-catchup / rwe-weekly-audio):\n"
-        "  1. Remove ANTHROPIC_API_KEY from every settings env block above.\n"
-        "  2. Remove or fix apiKeyHelper entries.\n"
+        "  1. Remove ANTHROPIC_API_KEY from settings env blocks (cannot be scrubbed).\n"
+        "  2. Keep your keychain/.zshrc key for week_that_was — rwe scripts scrub it.\n"
         "  3. Run: claude doctor\n"
         "  4. Re-run: rwe-auth-check.sh --test-api --doctor\n"
         "  5. Retry: bin/rwe-catchup.sh --from YYYY-MM-DD --to YYYY-MM-DD\n"
-        "\nTo remove a key from ~/.claude/settings.json:\n"
+        "\nTo remove the dead key from ~/.claude/settings.json:\n"
+        "  cp ~/.claude/settings.json ~/.claude/settings.json.bak\n"
         "  jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json"
     )
     sys.exit(1)
 
+if warnings:
+    print("\nNo settings-file blockers. Shell/.zshrc warnings above are OK for catch-up.")
 print("\nNo OAuth blockers detected in audited sources.")
 print("If claude -p still fails, run with --doctor and inspect the debug log for [MCP] lines.")
 sys.exit(0)

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -39,6 +39,7 @@ python3 - <<'PY'
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Audit Claude Code auth sources that break headless OAuth runs (rwe-run.sh,
+# rwe-catchup.sh, rwe-weekly-audio). The daily/weekly-audio flows use
+# `claude -p` with a claude.ai subscription — any ANTHROPIC_API_KEY or
+# apiKeyHelper injected from settings files overrides OAuth and causes
+# "Invalid API key · Fix external API key" even when the shell has nothing
+# exported (env -u does not clear settings.json env blocks).
+#
+# Usage:
+#   rwe-auth-check.sh              # print audit, exit 1 if blockers found
+#   rwe-auth-check.sh --test-api   # also curl-test any keys found
+#   rwe-auth-check.sh --doctor     # also run `claude doctor` if available
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${HERE}/rwe-common.sh"
+
+TEST_API=0
+RUN_DOCTOR=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --test-api) TEST_API=1; shift ;;
+    --doctor)   RUN_DOCTOR=1; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+REPO_ROOT="$(rwe_repo_root "${HERE}")" || exit 1
+
+export RWE_AUTH_TEST_API="${TEST_API}"
+export RWE_AUTH_REPO_ROOT="${REPO_ROOT}"
+
+python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+REPO = Path(os.environ["RWE_AUTH_REPO_ROOT"])
+TEST_API = os.environ.get("RWE_AUTH_TEST_API") == "1"
+
+AUTH_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+BLOCKER_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+issues = []
+notes = []
+
+
+def mask_key(value: str) -> str:
+    value = (value or "").strip()
+    if not value:
+        return "(empty)"
+    if len(value) <= 8:
+        return value[:2] + "…"
+    return value[:4] + "…" + value[-4:]
+
+
+def load_json(path: Path):
+    if not path.is_file():
+        return None, "not found"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc}"
+
+
+def test_api_key(key: str, label: str) -> None:
+    if not TEST_API or not key.strip():
+        return
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-sS",
+                "https://api.anthropic.com/v1/models",
+                "-H", f"x-api-key: {key.strip()}",
+                "-H", "anthropic-version: 2023-06-01",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        body = (proc.stdout or proc.stderr or "").strip()
+        if "authentication_error" in body or "invalid x-api-key" in body:
+            issues.append(f"{label}: Anthropic API rejects this key (authentication_error)")
+        elif proc.returncode == 0 and '"data"' in body:
+            notes.append(f"{label}: Anthropic API accepts this key")
+        else:
+            notes.append(f"{label}: API test inconclusive ({body[:120]})")
+    except Exception as exc:  # noqa: BLE001
+        notes.append(f"{label}: API test failed ({exc})")
+
+
+def audit_env_block(data: dict, label: str) -> None:
+    env = data.get("env")
+    if not isinstance(env, dict) or not env:
+        return
+    keys = sorted(env.keys())
+    print(f"  env keys: {', '.join(keys)}")
+    for key in BLOCKER_ENV_KEYS:
+        if key in env and str(env.get(key) or "").strip():
+            val = str(env[key])
+            issues.append(
+                f"{label}: {key} is set in settings env block ({mask_key(val)}) — "
+                "overrides OAuth in claude -p and causes auth failures when invalid"
+            )
+            test_api_key(val, f"{label} env.{key}")
+
+
+def audit_file(path: Path, label: str) -> None:
+    print(f"\n{label}")
+    print(f"  path: {path}")
+    data, err = load_json(path)
+    if err:
+        print(f"  status: {err}")
+        if err != "not found":
+            issues.append(f"{label}: {err}")
+        return
+    print("  status: present")
+    audit_env_block(data, label)
+    helper = data.get("apiKeyHelper")
+    if helper:
+        issues.append(
+            f"{label}: apiKeyHelper is set ({helper!r}) — conflicts with OAuth; "
+            "remove unless you intend API-key auth"
+        )
+        print(f"  apiKeyHelper: {helper}")
+
+
+def audit_shell_env() -> None:
+    print("\nShell environment (this process)")
+    for key in AUTH_ENV_KEYS:
+        val = os.environ.get(key, "")
+        if val:
+            print(f"  {key}: {mask_key(val)}")
+            if key in BLOCKER_ENV_KEYS:
+                issues.append(
+                    f"Shell exports {key} ({mask_key(val)}) — scrub with env -u before claude -p"
+                )
+                test_api_key(val, f"shell {key}")
+        else:
+            print(f"  {key}: (unset)")
+
+
+def audit_shell_profiles() -> None:
+    print("\nShell startup files (grep ANTHROPIC_API_KEY)")
+    pattern = re.compile(r"ANTHROPIC_API_KEY")
+    found = False
+    for rel in (".zshrc", ".zprofile", ".bash_profile", ".bashrc", ".profile"):
+        path = HOME / rel
+        if not path.is_file():
+            continue
+        hits = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+            if pattern.search(line) and not line.strip().startswith("#")
+        ]
+        if hits:
+            found = True
+            print(f"  {path}: {len(hits)} non-comment line(s)")
+            for hit in hits[:3]:
+                print(f"    {hit[:100]}")
+            issues.append(
+                f"{path} exports ANTHROPIC_API_KEY — remove or comment out for OAuth headless runs"
+            )
+    if not found:
+        print("  (no ANTHROPIC_API_KEY exports found in common profile files)")
+
+
+def audit_claude_json() -> None:
+    path = HOME / ".claude.json"
+    print("\n~/.claude.json (global config — distinct from ~/.claude/settings.json)")
+    print(f"  path: {path}")
+    data, err = load_json(path)
+    if err:
+        print(f"  status: {err}")
+        return
+    print("  status: present")
+    env = data.get("env")
+    if isinstance(env, dict) and env:
+        print(f"  env keys: {', '.join(sorted(env.keys()))}")
+        for key in BLOCKER_ENV_KEYS:
+            if key in env and str(env.get(key) or "").strip():
+                val = str(env[key])
+                issues.append(
+                    f"~/.claude.json env.{key} is set ({mask_key(val)}) — "
+                    "Claude Code injects this into every session (settingsEnv/globalEnv)"
+                )
+                test_api_key(val, f"~/.claude.json env.{key}")
+    helper = data.get("apiKeyHelper")
+    if helper:
+        issues.append(f"~/.claude.json apiKeyHelper is set ({helper!r})")
+        print(f"  apiKeyHelper: {helper}")
+
+
+# --- main audit ---
+print("=== Claude Code auth audit for Reading with Ears headless runs ===")
+print("Daily/weekly-audio flows expect claude.ai OAuth — not ANTHROPIC_API_KEY.")
+print("The error 'Invalid API key · Fix external API key' is Claude Code auth,")
+print("not Gmail or NotebookLM MCP (those show [MCP] errors in debug logs).")
+
+audit_shell_env()
+audit_claude_json()
+audit_file(HOME / ".claude" / "settings.json", "Global settings (~/.claude/settings.json)")
+audit_file(HOME / ".claude" / "settings.local.json", "Global local settings (~/.claude/settings.local.json)")
+audit_file(REPO / ".claude" / "settings.json", "Project settings (.claude/settings.json)")
+audit_file(REPO / ".claude" / "settings.local.json", "Project local settings (.claude/settings.local.json)")
+
+managed = Path("/Library/Application Support/ClaudeCode/managed-settings.json")
+audit_file(managed, "Managed settings (MDM)")
+
+audit_shell_profiles()
+
+print("\n=== Summary ===")
+if notes:
+    for n in notes:
+        print(f"NOTE: {n}")
+
+if issues:
+    print(f"\n{len(issues)} blocker(s) found:\n")
+    for i, item in enumerate(issues, 1):
+        print(f"  {i}. {item}")
+    print(
+        "\nFix (OAuth headless — rwe-run / rwe-catchup / rwe-weekly-audio):\n"
+        "  1. Remove ANTHROPIC_API_KEY from every settings env block above.\n"
+        "  2. Remove or fix apiKeyHelper entries.\n"
+        "  3. Run: claude doctor\n"
+        "  4. Re-run: rwe-auth-check.sh --test-api --doctor\n"
+        "  5. Retry: bin/rwe-catchup.sh --from YYYY-MM-DD --to YYYY-MM-DD\n"
+        "\nTo remove a key from ~/.claude/settings.json:\n"
+        "  jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json"
+    )
+    sys.exit(1)
+
+print("\nNo OAuth blockers detected in audited sources.")
+print("If claude -p still fails, run with --doctor and inspect the debug log for [MCP] lines.")
+sys.exit(0)
+PY
+
+status=$?
+
+if [[ "${RUN_DOCTOR}" -eq 1 ]] && command -v claude >/dev/null 2>&1; then
+  echo ""
+  echo "=== claude doctor ==="
+  claude doctor || true
+elif [[ "${RUN_DOCTOR}" -eq 1 ]]; then
+  echo "NOTE: claude CLI not on PATH — skipping claude doctor"
+fi
+
+exit "${status}"

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -46,6 +46,16 @@ echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") rwe-catchup from=${FROM_DATE} to=${TO_D
 
 "${RWE_ROOT}/scripts/install-local.sh"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
+if ! rwe_check_claude_oauth; then
+  exit 1
+fi
+
 STATE_DIR="${HOME}/.local/state/reading-with-ears"
 mkdir -p "${STATE_DIR}"
 
@@ -71,14 +81,6 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
     CLAUDE_PROMPT="Read and follow skills/user/reading-list-builder/SKILL.md and run the DAILY FLOW (Steps 0-8) for ${current}. In all Gmail searches use 'after:${gmail_after} before:${gmail_before}' to scope results to exactly this day. Do not run the weekly audio flow."
 
     cd "${RWE_ROOT}"
-
-    if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
-      echo "[${current}] Aborting — fix Claude auth blockers above, then re-run."
-      echo "[${current}] Run: bin/rwe-auth-check.sh --test-api --doctor"
-      failed=$((failed + 1))
-      current=$(date -j -v+1d -f "%Y-%m-%d" "${current}" +"%Y-%m-%d")
-      continue
-    fi
 
     # Full claude debug capture (unfiltered — a category filter like "mcp" broke
     # stdin prompt piping in testing) per day, so a failure (Gmail vs. NotebookLM

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -72,6 +72,14 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
 
     cd "${RWE_ROOT}"
 
+    if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+      echo "[${current}] Aborting — fix Claude auth blockers above, then re-run."
+      echo "[${current}] Run: bin/rwe-auth-check.sh --test-api --doctor"
+      failed=$((failed + 1))
+      current=$(date -j -v+1d -f "%Y-%m-%d" "${current}" +"%Y-%m-%d")
+      continue
+    fi
+
     # Full claude debug capture (unfiltered — a category filter like "mcp" broke
     # stdin prompt piping in testing) per day, so a failure (Gmail vs. NotebookLM
     # vs. something else in the MCP handshake) doesn't require manually reproducing
@@ -101,11 +109,7 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
     else
       echo "[${current}] Pipeline failed — sentinel not written, will retry on next catch-up run."
       echo "[${current}] MCP debug log: ${DEBUG_FILE}"
-      if [[ -f "${DEBUG_FILE}" ]]; then
-        echo "[${current}] --- last 40 lines of MCP debug log ---"
-        tail -40 "${DEBUG_FILE}"
-        echo "[${current}] --- end debug log excerpt ---"
-      fi
+      rwe_tail_debug_log "${DEBUG_FILE}" "[${current}] MCP debug log"
       failed=$((failed + 1))
     fi
   fi

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -40,3 +40,31 @@ print(os.path.expanduser(str(r).strip()), end='')
   echo "reading-with-ears: set RWE_REPO or repo_root in ~/.config/reading-with-ears/config.json (see docs/install.md)." >&2
   return 1
 }
+
+# Preflight for headless OAuth runs. Fails fast when settings files still inject
+# ANTHROPIC_API_KEY (env -u in the caller does not clear settings.json env blocks).
+rwe_audit_claude_auth() {
+  local repo_root="${1:?repo root}"
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+  if [[ -x "${here}/rwe-auth-check.sh" ]]; then
+    RWE_REPO="${repo_root}" "${here}/rwe-auth-check.sh"
+    return $?
+  fi
+  echo "WARN: rwe-auth-check.sh not found — skipping Claude auth preflight" >&2
+  return 0
+}
+
+rwe_tail_debug_log() {
+  local debug_file="${1:?debug log path}"
+  local label="${2:-debug log}"
+  if [[ -f "${debug_file}" ]]; then
+    local lines
+    lines="$(wc -l < "${debug_file}" | tr -d ' ')"
+    echo "--- ${label} (${lines} lines, last 40) ---"
+    tail -40 "${debug_file}"
+    echo "--- end ${label} ---"
+  else
+    echo "WARN: ${label} not found at ${debug_file}"
+  fi
+}

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -1,6 +1,8 @@
 # Shared helpers for Reading with Ears bin scripts.
 # shellcheck shell=bash
 
+# Absolute path to bin/ — set at source time so helpers work after callers cd elsewhere.
+_RWE_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Resolve repo root (directory that contains reading-with-ears/).
 # Precedence: RWE_REPO → ~/.config/reading-with-ears/config.json repo_root
 # → caller lives in-repo at bin/ (parent is repo root).
@@ -45,13 +47,34 @@ print(os.path.expanduser(str(r).strip()), end='')
 # ANTHROPIC_API_KEY (env -u in the caller does not clear settings.json env blocks).
 rwe_audit_claude_auth() {
   local repo_root="${1:?repo root}"
-  local here
-  here="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
-  if [[ -x "${here}/rwe-auth-check.sh" ]]; then
-    RWE_REPO="${repo_root}" "${here}/rwe-auth-check.sh"
+  if [[ -x "${_RWE_BIN_DIR}/rwe-auth-check.sh" ]]; then
+    RWE_REPO="${repo_root}" "${_RWE_BIN_DIR}/rwe-auth-check.sh"
     return $?
   fi
-  echo "WARN: rwe-auth-check.sh not found — skipping Claude auth preflight" >&2
+  echo "WARN: rwe-auth-check.sh not found at ${_RWE_BIN_DIR} — skipping Claude auth preflight" >&2
+  return 0
+}
+
+# Headless flows scrub ANTHROPIC_API_KEY — they need an active claude.ai OAuth session.
+rwe_check_claude_oauth() {
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "WARN: claude CLI not on PATH — cannot verify OAuth login" >&2
+    return 0
+  fi
+  local status_out
+  status_out="$(env -u ANTHROPIC_API_KEY claude /status 2>&1 || true)"
+  if echo "${status_out}" | grep -qiE 'not logged in|please run /login'; then
+    echo "ERROR: Claude Code is not logged in."
+    echo "  rwe-catchup / rwe-run scrub ANTHROPIC_API_KEY and use your claude.ai subscription."
+    echo "  Fix: run interactively once, then retry catch-up:"
+    echo "    claude /login"
+    return 1
+  fi
+  if echo "${status_out}" | grep -qiE 'auth token|logged in|claude\.ai|subscription'; then
+    return 0
+  fi
+  echo "WARN: Could not confirm Claude OAuth login from 'claude /status'."
+  echo "  If catch-up fails with 'Not logged in · Please run /login', run: claude /login"
   return 0
 }
 

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -56,6 +56,12 @@ fi
 
 cd "${RWE_ROOT}"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
 CLAUDE_PROMPT=$'Read and follow skills/user/reading-list-builder/SKILL.md and run the DAILY FLOW (Steps 0-8) for today\'s date (use America/Los_Angeles for "today"). Do not run the weekly audio flow.'
 
 # Full claude debug capture (unfiltered — a category filter like "mcp" broke
@@ -82,11 +88,7 @@ if ! echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
   --debug \
   --debug-file "${DEBUG_FILE}"; then
   echo "ERROR: daily flow failed. MCP debug log: ${DEBUG_FILE}"
-  if [[ -f "${DEBUG_FILE}" ]]; then
-    echo "--- last 40 lines of MCP debug log ---"
-    tail -40 "${DEBUG_FILE}"
-    echo "--- end debug log excerpt ---"
-  fi
+  rwe_tail_debug_log "${DEBUG_FILE}" "MCP debug log"
   exit 1
 fi
 

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -45,6 +45,16 @@ echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") rwe-run ==="
 
 "${RWE_ROOT}/scripts/install-local.sh"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
+if ! rwe_check_claude_oauth; then
+  exit 1
+fi
+
 STATE_DIR="${HOME}/.local/state/reading-with-ears"
 mkdir -p "${STATE_DIR}"
 SENTINEL="${STATE_DIR}/done-$(date +%F)"
@@ -55,12 +65,6 @@ if [[ -f "${SENTINEL}" ]]; then
 fi
 
 cd "${RWE_ROOT}"
-
-if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
-  echo "Aborting — fix Claude auth blockers above, then re-run."
-  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
-  exit 1
-fi
 
 CLAUDE_PROMPT=$'Read and follow skills/user/reading-list-builder/SKILL.md and run the DAILY FLOW (Steps 0-8) for today\'s date (use America/Los_Angeles for "today"). Do not run the weekly audio flow.'
 

--- a/bin/rwe-weekly-audio
+++ b/bin/rwe-weekly-audio
@@ -53,6 +53,10 @@ if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
   exit 1
 fi
 
+if ! rwe_check_claude_oauth; then
+  exit 1
+fi
+
 CLAUDE_PROMPT="Read and follow skills/user/reading-list-builder/SKILL.md and run the WEEKLY AUDIO FLOW (Steps W1-W4) for ISO week ${WEEK_ARG}. Do not run the daily flow."
 
 # Full claude debug capture (unfiltered — a category filter like "mcp" broke

--- a/bin/rwe-weekly-audio
+++ b/bin/rwe-weekly-audio
@@ -47,6 +47,12 @@ echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") rwe-weekly-audio week=${WEEK_ARG} ==="
 
 cd "${RWE_ROOT}"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
 CLAUDE_PROMPT="Read and follow skills/user/reading-list-builder/SKILL.md and run the WEEKLY AUDIO FLOW (Steps W1-W4) for ISO week ${WEEK_ARG}. Do not run the daily flow."
 
 # Full claude debug capture (unfiltered — a category filter like "mcp" broke
@@ -72,11 +78,7 @@ if ! echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
   --debug \
   --debug-file "${DEBUG_FILE}"; then
   echo "ERROR: weekly audio flow failed. MCP debug log: ${DEBUG_FILE}"
-  if [[ -f "${DEBUG_FILE}" ]]; then
-    echo "--- last 40 lines of MCP debug log ---"
-    tail -40 "${DEBUG_FILE}"
-    echo "--- end debug log excerpt ---"
-  fi
+  rwe_tail_debug_log "${DEBUG_FILE}" "MCP debug log"
   exit 1
 fi
 

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -77,6 +77,22 @@ Authenticate the `nlm` CLI:
 nlm login
 ```
 
+### Claude Code auth for headless runs (`rwe-run`, `rwe-catchup`, `rwe-weekly-audio`)
+
+These scripts invoke `claude -p` with your **claude.ai subscription (OAuth)**. They scrub
+`ANTHROPIC_API_KEY` from the shell, but Claude Code also reads keys from settings files —
+`~/.claude/settings.json` (global) and `~/.claude.json` (config) are **different files**.
+
+If catch-up fails immediately with `Invalid API key · Fix external API key`, run:
+
+```bash
+bin/rwe-auth-check.sh --test-api --doctor
+```
+
+Remove any `ANTHROPIC_API_KEY` from settings `env` blocks and any `apiKeyHelper` entries.
+That error is Claude Code auth, not Gmail or NotebookLM MCP (MCP failures appear as `[MCP]`
+lines in `~/logs/reading-with-ears/catchup-debug-*.log`).
+
 ---
 
 ## 4. Install shell wrappers

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -93,6 +93,10 @@ Remove any `ANTHROPIC_API_KEY` from settings `env` blocks and any `apiKeyHelper`
 That error is Claude Code auth, not Gmail or NotebookLM MCP (MCP failures appear as `[MCP]`
 lines in `~/logs/reading-with-ears/catchup-debug-*.log`).
 
+Headless runs also require an active **claude.ai OAuth session** (`claude /login`). The
+scripts scrub your shell API key with `env -u`; without OAuth you will see
+`Not logged in · Please run /login`.
+
 ---
 
 ## 4. Install shell wrappers

--- a/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
+++ b/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
@@ -149,6 +149,15 @@ fi
 if feature_enabled claude; then
 if have claude; then
   ok "claude CLI ($(claude --version 2>/dev/null | head -1 || echo present))"
+  auth_check="${REPO_ROOT}/bin/rwe-auth-check.sh"
+  if [[ -x "${auth_check}" ]]; then
+    if bash "${auth_check}" >/dev/null 2>&1; then
+      ok "Claude OAuth preflight (rwe-auth-check.sh) — no blockers"
+    else
+      bad "Claude auth blockers detected — run: bin/rwe-auth-check.sh --test-api --doctor"
+      note "Headless rwe-run / rwe-catchup need claude.ai OAuth, not ANTHROPIC_API_KEY in settings files."
+    fi
+  fi
 else
   bad "claude CLI not found (required for rwe-run.sh)"
   if [[ "${APPLY}" -eq 1 ]] && have npm; then
@@ -218,7 +227,7 @@ fi
 if feature_enabled permissions; then
 bin_dir="${REPO_ROOT}/bin"
 if [[ -d "${bin_dir}" ]]; then
-  for x in rwe-common.sh rwe-run.sh rwe-publish rwe-catchup.sh; do
+  for x in rwe-common.sh rwe-run.sh rwe-publish rwe-catchup.sh rwe-auth-check.sh; do
     [[ -f "${bin_dir}/${x}" ]] || continue
     if [[ ! -x "${bin_dir}/${x}" ]]; then
       warn "${bin_dir}/${x} is not executable — fixing chmod +x"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues auth debugging for the `rwe-catchup.sh` blocker (`Invalid API key · Fix external API key`).

**Root cause (narrowed):** The prior session removed `ANTHROPIC_API_KEY` from `~/.claude.json`, but the debug log showed `settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY` — that comes from **`~/.claude/settings.json`**, a different file. `env -u ANTHROPIC_API_KEY` in the shell scripts does not clear settings-file injection. This error is Claude Code OAuth vs. API-key conflict, not Gmail/NotebookLM MCP.

## Changes

- **`bin/rwe-auth-check.sh`** — audits shell env, `~/.claude.json`, `~/.claude/settings.json`, project settings, MDM, and shell profiles; optional `--test-api` (curl) and `--doctor`
- **`rwe-run.sh` / `rwe-catchup.sh` / `rwe-weekly-audio`** — fail fast with auth preflight before `claude -p`; improved debug log tail (includes line count)
- **`verify-reading-with-ears-setup.sh`** — runs auth preflight when `claude` is on PATH
- **`docs/install.md`** — troubleshooting section for this error
- **`.scratch/session-context-2026-07-02-auth-debug.md`** — updated handoff with laptop runbook

## Test on laptop

```bash
git fetch && git checkout cursor/rwe-auth-diagnostics-001e
bin/rwe-auth-check.sh --test-api --doctor
# If blockers in ~/.claude/settings.json:
jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0289afc9-c134-42de-ac4b-2f98c446001e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0289afc9-c134-42de-ac4b-2f98c446001e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

