### PR TITLE
Add rwe-connectivity-check.sh for headless Gmail/MCP diagnostics

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,5 @@
 {
   "mcpServers": {
-    "gmail": {
-      "url": "https://gmail.mcp.claude.com/mcp"
-    },
     "notebooklm": {
       "command": "uvx",
       "args": ["--from", "notebooklm-mcp-cli", "notebooklm-mcp"]

--- a/.scratch/session-context-2026-07-02-auth-debug.md
+++ b/.scratch/session-context-2026-07-02-auth-debug.md
@@ -1,25 +1,21 @@
 ## Context handoff — auth debugging (updated 2026-07-03)
 
-**Status:** Root cause narrowed; diagnostic tooling added on branch `cursor/rwe-auth-diagnostics-001e`.
+**Status:** Root cause confirmed on laptop (2026-07-03).
 
-### Most likely remaining blocker (never inspected on laptop)
+### Confirmed root cause
 
-The debug log from the prior session showed:
+Two **different** `ANTHROPIC_API_KEY` values:
 
-```
-settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY
-```
+| Source | Fingerprint | API test |
+|--------|-------------|----------|
+| Shell / keychain (`.zshrc`) | `sk-a…nQAA` | **valid** |
+| `~/.claude/settings.json` env | `sk-a…HgAA` | **rejected** |
 
-`settingsEnv` comes from **`~/.claude/settings.json`**, not `~/.claude.json` (which was
-already cleaned). The user removed the dead key from `~/.claude.json` only — if
-`~/.claude/settings.json` still has `env.ANTHROPIC_API_KEY`, `claude -p` will keep
-injecting it regardless of `env -u ANTHROPIC_API_KEY` in the shell scripts.
+`rwe-catchup.sh` scrubs the shell key with `env -u`, but Claude Code still injects the
+**dead** key from `~/.claude/settings.json`. That produces `Invalid API key · Fix external
+API key`. Shell/.zshrc warnings are benign — keep keychain for `week_that_was.py`.
 
-The exact error `Invalid API key · Fix external API key` is **Claude Code OAuth vs.
-API-key conflict** (GitHub anthropics/claude-code#11587), not NotebookLM or Gmail MCP.
-MCP auth failures show `[MCP]` / `AxiosError` / `401` lines in the debug log instead.
-
-### Run on laptop (in order)
+### Fix (run on laptop)
 
 ```bash
 # 1. New audit (replaces the four manual cat commands)

--- a/.scratch/session-context-2026-07-02-auth-debug.md
+++ b/.scratch/session-context-2026-07-02-auth-debug.md
@@ -1,138 +1,67 @@
-## Context handoff from previous session
+## Context handoff — auth debugging (updated 2026-07-03)
 
-**What we were working on:**
-Testing the `reading-list-builder` skill's v3.0 migration (weekly notebook
-accumulation + separate weekly audio flow, replacing the old daily-audio
-scheme — see `docs/weekly-cadence-migration.md`) by running a catch-up
-backfill for the week of 2026-06-22 on the user's laptop:
-`bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22`. This is the first
-live exercise of the new weekly-notebook/reconciliation logic in
-`reading-list-builder` v3.0 — nothing in that logic has been verified
-against real Gmail/NotebookLM MCP yet.
+**Status:** Root cause narrowed; diagnostic tooling added on branch `cursor/rwe-auth-diagnostics-001e`.
 
-**Branch:** `claude/reading-list-pipeline-ahpsE` on `dhk/adventures-in-ai`
-(this is the branch for PR #25, not yet merged). Latest relevant commits:
-- `616527a` — scrub `ANTHROPIC_API_KEY` via `env -u` before every `claude -p`
-  invocation in `bin/rwe-run.sh`, `bin/rwe-catchup.sh`, `bin/rwe-weekly-audio`
-- `29adca1` — capture `claude`'s full `--debug`/`--debug-file` output on
-  failure in all three scripts, tail the last 40 lines to console on failure
-- `53730dd` — print the first 20 chars of `$ANTHROPIC_API_KEY` (shell-level)
-  right before scrubbing it, as a diagnostic
+### Most likely remaining blocker (never inspected on laptop)
 
-**What's already done — ruled in/out, in order discovered:**
+The debug log from the prior session showed:
 
-1. Every catch-up attempt fails identically with the exact same one-line
-   banner: `Invalid API key · Fix external API key`, then
-   `[2026-06-22] Pipeline failed — sentinel not written`.
-2. Confirmed the daily flow's actual work never happens: no
-   `dhkondata/reading-db/runs/2026-06-22.yaml` gets written. This is a real
-   failure, not a spurious/benign exit code on top of successful work.
-3. First hypothesis (WRONG on its own, but real and now fixed): a claude.ai
-   token + `ANTHROPIC_API_KEY` auth conflict. User ran `claude /logout` —
-   identical error persisted even before re-login, ruling this out as the
-   *sole* cause.
-4. Manually confirmed via `echo "ANTHROPIC_API_KEY is: ${ANTHROPIC_API_KEY:-<unset>}"`
-   that the *shell* genuinely has nothing exported — yet Claude Code's
-   startup banner still showed "API Usage Billing" mode and the auth-conflict
-   warning. This proved the key wasn't coming from the shell environment at
-   all.
-5. Full `--debug`/`--debug-file` capture (added this session, commit
-   `29adca1`) revealed the real signal:
-   ```
-   CA certs: Config fallback - globalEnv keys: , settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY
-   ```
-   — confirming `ANTHROPIC_API_KEY` was being force-injected from a
-   **settings file**, not the process environment, which is why `/logout`
-   and shell `unset` never touched it.
-6. Found the source: `~/.claude.json`'s top-level `"env"` block had
-   `ANTHROPIC_API_KEY` and `VERCEL_TOKEN` both set globally (applies to
-   *every* Claude Code session on the machine, not just this repo).
-   `/Library/Application Support/ClaudeCode/managed-settings.json` does
-   **not exist** on this machine (ruled out — it's not an MDM/managed
-   setting).
-7. Directly tested the exact key value against Anthropic's API:
-   ```bash
-   curl -s https://api.anthropic.com/v1/models \
-     -H "x-api-key: $(jq -r '.env.ANTHROPIC_API_KEY' ~/.claude.json)" \
-     -H "anthropic-version: 2023-06-01"
-   ```
-   → `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`.
-   **Confirmed fact:** this specific key is dead/rejected by Anthropic's API.
-   (Earlier claim that the key was "malformed" was walked back — we don't
-   actually know *why* it's invalid, just that it is. A separate JSON-parse
-   error seen nearby in the debug log — `Unexpected token '/', "/Users/dhk"...
-   is not valid JSON` at `Object.assign.cache` — was never confirmed to be
-   related; may be a red herring from an unrelated cache file.)
-8. User removed it: backed up (`~/.claude.json.bak`), then
-   ```bash
-   jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude.json > /tmp/claude.json.new && mv /tmp/claude.json.new ~/.claude.json
-   ```
-   Unexpectedly, `jq '.env' ~/.claude.json` now returns `null` entirely —
-   `VERCEL_TOKEN` is gone too, not just the one key (still recoverable from
-   the `.bak` file if needed for something unrelated).
+```
+settingsEnv keys: VERCEL_TOKEN,ANTHROPIC_API_KEY
+```
 
-**The specific blocker that caused this handoff:**
-**Despite removing `ANTHROPIC_API_KEY` from `~/.claude.json` and confirming
-the shell itself has nothing exported (the new diagnostic print showed a
-blank value), the exact same `Invalid API key · Fix external API key`
-failure still occurs on re-run.** This means the dead key we found and
-removed was NOT the sole or even necessarily the correct source — there
-must be another place Claude Code is picking up a bad credential from, or
-this error was never actually about `ANTHROPIC_API_KEY` at all (it could be
-a completely different "external API key" — e.g. the `notebooklm` MCP
-server's own separate credential, unrelated to Anthropic auth).
+`settingsEnv` comes from **`~/.claude/settings.json`**, not `~/.claude.json` (which was
+already cleaned). The user removed the dead key from `~/.claude.json` only — if
+`~/.claude/settings.json` still has `env.ANTHROPIC_API_KEY`, `claude -p` will keep
+injecting it regardless of `env -u ANTHROPIC_API_KEY` in the shell scripts.
 
-On the most recent run, the debug log tail (`tail -40`) printed **nothing**
-— either the debug file is empty, wasn't created, or the failure now
-happens even earlier than before. This is unconfirmed — the following
-commands were requested but their output was never received before this
-handoff:
+The exact error `Invalid API key · Fix external API key` is **Claude Code OAuth vs.
+API-key conflict** (GitHub anthropics/claude-code#11587), not NotebookLM or Gmail MCP.
+MCP auth failures show `[MCP]` / `AxiosError` / `401` lines in the debug log instead.
+
+### Run on laptop (in order)
+
+```bash
+# 1. New audit (replaces the four manual cat commands)
+bin/rwe-auth-check.sh --test-api --doctor
+
+# 2. If blockers found in ~/.claude/settings.json:
+jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json \
+  && mv /tmp/s.json ~/.claude/settings.json
+
+# 3. Re-check, then single-day catch-up
+bin/rwe-auth-check.sh --test-api
+bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22
+
+# 4. Confirm sentinel + run YAML written
+ls -la ~/.local/state/reading-with-ears/done-2026-06-22
+ls -la ~/dhkondata/reading-db/runs/2026-06-22.yaml   # or path from config
+```
+
+If auth check passes but catch-up still fails, inspect the full debug log (not just tail):
 
 ```bash
 wc -l ~/logs/reading-with-ears/catchup-debug-2026-06-22.log
-cat ~/logs/reading-with-ears/catchup-debug-2026-06-22.log
-cat ~/.claude/settings.json 2>/dev/null       # NOTE: different file from ~/.claude.json, never actually checked
-cat .claude/settings.json 2>/dev/null
-cat .claude/settings.local.json 2>/dev/null
+cat ~/logs/reading-with-ears/catchup-debug-2026-06-22.log | rg -i 'mcp|axios|401|invalid'
 ```
 
-**What to do next — in order:**
+### MCP isolation test (only if auth check is clean)
 
-1. Get the output of the four commands above. In particular, `~/.claude/settings.json`
-   (global Claude Code settings — distinct from `~/.claude.json`, the config file
-   already fixed) was flagged as a candidate early on and never actually inspected.
-2. If the debug log is genuinely empty, re-run with the instrumented script
-   (`bin/rwe-catchup.sh --from 2026-06-22 --to 2026-06-22` on branch
-   `claude/reading-list-pipeline-ahpsE`, already pulled) and get the fresh debug
-   file content — look specifically for `[MCP]`-tagged lines and any `AxiosError`/
-   `401`/`invalid x-api-key` occurrences, and note what immediately precedes them
-   (which server, Gmail vs. `notebooklm`, was active at that point).
-3. Consider directly testing the `notebooklm` MCP server in isolation, since it's
-   never been ruled in or out as the actual source of "invalid API key" (all
-   investigation so far has focused on Anthropic account auth, not the
-   third-party `notebooklm-mcp-cli` tool's own credential):
-   ```bash
-   cd reading-with-ears
-   claude --mcp-config automation/mcp-headless.json --strict-mcp-config
-   # ask: "list my notebooklm notebooks" and separately "search gmail for label:newsletter/news after:2026/06/22"
-   ```
-   Whichever one fails in isolation is the real answer.
-4. Once the actual root cause is found and fixed, re-run the single-day test
-   (`--from 2026-06-22 --to 2026-06-22`), confirm
-   `dhkondata/reading-db/runs/2026-06-22.yaml` gets written with real content,
-   *then* proceed to the remaining 9 days of catch-up
-   (`--from 2026-06-23 --to 2026-07-01`), watching closely for the STEP 3
-   reconciliation logic (untested live) if any pre-migration daily notebooks
-   exist for this week.
-5. Only after the daily flow is confirmed working: test the weekly audio flow
-   (`bin/rwe-weekly-audio`), which depends on the `--notebook-week` flag added
-   to `publish_episodes.py` this session (also unverified live).
+```bash
+cd reading-with-ears
+claude --mcp-config automation/mcp-headless.json --strict-mcp-config
+# "list my notebooklm notebooks"  — tests notebooklm
+# "search gmail for label:newsletter/news after:2026/06/22"  — tests gmail
+```
 
-**Other context, likely not relevant to this specific blocker but useful if asked:**
-- Two other PRs opened this session, unrelated to this auth issue: PR #26
-  (`handoff` skill, rebuilt cleanly on `main`) and PR #27 (three design-doc
-  clarifications for `week-that-was-design.md`, recovered from an uncommitted
-  local review). Both already merged-ready, no action needed.
-- Filed issue #28 for a separate, minor install friction (`rwe-catchup.sh:
-  command not found` when `~/bin` isn't on `PATH`) — unrelated to this auth
-  investigation.
+### After daily flow works
+
+1. Remaining catch-up: `--from 2026-06-23 --to 2026-07-01` (watch STEP 3 reconciliation)
+2. Weekly audio: `bin/rwe-weekly-audio` (unverified live)
+
+### What changed in repo (this session)
+
+- `bin/rwe-auth-check.sh` — audits all credential sources + optional API test + `claude doctor`
+- `rwe-run.sh`, `rwe-catchup.sh`, `rwe-weekly-audio` — preflight auth check before `claude -p`
+- `verify-reading-with-ears-setup.sh` — includes auth preflight when `claude` is on PATH
+- `docs/install.md` — troubleshooting section for this error

--- a/.scratch/session-context-2026-07-10-catchup-debug.md
+++ b/.scratch/session-context-2026-07-10-catchup-debug.md
@@ -1,0 +1,126 @@
+## Context handoff — reading-list-builder v3.0 catch-up (2026-07-10)
+
+**Goal:** Backfill daily flow for week of 2026-06-22 via
+`bin/rwe-catchup.sh --from 2026-06-22 --to 2026-07-01` on branch
+`claude/reading-list-pipeline-ahpsE` (PR #25). First live test of weekly-notebook
+accumulation + STEP 3 reconciliation (unverified live).
+
+**User machine:** macOS, repo at `~/Documents/dev/adventures-in-ai`,
+`claude --version` → **2.1.200** in interactive shell (but scripts were picking up
+**2.1.87** from `/opt/homebrew/bin/claude` until PATH fix).
+
+---
+
+### Issues resolved (in order discovered)
+
+| # | Symptom | Root cause | Fix |
+|---|---------|------------|-----|
+| 1 | `Invalid API key · Fix external API key` | Dead `ANTHROPIC_API_KEY` in `~/.claude/settings.json` (different from valid keychain key in `.zshrc`) | `jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json` |
+| 2 | `Not logged in · Please run /login` | OAuth session cleared during debugging; `env -u` scrubs shell API key | `claude /login` |
+| 3 | `gmail.mcp.claude.com` Failed in `claude mcp list` | Deprecated endpoint (404) | Use `gmailmcp.googleapis.com`; remove legacy `claude mcp remove gmail` |
+| 4 | `--strict-mcp-config` blocked claude.ai Gmail | Only loaded dead HTTP URL from config | Removed strict mode; `mcp-headless.json` = notebooklm + gmail HTTP |
+| 5 | Connectivity check shows 2.1.87, shell shows 2.1.200 | Scripts prepended `/opt/homebrew/bin` before user's PATH | `rwe_ensure_path` + `rwe_claude_bin` picks newest version |
+| 6 | Interactive Gmail works (`search_threads`), headless `-p` has no Gmail | claude.ai Connectors load Calendar/Drive/etc. but Gmail missing in `-p`; needs user-scoped HTTP MCP login | `claude mcp login gmail` after `claude mcp add ... gmailmcp.googleapis.com` |
+
+**Interactive Gmail confirmed working** (2026-07-03): `search_threads "dolphin club"` → 201 threads.
+
+**Still failing on 2026-06-24 catch-up** (last report): headless session lists Dropbox,
+Calendar, Drive, Notion, Twilio, NotebookLM — **no Gmail**. Plus stale 2.1.87 warning.
+
+---
+
+### Repo tooling added (branches / PRs)
+
+| PR | Branch | What |
+|----|--------|------|
+| #29 | `cursor/rwe-auth-diagnostics-001e` | `bin/rwe-auth-check.sh`, auth preflight in rwe scripts |
+| #30 | `cursor/rwe-connectivity-check-001e` | `bin/rwe-connectivity-check.sh`, Gmail MCP model fix, PATH pinning, skill tool-name flexibility |
+
+**Key scripts:**
+- `bin/rwe-auth-check.sh` — settings/keychain audit (`--test-api --doctor`)
+- `bin/rwe-connectivity-check.sh` — layered probes (`--live --verbose --date YYYY-MM-DD`)
+- `rwe_claude_bin()` in `rwe-common.sh` — picks highest-version `claude` on PATH
+- Override: `export RWE_CLAUDE_BIN=/path/to/claude`
+
+**Gmail tool names (skill v3.0 updated):**
+- claude.ai connector: `search_threads`, `get_thread` (`mcp__claude_ai_Gmail__*`)
+- Legacy: `gmail_search_messages`, `gmail_read_message`
+
+**mcp-headless.json (current):**
+```json
+{
+  "mcpServers": {
+    "gmail": { "type": "http", "url": "https://gmailmcp.googleapis.com/mcp/v1" },
+    "notebooklm": { "type": "stdio", "command": "uvx", "args": ["--from", "notebooklm-mcp-cli", "notebooklm-mcp"] }
+  }
+}
+```
+
+`ENABLE_CLAUDEAI_MCP_SERVERS=true` set in `rwe_claude_headless()`.
+
+---
+
+### What to run on laptop next (in order)
+
+```bash
+cd ~/Documents/dev/adventures-in-ai
+git fetch
+git checkout cursor/rwe-connectivity-check-001e   # or merge PR #30
+git pull
+
+# 1. Confirm scripts use 2.1.200 (not brew 2.1.87)
+which -a claude
+claude --version
+# Optional: brew uninstall claude-code
+
+# 2. Register + authenticate Gmail for headless -p
+claude mcp remove gmail 2>/dev/null || true
+claude mcp add --transport http --scope user gmail https://gmailmcp.googleapis.com/mcp/v1
+claude mcp login gmail
+
+# 3. Verify
+claude mcp list   # gmail + claude.ai Gmail both Connected
+bin/rwe-connectivity-check.sh --live --verbose --date 2026-06-24
+# Expect: step 9 finds Gmail tools; catchup log shows "Using claude: ... 2.1.200"
+
+# 4. Force re-run one day
+rm -f ~/.local/state/reading-with-ears/done-2026-06-24
+bin/rwe-catchup.sh --from 2026-06-24 --to 2026-06-24
+
+# 5. Confirm success
+ls ~/.local/state/reading-with-ears/done-2026-06-24
+wc -l ~/Documents/dev/adventures-in-ai/dhkondata/reading-db/runs/2026-06-24.yaml
+```
+
+Then remaining days: `--from 2026-06-25 --to 2026-07-01` (skip days with valid sentinels).
+
+---
+
+### How to verify catch-up succeeded
+
+| Check | Path / signal |
+|-------|----------------|
+| Script output | `[YYYY-MM-DD] Done.` and `0 failed` |
+| Sentinel | `~/.local/state/reading-with-ears/done-YYYY-MM-DD` exists |
+| Run YAML | `dhkondata/reading-db/runs/YYYY-MM-DD.yaml` non-empty |
+| Logs | `~/logs/reading-with-ears/catchup-$(date +%F).log` |
+| Debug | `~/logs/reading-with-ears/catchup-debug-YYYY-MM-DD.log` |
+
+**Force re-run:** `rm ~/.local/state/reading-with-ears/done-YYYY-MM-DD` then catch-up that day.
+
+---
+
+### Not yet verified live
+
+- Full catch-up week with STEP 3 reconciliation (mid-week v3.0 cutover)
+- `bin/rwe-weekly-audio` + `--notebook-week` in `publish_episodes.py`
+- `2026-06-22` may have sentinel from partial run — verify YAML content, not just sentinel
+
+---
+
+### Unrelated but noted
+
+- **codex MCP** on laptop triggers macOS malware block — `claude mcp remove codex` if not needed
+- **gmail-send** is send-only, wrong for this pipeline
+- **woven** has no Gmail
+- Issue #28: `rwe-catchup.sh: command not found` when `~/bin` not on PATH

--- a/.scratch/session-context-2026-07-10-catchup-debug.md
+++ b/.scratch/session-context-2026-07-10-catchup-debug.md
@@ -1,5 +1,8 @@
 ## Context handoff — reading-list-builder v3.0 catch-up (2026-07-10)
 
+**Saved:** 2026-07-10 16:29 UTC via `/save-context`
+**Session status:** Paused at headless Gmail blocker; laptop steps below unblock catch-up.
+
 **Goal:** Backfill daily flow for week of 2026-06-22 via
 `bin/rwe-catchup.sh --from 2026-06-22 --to 2026-07-01` on branch
 `claude/reading-list-pipeline-ahpsE` (PR #25). First live test of weekly-notebook

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -51,7 +51,76 @@ AUTH_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH
 BLOCKER_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
 
 issues = []
+warnings = []
 notes = []
+key_sources: dict[str, list[str]] = {}  # fingerprint -> labels
+
+
+def fingerprint(value: str) -> str:
+    value = (value or "").strip()
+    if len(value) < 12:
+        return value
+    return f"{value[:8]}…{value[-4:]}"
+
+
+def record_key(value: str, label: str) -> None:
+    fp = fingerprint(value)
+    if fp:
+        key_sources.setdefault(fp, [])
+        if label not in key_sources[fp]:
+            key_sources[fp].append(label)
+
+
+def test_api_key(key: str, label: str) -> str | None:
+    """Return 'valid', 'invalid', or None if not tested."""
+    if not TEST_API or not key.strip():
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-sS",
+                "https://api.anthropic.com/v1/models",
+                "-H", f"x-api-key: {key.strip()}",
+                "-H", "anthropic-version: 2023-06-01",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        body = (proc.stdout or proc.stderr or "").strip()
+        if "authentication_error" in body or "invalid x-api-key" in body:
+            return "invalid"
+        if proc.returncode == 0 and '"data"' in body:
+            return "valid"
+        notes.append(f"{label}: API test inconclusive ({body[:120]})")
+    except Exception as exc:  # noqa: BLE001
+        notes.append(f"{label}: API test failed ({exc})")
+    return None
+
+
+def audit_env_block(data: dict, label: str, *, critical: bool) -> None:
+    env = data.get("env")
+    if not isinstance(env, dict) or not env:
+        return
+    keys = sorted(env.keys())
+    print(f"  env keys: {', '.join(keys)}")
+    for key in BLOCKER_ENV_KEYS:
+        if key in env and str(env.get(key) or "").strip():
+            val = str(env[key])
+            record_key(val, label)
+            msg = (
+                f"{label}: {key} in settings env block ({mask_key(val)}) — "
+                "Claude Code injects this; env -u in rwe scripts cannot remove it"
+            )
+            if critical:
+                issues.append(msg)
+            else:
+                warnings.append(msg)
+            result = test_api_key(val, f"{label} env.{key}")
+            if result == "valid":
+                notes.append(f"{label} env.{key}: Anthropic API accepts this key")
+            elif result == "invalid":
+                issues.append(f"{label} env.{key}: Anthropic API rejects this key (authentication_error)")
 
 
 def mask_key(value: str) -> str:
@@ -72,49 +141,7 @@ def load_json(path: Path):
         return None, f"invalid JSON: {exc}"
 
 
-def test_api_key(key: str, label: str) -> None:
-    if not TEST_API or not key.strip():
-        return
-    try:
-        proc = subprocess.run(
-            [
-                "curl", "-sS",
-                "https://api.anthropic.com/v1/models",
-                "-H", f"x-api-key: {key.strip()}",
-                "-H", "anthropic-version: 2023-06-01",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=20,
-        )
-        body = (proc.stdout or proc.stderr or "").strip()
-        if "authentication_error" in body or "invalid x-api-key" in body:
-            issues.append(f"{label}: Anthropic API rejects this key (authentication_error)")
-        elif proc.returncode == 0 and '"data"' in body:
-            notes.append(f"{label}: Anthropic API accepts this key")
-        else:
-            notes.append(f"{label}: API test inconclusive ({body[:120]})")
-    except Exception as exc:  # noqa: BLE001
-        notes.append(f"{label}: API test failed ({exc})")
-
-
-def audit_env_block(data: dict, label: str) -> None:
-    env = data.get("env")
-    if not isinstance(env, dict) or not env:
-        return
-    keys = sorted(env.keys())
-    print(f"  env keys: {', '.join(keys)}")
-    for key in BLOCKER_ENV_KEYS:
-        if key in env and str(env.get(key) or "").strip():
-            val = str(env[key])
-            issues.append(
-                f"{label}: {key} is set in settings env block ({mask_key(val)}) — "
-                "overrides OAuth in claude -p and causes auth failures when invalid"
-            )
-            test_api_key(val, f"{label} env.{key}")
-
-
-def audit_file(path: Path, label: str) -> None:
+def audit_file(path: Path, label: str, *, critical: bool = True) -> None:
     print(f"\n{label}")
     print(f"  path: {path}")
     data, err = load_json(path)
@@ -124,7 +151,7 @@ def audit_file(path: Path, label: str) -> None:
             issues.append(f"{label}: {err}")
         return
     print("  status: present")
-    audit_env_block(data, label)
+    audit_env_block(data, label, critical=critical)
     helper = data.get("apiKeyHelper")
     if helper:
         issues.append(
@@ -141,10 +168,16 @@ def audit_shell_env() -> None:
         if val:
             print(f"  {key}: {mask_key(val)}")
             if key in BLOCKER_ENV_KEYS:
-                issues.append(
-                    f"Shell exports {key} ({mask_key(val)}) — scrub with env -u before claude -p"
+                record_key(val, "shell")
+                warnings.append(
+                    f"Shell exports {key} ({mask_key(val)}) — rwe scripts scrub with env -u; "
+                    "safe to keep for week_that_was.py / rwe-weekly"
                 )
-                test_api_key(val, f"shell {key}")
+                result = test_api_key(val, f"shell {key}")
+                if result == "valid":
+                    notes.append(f"shell {key}: Anthropic API accepts this key")
+                elif result == "invalid":
+                    warnings.append(f"shell {key}: Anthropic API rejects this key")
         else:
             print(f"  {key}: (unset)")
 
@@ -167,8 +200,9 @@ def audit_shell_profiles() -> None:
             print(f"  {path}: {len(hits)} non-comment line(s)")
             for hit in hits[:3]:
                 print(f"    {hit[:100]}")
-            issues.append(
-                f"{path} exports ANTHROPIC_API_KEY — remove or comment out for OAuth headless runs"
+            warnings.append(
+                f"{path} exports ANTHROPIC_API_KEY — OK for week_that_was; "
+                "rwe-run/catchup scrub it with env -u"
             )
     if not found:
         print("  (no ANTHROPIC_API_KEY exports found in common profile files)")
@@ -189,11 +223,14 @@ def audit_claude_json() -> None:
         for key in BLOCKER_ENV_KEYS:
             if key in env and str(env.get(key) or "").strip():
                 val = str(env[key])
+                record_key(val, "~/.claude.json")
                 issues.append(
                     f"~/.claude.json env.{key} is set ({mask_key(val)}) — "
-                    "Claude Code injects this into every session (settingsEnv/globalEnv)"
+                    "Claude Code injects this into every session"
                 )
-                test_api_key(val, f"~/.claude.json env.{key}")
+                result = test_api_key(val, f"~/.claude.json env.{key}")
+                if result == "invalid":
+                    issues.append(f"~/.claude.json env.{key}: Anthropic API rejects this key")
     helper = data.get("apiKeyHelper")
     if helper:
         issues.append(f"~/.claude.json apiKeyHelper is set ({helper!r})")
@@ -218,10 +255,32 @@ audit_file(managed, "Managed settings (MDM)")
 
 audit_shell_profiles()
 
+# Detect multiple distinct keys — classic cause of "Invalid API key" after env -u
+print("\n=== Key fingerprint check ===")
+if len(key_sources) > 1:
+    print("MISMATCH: multiple distinct ANTHROPIC_API_KEY values found:")
+    for fp, labels in key_sources.items():
+        print(f"  {fp}: {', '.join(labels)}")
+    print(
+        "\nDiagnosis: rwe scripts scrub the shell key (env -u), but Claude Code still "
+        "injects keys from settings files. If the settings key is dead, you get "
+        "'Invalid API key · Fix external API key' even when your keychain key is valid."
+    )
+elif len(key_sources) == 1:
+    fp, labels = next(iter(key_sources.items()))
+    print(f"Single key fingerprint ({fp}) from: {', '.join(labels)}")
+else:
+    print("No ANTHROPIC_API_KEY values found in audited sources.")
+
 print("\n=== Summary ===")
 if notes:
     for n in notes:
         print(f"NOTE: {n}")
+
+if warnings:
+    print(f"\n{len(warnings)} warning(s) (scrubbed by rwe scripts — not blockers for catch-up):\n")
+    for i, item in enumerate(warnings, 1):
+        print(f"  {i}. {item}")
 
 if issues:
     print(f"\n{len(issues)} blocker(s) found:\n")
@@ -229,16 +288,19 @@ if issues:
         print(f"  {i}. {item}")
     print(
         "\nFix (OAuth headless — rwe-run / rwe-catchup / rwe-weekly-audio):\n"
-        "  1. Remove ANTHROPIC_API_KEY from every settings env block above.\n"
-        "  2. Remove or fix apiKeyHelper entries.\n"
+        "  1. Remove ANTHROPIC_API_KEY from settings env blocks (cannot be scrubbed).\n"
+        "  2. Keep your keychain/.zshrc key for week_that_was — rwe scripts scrub it.\n"
         "  3. Run: claude doctor\n"
         "  4. Re-run: rwe-auth-check.sh --test-api --doctor\n"
         "  5. Retry: bin/rwe-catchup.sh --from YYYY-MM-DD --to YYYY-MM-DD\n"
-        "\nTo remove a key from ~/.claude/settings.json:\n"
+        "\nTo remove the dead key from ~/.claude/settings.json:\n"
+        "  cp ~/.claude/settings.json ~/.claude/settings.json.bak\n"
         "  jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json"
     )
     sys.exit(1)
 
+if warnings:
+    print("\nNo settings-file blockers. Shell/.zshrc warnings above are OK for catch-up.")
 print("\nNo OAuth blockers detected in audited sources.")
 print("If claude -p still fails, run with --doctor and inspect the debug log for [MCP] lines.")
 sys.exit(0)

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -256,6 +256,44 @@ audit_file(managed, "Managed settings (MDM)")
 
 audit_shell_profiles()
 
+
+def audit_oauth_login() -> None:
+    print("\nClaude Code OAuth session (required for claude -p after env -u scrub)")
+    if not shutil.which("claude"):
+        print("  claude CLI: not on PATH")
+        warnings.append("claude CLI not on PATH — cannot verify OAuth login")
+        return
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    try:
+        proc = subprocess.run(
+            ["claude", "/status"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=env,
+        )
+        out = ((proc.stdout or "") + (proc.stderr or "")).strip()
+        if out:
+            for line in out.splitlines()[:12]:
+                print(f"  {line}")
+        if re.search(r"not logged in|please run /login", out, re.I):
+            issues.append(
+                "Claude Code OAuth: not logged in — run interactively once: claude /login"
+            )
+        elif re.search(r"unknown skill", out, re.I):
+            notes.append("claude /status not available on this Claude Code version — use rwe-connectivity-check.sh --live")
+        elif re.search(r"auth token|logged in|claude\.ai|subscription|max", out, re.I):
+            notes.append("Claude Code OAuth session appears active (claude /status)")
+        else:
+            warnings.append(
+                "Could not confirm OAuth from claude /status — if catch-up fails, run: claude /login"
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"claude /status failed ({exc}) — if catch-up fails, run: claude /login")
+
+
+audit_oauth_login()
+
 # Detect multiple distinct keys — classic cause of "Invalid API key" after env -u
 print("\n=== Key fingerprint check ===")
 if len(key_sources) > 1:

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -39,6 +39,7 @@ python3 - <<'PY'
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path

--- a/bin/rwe-auth-check.sh
+++ b/bin/rwe-auth-check.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Audit Claude Code auth sources that break headless OAuth runs (rwe-run.sh,
+# rwe-catchup.sh, rwe-weekly-audio). The daily/weekly-audio flows use
+# `claude -p` with a claude.ai subscription — any ANTHROPIC_API_KEY or
+# apiKeyHelper injected from settings files overrides OAuth and causes
+# "Invalid API key · Fix external API key" even when the shell has nothing
+# exported (env -u does not clear settings.json env blocks).
+#
+# Usage:
+#   rwe-auth-check.sh              # print audit, exit 1 if blockers found
+#   rwe-auth-check.sh --test-api   # also curl-test any keys found
+#   rwe-auth-check.sh --doctor     # also run `claude doctor` if available
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${HERE}/rwe-common.sh"
+
+TEST_API=0
+RUN_DOCTOR=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --test-api) TEST_API=1; shift ;;
+    --doctor)   RUN_DOCTOR=1; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+REPO_ROOT="$(rwe_repo_root "${HERE}")" || exit 1
+
+export RWE_AUTH_TEST_API="${TEST_API}"
+export RWE_AUTH_REPO_ROOT="${REPO_ROOT}"
+
+python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+REPO = Path(os.environ["RWE_AUTH_REPO_ROOT"])
+TEST_API = os.environ.get("RWE_AUTH_TEST_API") == "1"
+
+AUTH_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+BLOCKER_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+issues = []
+notes = []
+
+
+def mask_key(value: str) -> str:
+    value = (value or "").strip()
+    if not value:
+        return "(empty)"
+    if len(value) <= 8:
+        return value[:2] + "…"
+    return value[:4] + "…" + value[-4:]
+
+
+def load_json(path: Path):
+    if not path.is_file():
+        return None, "not found"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc}"
+
+
+def test_api_key(key: str, label: str) -> None:
+    if not TEST_API or not key.strip():
+        return
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-sS",
+                "https://api.anthropic.com/v1/models",
+                "-H", f"x-api-key: {key.strip()}",
+                "-H", "anthropic-version: 2023-06-01",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        body = (proc.stdout or proc.stderr or "").strip()
+        if "authentication_error" in body or "invalid x-api-key" in body:
+            issues.append(f"{label}: Anthropic API rejects this key (authentication_error)")
+        elif proc.returncode == 0 and '"data"' in body:
+            notes.append(f"{label}: Anthropic API accepts this key")
+        else:
+            notes.append(f"{label}: API test inconclusive ({body[:120]})")
+    except Exception as exc:  # noqa: BLE001
+        notes.append(f"{label}: API test failed ({exc})")
+
+
+def audit_env_block(data: dict, label: str) -> None:
+    env = data.get("env")
+    if not isinstance(env, dict) or not env:
+        return
+    keys = sorted(env.keys())
+    print(f"  env keys: {', '.join(keys)}")
+    for key in BLOCKER_ENV_KEYS:
+        if key in env and str(env.get(key) or "").strip():
+            val = str(env[key])
+            issues.append(
+                f"{label}: {key} is set in settings env block ({mask_key(val)}) — "
+                "overrides OAuth in claude -p and causes auth failures when invalid"
+            )
+            test_api_key(val, f"{label} env.{key}")
+
+
+def audit_file(path: Path, label: str) -> None:
+    print(f"\n{label}")
+    print(f"  path: {path}")
+    data, err = load_json(path)
+    if err:
+        print(f"  status: {err}")
+        if err != "not found":
+            issues.append(f"{label}: {err}")
+        return
+    print("  status: present")
+    audit_env_block(data, label)
+    helper = data.get("apiKeyHelper")
+    if helper:
+        issues.append(
+            f"{label}: apiKeyHelper is set ({helper!r}) — conflicts with OAuth; "
+            "remove unless you intend API-key auth"
+        )
+        print(f"  apiKeyHelper: {helper}")
+
+
+def audit_shell_env() -> None:
+    print("\nShell environment (this process)")
+    for key in AUTH_ENV_KEYS:
+        val = os.environ.get(key, "")
+        if val:
+            print(f"  {key}: {mask_key(val)}")
+            if key in BLOCKER_ENV_KEYS:
+                issues.append(
+                    f"Shell exports {key} ({mask_key(val)}) — scrub with env -u before claude -p"
+                )
+                test_api_key(val, f"shell {key}")
+        else:
+            print(f"  {key}: (unset)")
+
+
+def audit_shell_profiles() -> None:
+    print("\nShell startup files (grep ANTHROPIC_API_KEY)")
+    pattern = re.compile(r"ANTHROPIC_API_KEY")
+    found = False
+    for rel in (".zshrc", ".zprofile", ".bash_profile", ".bashrc", ".profile"):
+        path = HOME / rel
+        if not path.is_file():
+            continue
+        hits = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+            if pattern.search(line) and not line.strip().startswith("#")
+        ]
+        if hits:
+            found = True
+            print(f"  {path}: {len(hits)} non-comment line(s)")
+            for hit in hits[:3]:
+                print(f"    {hit[:100]}")
+            issues.append(
+                f"{path} exports ANTHROPIC_API_KEY — remove or comment out for OAuth headless runs"
+            )
+    if not found:
+        print("  (no ANTHROPIC_API_KEY exports found in common profile files)")
+
+
+def audit_claude_json() -> None:
+    path = HOME / ".claude.json"
+    print("\n~/.claude.json (global config — distinct from ~/.claude/settings.json)")
+    print(f"  path: {path}")
+    data, err = load_json(path)
+    if err:
+        print(f"  status: {err}")
+        return
+    print("  status: present")
+    env = data.get("env")
+    if isinstance(env, dict) and env:
+        print(f"  env keys: {', '.join(sorted(env.keys()))}")
+        for key in BLOCKER_ENV_KEYS:
+            if key in env and str(env.get(key) or "").strip():
+                val = str(env[key])
+                issues.append(
+                    f"~/.claude.json env.{key} is set ({mask_key(val)}) — "
+                    "Claude Code injects this into every session (settingsEnv/globalEnv)"
+                )
+                test_api_key(val, f"~/.claude.json env.{key}")
+    helper = data.get("apiKeyHelper")
+    if helper:
+        issues.append(f"~/.claude.json apiKeyHelper is set ({helper!r})")
+        print(f"  apiKeyHelper: {helper}")
+
+
+# --- main audit ---
+print("=== Claude Code auth audit for Reading with Ears headless runs ===")
+print("Daily/weekly-audio flows expect claude.ai OAuth — not ANTHROPIC_API_KEY.")
+print("The error 'Invalid API key · Fix external API key' is Claude Code auth,")
+print("not Gmail or NotebookLM MCP (those show [MCP] errors in debug logs).")
+
+audit_shell_env()
+audit_claude_json()
+audit_file(HOME / ".claude" / "settings.json", "Global settings (~/.claude/settings.json)")
+audit_file(HOME / ".claude" / "settings.local.json", "Global local settings (~/.claude/settings.local.json)")
+audit_file(REPO / ".claude" / "settings.json", "Project settings (.claude/settings.json)")
+audit_file(REPO / ".claude" / "settings.local.json", "Project local settings (.claude/settings.local.json)")
+
+managed = Path("/Library/Application Support/ClaudeCode/managed-settings.json")
+audit_file(managed, "Managed settings (MDM)")
+
+audit_shell_profiles()
+
+print("\n=== Summary ===")
+if notes:
+    for n in notes:
+        print(f"NOTE: {n}")
+
+if issues:
+    print(f"\n{len(issues)} blocker(s) found:\n")
+    for i, item in enumerate(issues, 1):
+        print(f"  {i}. {item}")
+    print(
+        "\nFix (OAuth headless — rwe-run / rwe-catchup / rwe-weekly-audio):\n"
+        "  1. Remove ANTHROPIC_API_KEY from every settings env block above.\n"
+        "  2. Remove or fix apiKeyHelper entries.\n"
+        "  3. Run: claude doctor\n"
+        "  4. Re-run: rwe-auth-check.sh --test-api --doctor\n"
+        "  5. Retry: bin/rwe-catchup.sh --from YYYY-MM-DD --to YYYY-MM-DD\n"
+        "\nTo remove a key from ~/.claude/settings.json:\n"
+        "  jq 'del(.env.ANTHROPIC_API_KEY)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json"
+    )
+    sys.exit(1)
+
+print("\nNo OAuth blockers detected in audited sources.")
+print("If claude -p still fails, run with --doctor and inspect the debug log for [MCP] lines.")
+sys.exit(0)
+PY
+
+status=$?
+
+if [[ "${RUN_DOCTOR}" -eq 1 ]] && command -v claude >/dev/null 2>&1; then
+  echo ""
+  echo "=== claude doctor ==="
+  claude doctor || true
+elif [[ "${RUN_DOCTOR}" -eq 1 ]]; then
+  echo "NOTE: claude CLI not on PATH — skipping claude doctor"
+fi
+
+exit "${status}"

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -110,6 +110,7 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
       processed=$((processed + 1))
     else
       echo "[${current}] Pipeline failed — sentinel not written, will retry on next catch-up run."
+      echo "[${current}] Diagnose: bin/rwe-connectivity-check.sh --live --verbose --date ${current}"
       echo "[${current}] MCP debug log: ${DEBUG_FILE}"
       rwe_tail_debug_log "${DEBUG_FILE}" "[${current}] MCP debug log"
       failed=$((failed + 1))

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -46,6 +46,16 @@ echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") rwe-catchup from=${FROM_DATE} to=${TO_D
 
 "${RWE_ROOT}/scripts/install-local.sh"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
+if ! rwe_check_claude_oauth; then
+  exit 1
+fi
+
 STATE_DIR="${HOME}/.local/state/reading-with-ears"
 mkdir -p "${STATE_DIR}"
 
@@ -71,14 +81,6 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
     CLAUDE_PROMPT="Read and follow skills/user/reading-list-builder/SKILL.md and run the DAILY FLOW (Steps 0-8) for ${current}. In all Gmail searches use 'after:${gmail_after} before:${gmail_before}' to scope results to exactly this day. Do not run the weekly audio flow."
 
     cd "${RWE_ROOT}"
-
-    if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
-      echo "[${current}] Aborting — fix Claude auth blockers above, then re-run."
-      echo "[${current}] Run: bin/rwe-auth-check.sh --test-api --doctor"
-      failed=$((failed + 1))
-      current=$(date -j -v+1d -f "%Y-%m-%d" "${current}" +"%Y-%m-%d")
-      continue
-    fi
 
     # Full claude debug capture (unfiltered — a category filter like "mcp" broke
     # stdin prompt piping in testing) per day, so a failure (Gmail vs. NotebookLM

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -72,6 +72,14 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
 
     cd "${RWE_ROOT}"
 
+    if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+      echo "[${current}] Aborting — fix Claude auth blockers above, then re-run."
+      echo "[${current}] Run: bin/rwe-auth-check.sh --test-api --doctor"
+      failed=$((failed + 1))
+      current=$(date -j -v+1d -f "%Y-%m-%d" "${current}" +"%Y-%m-%d")
+      continue
+    fi
+
     # Full claude debug capture (unfiltered — a category filter like "mcp" broke
     # stdin prompt piping in testing) per day, so a failure (Gmail vs. NotebookLM
     # vs. something else in the MCP handshake) doesn't require manually reproducing
@@ -101,11 +109,7 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
     else
       echo "[${current}] Pipeline failed — sentinel not written, will retry on next catch-up run."
       echo "[${current}] MCP debug log: ${DEBUG_FILE}"
-      if [[ -f "${DEBUG_FILE}" ]]; then
-        echo "[${current}] --- last 40 lines of MCP debug log ---"
-        tail -40 "${DEBUG_FILE}"
-        echo "[${current}] --- end debug log excerpt ---"
-      fi
+      rwe_tail_debug_log "${DEBUG_FILE}" "[${current}] MCP debug log"
       failed=$((failed + 1))
     fi
   fi

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -15,7 +15,7 @@ REPO_ROOT="$(rwe_repo_root "${HERE}")"
 RWE_ROOT="${REPO_ROOT}/reading-with-ears"
 
 # Do not source ~/.zshrc — see note in rwe-run.sh.
-export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+# PATH: rwe-common.sh appends homebrew/local fallbacks; does not prepend them.
 
 SKILL_VERSION_REQUIRED="3.0"
 SKILL_FILE="${RWE_ROOT}/skills/user/reading-list-builder/SKILL.md"

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -55,6 +55,7 @@ fi
 if ! rwe_check_claude_oauth; then
   exit 1
 fi
+rwe_claude_version_warn 2>&1 | while read -r line; do [[ -n "${line}" ]] && echo "${line}"; done
 
 STATE_DIR="${HOME}/.local/state/reading-with-ears"
 mkdir -p "${STATE_DIR}"

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -55,6 +55,7 @@ fi
 if ! rwe_check_claude_oauth; then
   exit 1
 fi
+rwe_log_claude_bin
 rwe_claude_version_warn 2>&1 | while read -r line; do [[ -n "${line}" ]] && echo "${line}"; done
 
 STATE_DIR="${HOME}/.local/state/reading-with-ears"

--- a/bin/rwe-catchup.sh
+++ b/bin/rwe-catchup.sh
@@ -98,11 +98,7 @@ while [[ "$current" < "$TO_DATE" || "$current" == "$TO_DATE" ]]; do
     # case the caller's shell has it set (e.g. a prior rwe-weekly run this session),
     # which otherwise makes claude refuse to start with an auth-conflict error.
     # Use 'if' so a single day's failure doesn't abort the whole catch-up run.
-    if echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
-        --permission-mode bypassPermissions \
-        --strict-mcp-config \
-        --mcp-config "${RWE_ROOT}/automation/mcp-headless.json" \
-        --add-dir "${RWE_ROOT}" \
+    if echo "${CLAUDE_PROMPT}" | rwe_claude_headless "${RWE_ROOT}" \
         --debug \
         --debug-file "${DEBUG_FILE}"; then
       touch "${SENTINEL}"

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -40,3 +40,31 @@ print(os.path.expanduser(str(r).strip()), end='')
   echo "reading-with-ears: set RWE_REPO or repo_root in ~/.config/reading-with-ears/config.json (see docs/install.md)." >&2
   return 1
 }
+
+# Preflight for headless OAuth runs. Fails fast when settings files still inject
+# ANTHROPIC_API_KEY (env -u in the caller does not clear settings.json env blocks).
+rwe_audit_claude_auth() {
+  local repo_root="${1:?repo root}"
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+  if [[ -x "${here}/rwe-auth-check.sh" ]]; then
+    RWE_REPO="${repo_root}" "${here}/rwe-auth-check.sh"
+    return $?
+  fi
+  echo "WARN: rwe-auth-check.sh not found — skipping Claude auth preflight" >&2
+  return 0
+}
+
+rwe_tail_debug_log() {
+  local debug_file="${1:?debug log path}"
+  local label="${2:-debug log}"
+  if [[ -f "${debug_file}" ]]; then
+    local lines
+    lines="$(wc -l < "${debug_file}" | tr -d ' ')"
+    echo "--- ${label} (${lines} lines, last 40) ---"
+    tail -40 "${debug_file}"
+    echo "--- end ${label} ---"
+  else
+    echo "WARN: ${label} not found at ${debug_file}"
+  fi
+}

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -9,7 +9,14 @@ _RWE_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # in ~/.local/bin that the user's interactive shell uses.
 rwe_ensure_path() {
   local dir
-  for dir in "${HOME}/.local/bin" /opt/homebrew/bin /usr/local/bin; do
+  # Prefer ~/.local/bin (native claude install) over entries already on PATH.
+  if [[ -d "${HOME}/.local/bin" ]]; then
+    case ":${PATH}:" in
+      *:"${HOME}/.local/bin":*) ;;
+      *) PATH="${HOME}/.local/bin:${PATH:-/usr/bin:/bin}" ;;
+    esac
+  fi
+  for dir in /opt/homebrew/bin /usr/local/bin; do
     [[ -d "${dir}" ]] || continue
     case ":${PATH}:" in
       *:"${dir}":*) ;;
@@ -20,6 +27,51 @@ rwe_ensure_path() {
 }
 
 rwe_ensure_path
+
+# Resolve the newest claude on PATH (avoids stale Homebrew shadowing native install).
+# Override: export RWE_CLAUDE_BIN=/path/to/claude
+rwe_claude_bin() {
+  if [[ -n "${RWE_CLAUDE_BIN:-}" && -x "${RWE_CLAUDE_BIN}" ]]; then
+    echo "${RWE_CLAUDE_BIN}"
+    return 0
+  fi
+  rwe_ensure_path
+  python3 - <<'PY'
+import os, re, subprocess, sys
+
+def ver_tuple(s):
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", s or "")
+    return tuple(int(x) for x in m.groups()) if m else (0, 0, 0)
+
+path = os.environ.get("PATH", "")
+seen = set()
+best = None
+best_v = (0, 0, 0)
+for d in path.split(":"):
+    p = os.path.join(d, "claude")
+    if not os.path.isfile(p) or os.access(p, os.X_OK):
+        continue
+    rp = os.path.realpath(p)
+    if rp in seen:
+        continue
+    seen.add(rp)
+    try:
+        out = subprocess.run([rp, "--version"], capture_output=True, text=True, timeout=10)
+        vt = ver_tuple((out.stdout or "") + (out.stderr or ""))
+    except Exception:
+        vt = (0, 0, 0)
+    if vt > best_v:
+        best_v = vt
+        best = rp
+print(best or "claude")
+PY
+}
+
+rwe_log_claude_bin() {
+  local bin
+  bin="$(rwe_claude_bin)"
+  echo "Using claude: ${bin} ($("${bin}" --version 2>/dev/null | head -1 || echo unknown))"
+}
 # Resolve repo root (directory that contains reading-with-ears/).
 # Precedence: RWE_REPO → ~/.config/reading-with-ears/config.json repo_root
 # → caller lives in-repo at bin/ (parent is repo root).
@@ -122,9 +174,10 @@ rwe_claude_headless() {
   shift
   local strict=()
   [[ "${RWE_STRICT_MCP:-0}" == "1" ]] && strict=(--strict-mcp-config)
-  # Honor claude.ai connector MCPs in headless runs (required for Gmail on many versions).
   export ENABLE_CLAUDEAI_MCP_SERVERS="${ENABLE_CLAUDEAI_MCP_SERVERS:-true}"
-  env -u ANTHROPIC_API_KEY claude -p \
+  local claude_bin
+  claude_bin="$(rwe_claude_bin)"
+  env -u ANTHROPIC_API_KEY "${claude_bin}" -p \
     --permission-mode bypassPermissions \
     ${strict[@]+"${strict[@]}"} \
     --mcp-config "${rwe_root}/automation/mcp-headless.json" \
@@ -134,11 +187,13 @@ rwe_claude_headless() {
 
 # Warn when Claude Code is below the version where claude.ai MCP in -p was restored.
 rwe_claude_version_warn() {
-  if ! command -v claude >/dev/null 2>&1; then
+  local bin
+  bin="$(rwe_claude_bin)"
+  if [[ ! -x "${bin}" ]] && ! command -v "${bin}" >/dev/null 2>&1; then
     return 0
   fi
   local ver
-  ver="$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  ver="$("${bin}" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
   [[ -z "${ver}" ]] && return 0
   python3 - "${ver}" <<'PY'
 import sys

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -109,7 +109,7 @@ rwe_claude_headless() {
   export ENABLE_CLAUDEAI_MCP_SERVERS="${ENABLE_CLAUDEAI_MCP_SERVERS:-true}"
   env -u ANTHROPIC_API_KEY claude -p \
     --permission-mode bypassPermissions \
-    "${strict[@]}" \
+    ${strict[@]+"${strict[@]}"} \
     --mcp-config "${rwe_root}/automation/mcp-headless.json" \
     --add-dir "${rwe_root}" \
     "$@"

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -63,6 +63,10 @@ rwe_check_claude_oauth() {
   fi
   local status_out
   status_out="$(env -u ANTHROPIC_API_KEY claude /status 2>&1 || true)"
+  if echo "${status_out}" | grep -qiE 'unknown skill'; then
+    # /status is not a valid command on all Claude Code versions (e.g. 2.1.87).
+    return 0
+  fi
   if echo "${status_out}" | grep -qiE 'not logged in|please run /login'; then
     echo "ERROR: Claude Code is not logged in."
     echo "  rwe-catchup / rwe-run scrub ANTHROPIC_API_KEY and use your claude.ai subscription."
@@ -90,4 +94,22 @@ rwe_tail_debug_log() {
   else
     echo "WARN: ${label} not found at ${debug_file}"
   fi
+}
+
+# Headless claude -p invocation shared by rwe-run / rwe-catchup / rwe-weekly-audio.
+# Gmail comes from claude.ai built-in connectors (Settings → Connectors → Gmail).
+# mcp-headless.json adds notebooklm only. Do NOT use --strict-mcp-config: it blocks
+# claude.ai Gmail and forces the deprecated gmail.mcp.claude.com endpoint (404).
+# Set RWE_STRICT_MCP=1 only for legacy debugging.
+rwe_claude_headless() {
+  local rwe_root="${1:?reading-with-ears root}"
+  shift
+  local strict=()
+  [[ "${RWE_STRICT_MCP:-0}" == "1" ]] && strict=(--strict-mcp-config)
+  env -u ANTHROPIC_API_KEY claude -p \
+    --permission-mode bypassPermissions \
+    "${strict[@]}" \
+    --mcp-config "${rwe_root}/automation/mcp-headless.json" \
+    --add-dir "${rwe_root}" \
+    "$@"
 }

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -97,19 +97,42 @@ rwe_tail_debug_log() {
 }
 
 # Headless claude -p invocation shared by rwe-run / rwe-catchup / rwe-weekly-audio.
-# Gmail comes from claude.ai built-in connectors (Settings → Connectors → Gmail).
-# mcp-headless.json adds notebooklm only. Do NOT use --strict-mcp-config: it blocks
-# claude.ai Gmail and forces the deprecated gmail.mcp.claude.com endpoint (404).
-# Set RWE_STRICT_MCP=1 only for legacy debugging.
+# Gmail: claude.ai connectors (mcp__claude_ai_Gmail__*) may load in -p on recent
+# Claude Code versions; also try user-scoped HTTP gmail in mcp-headless.json.
+# Set RWE_STRICT_MCP=1 to exclude claude.ai connectors (legacy/debug only).
 rwe_claude_headless() {
   local rwe_root="${1:?reading-with-ears root}"
   shift
   local strict=()
   [[ "${RWE_STRICT_MCP:-0}" == "1" ]] && strict=(--strict-mcp-config)
+  # Honor claude.ai connector MCPs in headless runs (required for Gmail on many versions).
+  export ENABLE_CLAUDEAI_MCP_SERVERS="${ENABLE_CLAUDEAI_MCP_SERVERS:-true}"
   env -u ANTHROPIC_API_KEY claude -p \
     --permission-mode bypassPermissions \
     "${strict[@]}" \
     --mcp-config "${rwe_root}/automation/mcp-headless.json" \
     --add-dir "${rwe_root}" \
     "$@"
+}
+
+# Warn when Claude Code is below the version where claude.ai MCP in -p was restored.
+rwe_claude_version_warn() {
+  if ! command -v claude >/dev/null 2>&1; then
+    return 0
+  fi
+  local ver
+  ver="$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  [[ -z "${ver}" ]] && return 0
+  python3 - "${ver}" <<'PY'
+import sys
+parts = [int(x) for x in sys.argv[1].split(".")[:3]]
+while len(parts) < 3:
+    parts.append(0)
+if tuple(parts) < (2, 1, 180):
+    print(
+        f"WARN: Claude Code {sys.argv[1]} — Gmail in claude -p needs 2.1.180+ "
+        f"(you have {parts[0]}.{parts[1]}.{parts[2]}). Run: claude install",
+        file=sys.stderr,
+    )
+PY
 }

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -3,6 +3,23 @@
 
 # Absolute path to bin/ — set at source time so helpers work after callers cd elsewhere.
 _RWE_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Append tool dirs as fallbacks for launchd/cron (minimal PATH). Never prepend
+# /opt/homebrew/bin — an old Homebrew `claude` there shadows a newer install
+# in ~/.local/bin that the user's interactive shell uses.
+rwe_ensure_path() {
+  local dir
+  for dir in "${HOME}/.local/bin" /opt/homebrew/bin /usr/local/bin; do
+    [[ -d "${dir}" ]] || continue
+    case ":${PATH}:" in
+      *:"${dir}":*) ;;
+      *) PATH="${PATH:+${PATH}:}${dir}" ;;
+    esac
+  done
+  export PATH
+}
+
+rwe_ensure_path
 # Resolve repo root (directory that contains reading-with-ears/).
 # Precedence: RWE_REPO → ~/.config/reading-with-ears/config.json repo_root
 # → caller lives in-repo at bin/ (parent is repo root).

--- a/bin/rwe-common.sh
+++ b/bin/rwe-common.sh
@@ -1,6 +1,8 @@
 # Shared helpers for Reading with Ears bin scripts.
 # shellcheck shell=bash
 
+# Absolute path to bin/ — set at source time so helpers work after callers cd elsewhere.
+_RWE_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Resolve repo root (directory that contains reading-with-ears/).
 # Precedence: RWE_REPO → ~/.config/reading-with-ears/config.json repo_root
 # → caller lives in-repo at bin/ (parent is repo root).
@@ -45,13 +47,34 @@ print(os.path.expanduser(str(r).strip()), end='')
 # ANTHROPIC_API_KEY (env -u in the caller does not clear settings.json env blocks).
 rwe_audit_claude_auth() {
   local repo_root="${1:?repo root}"
-  local here
-  here="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
-  if [[ -x "${here}/rwe-auth-check.sh" ]]; then
-    RWE_REPO="${repo_root}" "${here}/rwe-auth-check.sh"
+  if [[ -x "${_RWE_BIN_DIR}/rwe-auth-check.sh" ]]; then
+    RWE_REPO="${repo_root}" "${_RWE_BIN_DIR}/rwe-auth-check.sh"
     return $?
   fi
-  echo "WARN: rwe-auth-check.sh not found — skipping Claude auth preflight" >&2
+  echo "WARN: rwe-auth-check.sh not found at ${_RWE_BIN_DIR} — skipping Claude auth preflight" >&2
+  return 0
+}
+
+# Headless flows scrub ANTHROPIC_API_KEY — they need an active claude.ai OAuth session.
+rwe_check_claude_oauth() {
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "WARN: claude CLI not on PATH — cannot verify OAuth login" >&2
+    return 0
+  fi
+  local status_out
+  status_out="$(env -u ANTHROPIC_API_KEY claude /status 2>&1 || true)"
+  if echo "${status_out}" | grep -qiE 'not logged in|please run /login'; then
+    echo "ERROR: Claude Code is not logged in."
+    echo "  rwe-catchup / rwe-run scrub ANTHROPIC_API_KEY and use your claude.ai subscription."
+    echo "  Fix: run interactively once, then retry catch-up:"
+    echo "    claude /login"
+    return 1
+  fi
+  if echo "${status_out}" | grep -qiE 'auth token|logged in|claude\.ai|subscription'; then
+    return 0
+  fi
+  echo "WARN: Could not confirm Claude OAuth login from 'claude /status'."
+  echo "  If catch-up fails with 'Not logged in · Please run /login', run: claude /login"
   return 0
 }
 

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -63,6 +63,7 @@ STEP=0
 log() { echo "$*"; echo "$*" >> "${ARTIFACT_DIR}/summary.log"; }
 ok()  { log "  OK   $*"; }
 warn(){ log "  WARN $*"; WARNS=$((WARNS + 1)); }
+note(){ log "  NOTE $*"; }
 bad() { log "  FAIL $*"; ISSUES=$((ISSUES + 1)); }
 phase() {
   STEP=$((STEP + 1))

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -325,7 +325,10 @@ else:
 if "NO_GMAIL_TOOLS" in text:
     print("  FAIL Model reported NO_GMAIL_TOOLS")
 if ver_t and ver_t < (2, 1, 180):
-    print(f"  FAIL Claude Code {ver_m.group(1)} — claude.ai Gmail often missing in -p; upgrade: claude install")
+    if tools:
+        print(f"  WARN Claude Code {ver_m.group(1)} is below 2.1.180, but the live probe found Gmail tools anyway — no action needed")
+    else:
+        print(f"  FAIL Claude Code {ver_m.group(1)} — claude.ai Gmail often missing in -p; upgrade: claude install")
 if claudeai_lines:
     print("  INFO claudeai-mcp debug (sample):")
     for ln in claudeai_lines:
@@ -339,7 +342,7 @@ if deferred:
     for ln in deferred[:5]:
         print(f"    {ln[:140]}")
 
-ok = bool(tools) and "NO_GMAIL_TOOLS" not in text and (not ver_t or ver_t >= (2, 1, 180))
+ok = bool(tools) and "NO_GMAIL_TOOLS" not in text
 raise SystemExit(0 if ok else 1)
 PY
     gmail_scan=$?

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -46,7 +46,7 @@ RWE_ROOT="${REPO_ROOT}/reading-with-ears"
 MCP_CONFIG="${RWE_ROOT}/automation/mcp-headless.json"
 SKILL_FILE="${RWE_ROOT}/skills/user/reading-list-builder/SKILL.md"
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+# PATH set by rwe-common.sh (rwe_ensure_path)
 
 if [[ -z "${PROBE_DATE}" ]]; then
   PROBE_DATE="$(date -v-1d +%F 2>/dev/null || date -d 'yesterday' +%F)"
@@ -150,21 +150,43 @@ else
 fi
 
 phase "Toolchain"
-for cmd in claude python3 uvx curl jq; do
+if command -v claude >/dev/null 2>&1; then
+  ok "claude: $(command -v claude)"
+  claude --version 2>&1 | head -1 | tee "${ARTIFACT_DIR}/claude-version.txt" | while read -r line; do
+    ok "claude version: ${line}"
+  done
+  if command -v which >/dev/null 2>&1; then
+    claude_paths="$(which -a claude 2>/dev/null || true)"
+    if [[ -n "${claude_paths}" ]]; then
+      note "All claude binaries on PATH:"
+      while IFS= read -r cp; do
+        [[ -z "${cp}" ]] && continue
+        cv="$("${cp}" --version 2>/dev/null | head -1 || echo 'unknown')"
+        log "       ${cp} → ${cv}"
+      done <<< "${claude_paths}"
+      unique_ver="$(while IFS= read -r cp; do
+        [[ -z "${cp}" ]] && continue
+        "${cp}" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true
+      done <<< "${claude_paths}" | sort -u | wc -l | tr -d ' ')"
+      if [[ "${unique_ver}" -gt 1 ]]; then
+        warn "Multiple claude versions on PATH — scripts use the first one: $(command -v claude)"
+        note "Remove stale copy: brew uninstall claude-code  OR  rm /opt/homebrew/bin/claude"
+      fi
+    fi
+  fi
+  rwe_claude_version_warn 2>&1 | while read -r line; do
+    [[ -n "${line}" ]] && warn "${line#WARN: }"
+  done
+else
+  bad "claude: not on PATH"
+fi
+for cmd in python3 uvx curl jq; do
   if command -v "${cmd}" >/dev/null 2>&1; then
     ok "${cmd}: $(command -v "${cmd}")"
   else
     bad "${cmd}: not on PATH"
   fi
 done
-if command -v claude >/dev/null 2>&1; then
-  claude --version 2>&1 | head -1 | tee "${ARTIFACT_DIR}/claude-version.txt" | while read -r line; do
-    ok "claude version: ${line}"
-  done
-  rwe_claude_version_warn 2>&1 | while read -r line; do
-    [[ -n "${line}" ]] && warn "${line#WARN: }"
-  done
-fi
 if command -v nlm >/dev/null 2>&1; then
   ok "nlm: $(command -v nlm)"
 else

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -76,13 +76,8 @@ verbose_file() {
 }
 
 rwe_claude_headless_cmd() {
-  # Same flags as bin/rwe-catchup.sh — keep in sync.
-  env -u ANTHROPIC_API_KEY claude -p \
-    --permission-mode bypassPermissions \
-    --strict-mcp-config \
-    --mcp-config "${MCP_CONFIG}" \
-    --add-dir "${RWE_ROOT}" \
-    "$@"
+  # Same invocation as bin/rwe-catchup.sh — keep in sync via rwe_claude_headless().
+  rwe_claude_headless "${RWE_ROOT}" "$@"
 }
 
 run_claude_probe() {
@@ -210,35 +205,35 @@ fi
 phase "MCP registry (claude mcp list)"
 if command -v claude >/dev/null 2>&1; then
   claude mcp list 2>&1 | tee "${ARTIFACT_DIR}/mcp-list.txt" || true
-  if grep -qi 'gmail' "${ARTIFACT_DIR}/mcp-list.txt"; then
-    if grep -qiE 'gmail\.mcp\.claude\.com|claude\.ai Gmail' "${ARTIFACT_DIR}/mcp-list.txt"; then
-      ok "Full Gmail MCP listed (claude.ai / gmail.mcp.claude.com)"
-    else
-      warn "gmail entry found but may not be full Gmail MCP — check for gmail-send (send-only)"
-      grep -i gmail "${ARTIFACT_DIR}/mcp-list.txt" | while read -r line; do log "    ${line}"; done
-    fi
+  if grep -qiE 'claude\.ai Gmail|gmailmcp\.googleapis' "${ARTIFACT_DIR}/mcp-list.txt" \
+      && grep -i 'Gmail' "${ARTIFACT_DIR}/mcp-list.txt" | grep -qi 'Connected'; then
+    ok "claude.ai Gmail connector connected (gmailmcp.googleapis.com)"
   else
-    bad "Gmail MCP not in claude mcp list — run: claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp"
+    bad "claude.ai Gmail connector not connected — enable in Claude Settings → Connectors → Gmail"
+  fi
+  if grep -E '^gmail:.*gmail\.mcp\.claude\.com' "${ARTIFACT_DIR}/mcp-list.txt" | grep -qi 'Failed'; then
+    warn "Legacy gmail.mcp.claude.com registration failed (expected — endpoint deprecated/404). Remove with: claude mcp remove gmail"
   fi
   if grep -qi 'notebooklm\|nlm' "${ARTIFACT_DIR}/mcp-list.txt"; then
     ok "NotebookLM-related MCP listed"
   else
-    warn "NotebookLM not in claude mcp list (headless uses uvx via mcp-headless.json — may still work)"
+    warn "NotebookLM not in claude mcp list (headless adds it via mcp-headless.json — OK if uvx probe passed)"
   fi
   if grep -qi 'codex' "${ARTIFACT_DIR}/mcp-list.txt"; then
-    warn "codex MCP registered — unrelated to RWE; may trigger macOS malware block on session start"
+    warn "codex MCP registered — unrelated to RWE; may trigger macOS malware block. Remove: claude mcp remove codex"
   fi
 else
   bad "claude CLI missing — cannot list MCP servers"
 fi
 
-phase "Network reachability"
-if curl -sS -o /dev/null -w "%{http_code}" --max-time 15 \
-    "https://gmail.mcp.claude.com/mcp" >"${ARTIFACT_DIR}/gmail-mcp-http.txt" 2>&1; then
-  code="$(cat "${ARTIFACT_DIR}/gmail-mcp-http.txt")"
-  ok "gmail.mcp.claude.com reachable (HTTP ${code})"
+phase "Deprecated endpoint check (gmail.mcp.claude.com)"
+legacy_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+  'https://gmail.mcp.claude.com/mcp' 2>/dev/null || echo '000')"
+echo "${legacy_code}" > "${ARTIFACT_DIR}/gmail-legacy-mcp-http.txt"
+if [[ "${legacy_code}" == "404" || "${legacy_code}" == "000" ]]; then
+  ok "gmail.mcp.claude.com unavailable (${legacy_code}) — RWE uses claude.ai Gmail connector instead"
 else
-  warn "Could not reach gmail.mcp.claude.com — see ${ARTIFACT_DIR}/gmail-mcp-http.txt"
+  warn "gmail.mcp.claude.com returned HTTP ${legacy_code} (unexpected)"
 fi
 
 phase "NotebookLM subprocess (uvx)"
@@ -349,8 +344,8 @@ if [[ "${ISSUES}" -gt 0 ]]; then
   log ""
   log "Common fixes:"
   log "  claude /login"
-  log "  claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp"
-  log "  Open interactive claude once and approve Gmail connector OAuth"
+  log "  Claude Settings → Connectors → enable Gmail (claude.ai Gmail / gmailmcp.googleapis.com)"
+  log "  claude mcp remove gmail   # remove broken legacy gmail.mcp.claude.com registration"
   log "  nlm login"
   log "  Re-run: bin/rwe-connectivity-check.sh --live --verbose"
   exit 1

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -161,6 +161,9 @@ if command -v claude >/dev/null 2>&1; then
   claude --version 2>&1 | head -1 | tee "${ARTIFACT_DIR}/claude-version.txt" | while read -r line; do
     ok "claude version: ${line}"
   done
+  rwe_claude_version_warn 2>&1 | while read -r line; do
+    [[ -n "${line}" ]] && warn "${line#WARN: }"
+  done
 fi
 if command -v nlm >/dev/null 2>&1; then
   ok "nlm: $(command -v nlm)"
@@ -182,7 +185,7 @@ else
   warn "rwe-auth-check.sh not found"
 fi
 
-phase "Claude OAuth credential files"
+phase "Claude OAuth (informational — headless PONG probe is definitive)"
 found_cred=0
 for f in "${HOME}/.claude/.credentials.json" "${HOME}/.claude/credentials.json"; do
   if [[ -f "${f}" ]]; then
@@ -190,16 +193,20 @@ for f in "${HOME}/.claude/.credentials.json" "${HOME}/.claude/credentials.json";
     found_cred=1
   fi
 done
-[[ "${found_cred}" -eq 0 ]] && warn "No ~/.claude/.credentials.json — run: claude /login"
+if [[ "${found_cred}" -eq 0 ]]; then
+  note "No ~/.claude/.credentials.json on disk (normal on some installs — not a failure by itself)"
+fi
 
 status_out="$(env -u ANTHROPIC_API_KEY claude /status 2>&1 || true)"
 printf '%s\n' "${status_out}" > "${ARTIFACT_DIR}/claude-status.txt"
 if echo "${status_out}" | grep -qiE 'not logged in|please run /login'; then
   bad "claude /status: not logged in — run: claude /login"
+elif echo "${status_out}" | grep -qiE 'unknown skill'; then
+  note "claude /status unavailable on Claude Code $(claude --version 2>/dev/null | head -1 || echo this version) — use headless PONG probe below"
 elif echo "${status_out}" | grep -qiE 'auth token|logged in|claude\.ai|subscription|max'; then
   ok "claude /status: OAuth session appears active"
 else
-  warn "claude /status inconclusive — see ${ARTIFACT_DIR}/claude-status.txt"
+  note "claude /status inconclusive — see ${ARTIFACT_DIR}/claude-status.txt (headless PONG probe below is definitive)"
   [[ "${VERBOSE}" -eq 1 ]] && head -15 "${ARTIFACT_DIR}/claude-status.txt" | while read -r line; do log "    ${line}"; done
 fi
 
@@ -229,12 +236,15 @@ fi
 
 phase "Deprecated endpoint check (gmail.mcp.claude.com)"
 legacy_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
-  'https://gmail.mcp.claude.com/mcp' 2>/dev/null || echo '000')"
+  'https://gmail.mcp.claude.com/mcp' 2>/dev/null || true)"
+legacy_code="${legacy_code:-000}"
+# curl prints 000 on connection failure; avoid doubling with a fallback echo in $()
+legacy_code="${legacy_code:0:3}"
 echo "${legacy_code}" > "${ARTIFACT_DIR}/gmail-legacy-mcp-http.txt"
 if [[ "${legacy_code}" == "404" || "${legacy_code}" == "000" ]]; then
-  ok "gmail.mcp.claude.com unavailable (${legacy_code}) — RWE uses claude.ai Gmail connector instead"
+  ok "gmail.mcp.claude.com unavailable (HTTP ${legacy_code}) — expected; RWE uses claude.ai Gmail connector"
 else
-  warn "gmail.mcp.claude.com returned HTTP ${legacy_code} (unexpected)"
+  note "gmail.mcp.claude.com returned HTTP ${legacy_code} — RWE does not use this endpoint regardless"
 fi
 
 phase "NotebookLM subprocess (uvx)"
@@ -270,52 +280,84 @@ fi
 if [[ "${LEVEL}" == "live" ]]; then
     phase "Headless Gmail tool probe (claude -p + ToolSearch)"
     GMAIL_DEBUG="${ARTIFACT_DIR}/probe-gmail-tools.debug.log"
-    GMAIL_PROMPT='This is a connectivity test only. Use ToolSearch to find tools whose names contain "gmail" (case insensitive). List every matching tool name exactly as registered, one per line, no other text. If ToolSearch finds none, say exactly: NO_GMAIL_TOOLS.'
+    GMAIL_PROMPT='Connectivity test only. Use ToolSearch to find ALL tools whose names contain "gmail" (any case). List every matching tool name exactly as registered, one per line. Include mcp__claude_ai_Gmail__* tools if present. If ToolSearch finds none, say exactly: NO_GMAIL_TOOLS.'
     run_claude_probe "probe-gmail-tools" "${GMAIL_PROMPT}" "${GMAIL_DEBUG}" 180 || true
 
-    python3 - "${GMAIL_DEBUG}" "${ARTIFACT_DIR}/probe-gmail-tools.stdout" <<'PY'
+    python3 - "${GMAIL_DEBUG}" "${ARTIFACT_DIR}/probe-gmail-tools.stdout" "${ARTIFACT_DIR}/claude-version.txt" <<'PY'
 import re, sys
 from pathlib import Path
 
 debug = Path(sys.argv[1])
 stdout = Path(sys.argv[2])
+ver_file = Path(sys.argv[3])
 text = ""
 if debug.is_file():
     text += debug.read_text(encoding="utf-8", errors="replace")
 if stdout.is_file():
     text += "\n" + stdout.read_text(encoding="utf-8", errors="replace")
 
-tools = sorted(set(re.findall(r"mcp__gmail__\w+", text, re.I)))
+patterns = [
+    r"mcp__claude_ai_Gmail__\w+",
+    r"mcp__claude_ai_[A-Za-z_]+__\w+",
+    r"mcp__gmail__\w+",
+    r"mcp__Gmail__\w+",
+    r"\bgmail_search_messages\b",
+    r"\bgmail_read_message\b",
+    r"\bgmail_list_messages\b",
+    r"\bsearch_threads\b",
+    r"\bget_thread\b",
+]
+tools = sorted({m for pat in patterns for m in re.findall(pat, text, re.I)})
+
+claudeai_lines = [ln for ln in text.splitlines() if "claudeai-mcp" in ln.lower() or "claude_ai" in ln.lower()][:8]
+scope_lines = [ln for ln in text.splitlines() if "user:mcp_servers" in ln.lower() or "isprintmode" in ln.lower()][:5]
 deferred = [ln for ln in text.splitlines() if "deferred" in ln.lower() and "gmail" in ln.lower()]
-errors = [ln for ln in text.splitlines() if re.search(r"gmail.*(not available|failed|401|error)", ln, re.I)]
+
+ver = ver_file.read_text(encoding="utf-8", errors="replace") if ver_file.is_file() else ""
+ver_m = re.search(r"(\d+\.\d+\.\d+)", ver)
+ver_t = tuple(int(x) for x in ver_m.group(1).split(".")) if ver_m else (0, 0, 0)
 
 print("Gmail tool scan:")
 if tools:
-    print(f"  OK   Found tool IDs in logs/output: {', '.join(tools[:12])}")
+    print(f"  OK   Found: {', '.join(tools[:15])}")
 else:
-    print("  FAIL No mcp__gmail__* tools in probe output/debug log")
+    print("  FAIL No Gmail-related tools in probe output/debug log")
 if "NO_GMAIL_TOOLS" in text:
     print("  FAIL Model reported NO_GMAIL_TOOLS")
+if ver_t and ver_t < (2, 1, 180):
+    print(f"  FAIL Claude Code {ver_m.group(1)} — claude.ai Gmail often missing in -p; upgrade: claude install")
+if claudeai_lines:
+    print("  INFO claudeai-mcp debug (sample):")
+    for ln in claudeai_lines:
+        print(f"    {ln[:160]}")
+if scope_lines:
+    print("  INFO scope/print-mode debug (sample):")
+    for ln in scope_lines:
+        print(f"    {ln[:160]}")
 if deferred:
     print("  INFO deferred-tool lines (sample):")
     for ln in deferred[:5]:
         print(f"    {ln[:140]}")
-if errors:
-    print("  FAIL Gmail error lines:")
-    for ln in errors[:5]:
-        print(f"    {ln[:140]}")
-raise SystemExit(0 if tools and "NO_GMAIL_TOOLS" not in text else 1)
+
+ok = bool(tools) and "NO_GMAIL_TOOLS" not in text and (not ver_t or ver_t >= (2, 1, 180))
+raise SystemExit(0 if ok else 1)
 PY
     gmail_scan=$?
-    [[ "${gmail_scan}" -eq 0 ]] && ok "Gmail tools visible in headless probe" \
-      || bad "Gmail tools NOT visible in headless probe — this matches catch-up failures"
+    if [[ "${gmail_scan}" -ne 0 ]]; then
+      bad "Gmail tools NOT visible in headless probe"
+      note "claude.ai Gmail shows Connected in 'claude mcp list' but often does NOT load in claude -p on 2.1.87"
+      note "Fix: claude install  (target 2.1.180+) then re-run this check"
+      note "Also: claude mcp remove gmail && claude mcp add --transport http --scope user gmail https://gmailmcp.googleapis.com/mcp/v1"
+    else
+      ok "Gmail tools visible in headless probe"
+    fi
 
     phase "Headless Gmail search probe (optional live query)"
     SEARCH_DEBUG="${ARTIFACT_DIR}/probe-gmail-search.debug.log"
     gmail_after="$(echo "${PROBE_DATE}" | tr '-' '/')"
     gmail_next="$(date -j -v+1d -f "%Y-%m-%d" "${PROBE_DATE}" +%F 2>/dev/null || date -d "${PROBE_DATE} +1 day" +%F)"
     gmail_before="$(echo "${gmail_next}" | tr '-' '/')"
-    SEARCH_PROMPT="Connectivity test only. Call gmail_search_messages with q='label:newsletter/news after:${gmail_after} before:${gmail_before}' and reply with only the integer count of messages returned, nothing else."
+    SEARCH_PROMPT="Connectivity test only. Use ToolSearch to find a Gmail search tool, then search with query 'label:newsletter/news after:${gmail_after} before:${gmail_before}'. Reply with only the integer count of messages/threads returned, nothing else."
     if run_claude_probe "probe-gmail-search" "${SEARCH_PROMPT}" "${SEARCH_DEBUG}" 240; then
       ok "Gmail search probe completed for ${PROBE_DATE}"
       head -5 "${ARTIFACT_DIR}/probe-gmail-search.stdout" 2>/dev/null | while read -r line; do
@@ -344,9 +386,11 @@ log "Failures: ${ISSUES}  Warnings: ${WARNS}"
 if [[ "${ISSUES}" -gt 0 ]]; then
   log ""
   log "Common fixes:"
+  log "  claude install                    # upgrade to 2.1.180+ (Gmail in -p broken on 2.1.87)"
   log "  claude /login"
   log "  Claude Settings → Connectors → enable Gmail (claude.ai Gmail / gmailmcp.googleapis.com)"
-  log "  claude mcp remove gmail   # remove broken legacy gmail.mcp.claude.com registration"
+  log "  claude mcp remove gmail"
+  log "  claude mcp add --transport http --scope user gmail https://gmailmcp.googleapis.com/mcp/v1"
   log "  nlm login"
   log "  Re-run: bin/rwe-connectivity-check.sh --live --verbose"
   exit 1

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -150,9 +150,10 @@ else
 fi
 
 phase "Toolchain"
-if command -v claude >/dev/null 2>&1; then
-  ok "claude: $(command -v claude)"
-  claude --version 2>&1 | head -1 | tee "${ARTIFACT_DIR}/claude-version.txt" | while read -r line; do
+if command -v claude >/dev/null 2>&1 || [[ -n "$(rwe_claude_bin 2>/dev/null || true)" ]]; then
+  claude_bin="$(rwe_claude_bin)"
+  ok "claude: ${claude_bin}"
+  "${claude_bin}" --version 2>&1 | head -1 | tee "${ARTIFACT_DIR}/claude-version.txt" | while read -r line; do
     ok "claude version: ${line}"
   done
   if command -v which >/dev/null 2>&1; then
@@ -284,6 +285,19 @@ if command -v nlm >/dev/null 2>&1; then
   else
     warn "nlm login --check failed — run: nlm login (see ${ARTIFACT_DIR}/nlm-login-check.txt)"
   fi
+fi
+
+phase "Headless MCP server probe (claude -p)"
+MCP_LIST_DEBUG="${ARTIFACT_DIR}/probe-mcp-list.debug.log"
+MCP_PROMPT='Connectivity test only. List every MCP server name available in this session (e.g. Gmail, NotebookLM, Google Calendar). One name per line. If Gmail is missing, say exactly: GMAIL_MISSING.'
+run_claude_probe "probe-mcp-list" "${MCP_PROMPT}" "${MCP_LIST_DEBUG}" 120 || true
+if [[ -f "${ARTIFACT_DIR}/probe-mcp-list.stdout" ]] && grep -qi 'GMAIL_MISSING\|no gmail\|gmail is missing' "${ARTIFACT_DIR}/probe-mcp-list.stdout"; then
+  bad "Gmail MCP not loaded in headless session (other connectors may still work)"
+  note "Fix: claude mcp remove gmail; claude mcp add --transport http --scope user gmail https://gmailmcp.googleapis.com/mcp/v1"
+  note "Then in interactive claude: claude mcp login gmail  (or /mcp → gmail → Authenticate)"
+  note "Also verify claude.ai Settings → Connectors → Gmail is connected"
+elif [[ -f "${ARTIFACT_DIR}/probe-mcp-list.stdout" ]] && grep -qi 'gmail' "${ARTIFACT_DIR}/probe-mcp-list.stdout"; then
+  ok "Gmail appears in headless MCP server list"
 fi
 
 if [[ "${LEVEL}" != "quick" ]]; then

--- a/bin/rwe-connectivity-check.sh
+++ b/bin/rwe-connectivity-check.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# End-to-end connectivity checks for reading-with-ears headless runs (rwe-catchup,
+# rwe-run, rwe-weekly-audio). Mirrors the exact claude -p flags those scripts use.
+#
+# Usage:
+#   rwe-connectivity-check.sh              # standard: toolchain + auth + MCP registry
+#   rwe-connectivity-check.sh --live       # + headless claude -p probes (OAuth, Gmail tools)
+#   rwe-connectivity-check.sh --deep       # + full debug-log analysis + optional --doctor
+#   rwe-connectivity-check.sh --quick      # skip claude -p probes
+#   rwe-connectivity-check.sh --verbose    # extra detail
+#   rwe-connectivity-check.sh --date 2026-06-23   # Gmail probe date (default: yesterday)
+#
+# Artifacts: ~/logs/reading-with-ears/connectivity-<timestamp>/
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${HERE}/rwe-common.sh"
+
+LEVEL="standard"
+VERBOSE=0
+RUN_DOCTOR=0
+PROBE_DATE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quick)    LEVEL="quick"; shift ;;
+    --standard) LEVEL="standard"; shift ;;
+    --live)     LEVEL="live"; shift ;;
+    --deep)     LEVEL="deep"; shift ;;
+    --verbose|-v) VERBOSE=1; shift ;;
+    --doctor)   RUN_DOCTOR=1; shift ;;
+    --date)     PROBE_DATE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ "${LEVEL}" == "deep" ]] && LEVEL="live" && RUN_DOCTOR=1
+
+REPO_ROOT="$(rwe_repo_root "${HERE}")" || exit 1
+RWE_ROOT="${REPO_ROOT}/reading-with-ears"
+MCP_CONFIG="${RWE_ROOT}/automation/mcp-headless.json"
+SKILL_FILE="${RWE_ROOT}/skills/user/reading-list-builder/SKILL.md"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+
+if [[ -z "${PROBE_DATE}" ]]; then
+  PROBE_DATE="$(date -v-1d +%F 2>/dev/null || date -d 'yesterday' +%F)"
+fi
+
+STAMP="$(date +%Y%m%dT%H%M%S)"
+ARTIFACT_DIR="${HOME}/logs/reading-with-ears/connectivity-${STAMP}"
+mkdir -p "${ARTIFACT_DIR}"
+
+ISSUES=0
+WARNS=0
+STEP=0
+
+log() { echo "$*"; echo "$*" >> "${ARTIFACT_DIR}/summary.log"; }
+ok()  { log "  OK   $*"; }
+warn(){ log "  WARN $*"; WARNS=$((WARNS + 1)); }
+bad() { log "  FAIL $*"; ISSUES=$((ISSUES + 1)); }
+phase() {
+  STEP=$((STEP + 1))
+  log ""
+  log "=== [${STEP}] $* ==="
+}
+
+verbose_file() {
+  local label="$1" path="$2"
+  [[ "${VERBOSE}" -eq 1 && -f "${path}" ]] && log "  (${label}: ${path})"
+}
+
+rwe_claude_headless_cmd() {
+  # Same flags as bin/rwe-catchup.sh — keep in sync.
+  env -u ANTHROPIC_API_KEY claude -p \
+    --permission-mode bypassPermissions \
+    --strict-mcp-config \
+    --mcp-config "${MCP_CONFIG}" \
+    --add-dir "${RWE_ROOT}" \
+    "$@"
+}
+
+run_claude_probe() {
+  local name="$1" prompt="$2" debug_file="$3" timeout_sec="${4:-180}"
+  local out_file="${ARTIFACT_DIR}/${name}.stdout"
+  local err_file="${ARTIFACT_DIR}/${name}.stderr"
+  log "  Running headless probe: ${name} (timeout ${timeout_sec}s)…"
+  log "  debug → ${debug_file}"
+
+  # macOS lacks GNU timeout; use background waiter.
+  (
+    echo "${prompt}" | rwe_claude_headless_cmd \
+      --debug \
+      --debug-file "${debug_file}" \
+      >"${out_file}" 2>"${err_file}"
+  ) &
+  local pid=$!
+  local waited=0
+  while kill -0 "${pid}" 2>/dev/null; do
+    if [[ "${waited}" -ge "${timeout_sec}" ]]; then
+      kill "${pid}" 2>/dev/null || true
+      wait "${pid}" 2>/dev/null || true
+      bad "${name}: timed out after ${timeout_sec}s"
+      verbose_file "stdout" "${out_file}"
+      verbose_file "stderr" "${err_file}"
+      return 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  wait "${pid}" || true
+
+  verbose_file "stdout" "${out_file}"
+  verbose_file "stderr" "${err_file}"
+
+  local combined="${out_file}.combined"
+  { echo "=== stdout ==="; cat "${out_file}" 2>/dev/null || true
+    echo "=== stderr ==="; cat "${err_file}" 2>/dev/null || true
+  } >"${combined}"
+
+  if grep -qiE 'not logged in|please run /login|invalid api key' "${combined}"; then
+    bad "${name}: Claude auth failure — see ${combined}"
+    grep -iE 'not logged in|please run /login|invalid api key' "${combined}" | head -5 | while read -r line; do
+      log "    ${line}"
+    done
+    return 1
+  fi
+  if grep -qiE 'gmail_search_messages|gmail_read_message|mcp__gmail__' "${combined}"; then
+    ok "${name}: Gmail MCP tools referenced in output"
+  fi
+  if grep -qiE 'not available as callable tools|do not appear in the deferred tools|blocks step 1' "${combined}"; then
+    bad "${name}: Gmail tools not loaded in headless session — see ${combined}"
+    return 1
+  fi
+  return 0
+}
+
+phase "Repo layout"
+if [[ -f "${SKILL_FILE}" ]]; then
+  ok "Skill present: ${SKILL_FILE}"
+else
+  bad "Missing skill: ${SKILL_FILE}"
+fi
+if [[ -f "${MCP_CONFIG}" ]]; then
+  ok "MCP config: ${MCP_CONFIG}"
+  cp "${MCP_CONFIG}" "${ARTIFACT_DIR}/mcp-headless.json"
+else
+  bad "Missing MCP config: ${MCP_CONFIG}"
+fi
+
+phase "Toolchain"
+for cmd in claude python3 uvx curl jq; do
+  if command -v "${cmd}" >/dev/null 2>&1; then
+    ok "${cmd}: $(command -v "${cmd}")"
+  else
+    bad "${cmd}: not on PATH"
+  fi
+done
+if command -v claude >/dev/null 2>&1; then
+  claude --version 2>&1 | head -1 | tee "${ARTIFACT_DIR}/claude-version.txt" | while read -r line; do
+    ok "claude version: ${line}"
+  done
+fi
+if command -v nlm >/dev/null 2>&1; then
+  ok "nlm: $(command -v nlm)"
+else
+  warn "nlm CLI not found (notebooklm-mcp-cli) — audio/notebook CLI steps may fail"
+fi
+
+phase "Claude auth (settings + OAuth)"
+if [[ -x "${_RWE_BIN_DIR}/rwe-auth-check.sh" ]]; then
+  if RWE_REPO="${REPO_ROOT}" "${_RWE_BIN_DIR}/rwe-auth-check.sh" --test-api \
+      >"${ARTIFACT_DIR}/auth-check.txt" 2>&1; then
+    ok "rwe-auth-check.sh: no settings-file blockers"
+    grep -E '^  [0-9]+\.|MISMATCH|blocker|WARN' "${ARTIFACT_DIR}/auth-check.txt" | head -20 >> "${ARTIFACT_DIR}/summary.log" || true
+  else
+    bad "rwe-auth-check.sh: blockers found — see ${ARTIFACT_DIR}/auth-check.txt"
+    tail -20 "${ARTIFACT_DIR}/auth-check.txt" | while read -r line; do log "    ${line}"; done
+  fi
+else
+  warn "rwe-auth-check.sh not found"
+fi
+
+phase "Claude OAuth credential files"
+found_cred=0
+for f in "${HOME}/.claude/.credentials.json" "${HOME}/.claude/credentials.json"; do
+  if [[ -f "${f}" ]]; then
+    ok "Found ${f}"
+    found_cred=1
+  fi
+done
+[[ "${found_cred}" -eq 0 ]] && warn "No ~/.claude/.credentials.json — run: claude /login"
+
+status_out="$(env -u ANTHROPIC_API_KEY claude /status 2>&1 || true)"
+printf '%s\n' "${status_out}" > "${ARTIFACT_DIR}/claude-status.txt"
+if echo "${status_out}" | grep -qiE 'not logged in|please run /login'; then
+  bad "claude /status: not logged in — run: claude /login"
+elif echo "${status_out}" | grep -qiE 'auth token|logged in|claude\.ai|subscription|max'; then
+  ok "claude /status: OAuth session appears active"
+else
+  warn "claude /status inconclusive — see ${ARTIFACT_DIR}/claude-status.txt"
+  [[ "${VERBOSE}" -eq 1 ]] && head -15 "${ARTIFACT_DIR}/claude-status.txt" | while read -r line; do log "    ${line}"; done
+fi
+
+phase "MCP registry (claude mcp list)"
+if command -v claude >/dev/null 2>&1; then
+  claude mcp list 2>&1 | tee "${ARTIFACT_DIR}/mcp-list.txt" || true
+  if grep -qi 'gmail' "${ARTIFACT_DIR}/mcp-list.txt"; then
+    if grep -qiE 'gmail\.mcp\.claude\.com|claude\.ai Gmail' "${ARTIFACT_DIR}/mcp-list.txt"; then
+      ok "Full Gmail MCP listed (claude.ai / gmail.mcp.claude.com)"
+    else
+      warn "gmail entry found but may not be full Gmail MCP — check for gmail-send (send-only)"
+      grep -i gmail "${ARTIFACT_DIR}/mcp-list.txt" | while read -r line; do log "    ${line}"; done
+    fi
+  else
+    bad "Gmail MCP not in claude mcp list — run: claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp"
+  fi
+  if grep -qi 'notebooklm\|nlm' "${ARTIFACT_DIR}/mcp-list.txt"; then
+    ok "NotebookLM-related MCP listed"
+  else
+    warn "NotebookLM not in claude mcp list (headless uses uvx via mcp-headless.json — may still work)"
+  fi
+  if grep -qi 'codex' "${ARTIFACT_DIR}/mcp-list.txt"; then
+    warn "codex MCP registered — unrelated to RWE; may trigger macOS malware block on session start"
+  fi
+else
+  bad "claude CLI missing — cannot list MCP servers"
+fi
+
+phase "Network reachability"
+if curl -sS -o /dev/null -w "%{http_code}" --max-time 15 \
+    "https://gmail.mcp.claude.com/mcp" >"${ARTIFACT_DIR}/gmail-mcp-http.txt" 2>&1; then
+  code="$(cat "${ARTIFACT_DIR}/gmail-mcp-http.txt")"
+  ok "gmail.mcp.claude.com reachable (HTTP ${code})"
+else
+  warn "Could not reach gmail.mcp.claude.com — see ${ARTIFACT_DIR}/gmail-mcp-http.txt"
+fi
+
+phase "NotebookLM subprocess (uvx)"
+if command -v uvx >/dev/null 2>&1; then
+  if uvx --from notebooklm-mcp-cli notebooklm-mcp --help \
+      >"${ARTIFACT_DIR}/notebooklm-mcp-help.txt" 2>&1; then
+    ok "uvx notebooklm-mcp starts"
+  else
+    bad "uvx notebooklm-mcp failed — see ${ARTIFACT_DIR}/notebooklm-mcp-help.txt"
+  fi
+fi
+if command -v nlm >/dev/null 2>&1; then
+  if nlm login --check >"${ARTIFACT_DIR}/nlm-login-check.txt" 2>&1; then
+    ok "nlm login --check passed"
+  else
+    warn "nlm login --check failed — run: nlm login (see ${ARTIFACT_DIR}/nlm-login-check.txt)"
+  fi
+fi
+
+if [[ "${LEVEL}" != "quick" ]]; then
+  phase "Headless OAuth probe (claude -p, same flags as rwe-catchup)"
+  OAUTH_DEBUG="${ARTIFACT_DIR}/probe-oauth.debug.log"
+  OAUTH_PROMPT='Reply with exactly the single word PONG and nothing else. Do not use any tools.'
+  if run_claude_probe "probe-oauth" "${OAUTH_PROMPT}" "${OAUTH_DEBUG}" 120; then
+    if grep -qi '^PONG$' "${ARTIFACT_DIR}/probe-oauth.stdout" 2>/dev/null; then
+      ok "OAuth probe: model responded PONG"
+    else
+      warn "OAuth probe: no PONG in stdout — auth may still work; see ${ARTIFACT_DIR}/probe-oauth.stdout"
+    fi
+  fi
+fi
+
+if [[ "${LEVEL}" == "live" ]]; then
+    phase "Headless Gmail tool probe (claude -p + ToolSearch)"
+    GMAIL_DEBUG="${ARTIFACT_DIR}/probe-gmail-tools.debug.log"
+    GMAIL_PROMPT='This is a connectivity test only. Use ToolSearch to find tools whose names contain "gmail" (case insensitive). List every matching tool name exactly as registered, one per line, no other text. If ToolSearch finds none, say exactly: NO_GMAIL_TOOLS.'
+    run_claude_probe "probe-gmail-tools" "${GMAIL_PROMPT}" "${GMAIL_DEBUG}" 180 || true
+
+    python3 - "${GMAIL_DEBUG}" "${ARTIFACT_DIR}/probe-gmail-tools.stdout" <<'PY'
+import re, sys
+from pathlib import Path
+
+debug = Path(sys.argv[1])
+stdout = Path(sys.argv[2])
+text = ""
+if debug.is_file():
+    text += debug.read_text(encoding="utf-8", errors="replace")
+if stdout.is_file():
+    text += "\n" + stdout.read_text(encoding="utf-8", errors="replace")
+
+tools = sorted(set(re.findall(r"mcp__gmail__\w+", text, re.I)))
+deferred = [ln for ln in text.splitlines() if "deferred" in ln.lower() and "gmail" in ln.lower()]
+errors = [ln for ln in text.splitlines() if re.search(r"gmail.*(not available|failed|401|error)", ln, re.I)]
+
+print("Gmail tool scan:")
+if tools:
+    print(f"  OK   Found tool IDs in logs/output: {', '.join(tools[:12])}")
+else:
+    print("  FAIL No mcp__gmail__* tools in probe output/debug log")
+if "NO_GMAIL_TOOLS" in text:
+    print("  FAIL Model reported NO_GMAIL_TOOLS")
+if deferred:
+    print("  INFO deferred-tool lines (sample):")
+    for ln in deferred[:5]:
+        print(f"    {ln[:140]}")
+if errors:
+    print("  FAIL Gmail error lines:")
+    for ln in errors[:5]:
+        print(f"    {ln[:140]}")
+raise SystemExit(0 if tools and "NO_GMAIL_TOOLS" not in text else 1)
+PY
+    gmail_scan=$?
+    [[ "${gmail_scan}" -eq 0 ]] && ok "Gmail tools visible in headless probe" \
+      || bad "Gmail tools NOT visible in headless probe — this matches catch-up failures"
+
+    phase "Headless Gmail search probe (optional live query)"
+    SEARCH_DEBUG="${ARTIFACT_DIR}/probe-gmail-search.debug.log"
+    gmail_after="$(echo "${PROBE_DATE}" | tr '-' '/')"
+    gmail_next="$(date -j -v+1d -f "%Y-%m-%d" "${PROBE_DATE}" +%F 2>/dev/null || date -d "${PROBE_DATE} +1 day" +%F)"
+    gmail_before="$(echo "${gmail_next}" | tr '-' '/')"
+    SEARCH_PROMPT="Connectivity test only. Call gmail_search_messages with q='label:newsletter/news after:${gmail_after} before:${gmail_before}' and reply with only the integer count of messages returned, nothing else."
+    if run_claude_probe "probe-gmail-search" "${SEARCH_PROMPT}" "${SEARCH_DEBUG}" 240; then
+      ok "Gmail search probe completed for ${PROBE_DATE}"
+      head -5 "${ARTIFACT_DIR}/probe-gmail-search.stdout" 2>/dev/null | while read -r line; do
+        log "    stdout: ${line}"
+      done
+    else
+      bad "Gmail search probe failed for ${PROBE_DATE}"
+    fi
+fi
+
+if [[ "${LEVEL}" == "quick" ]]; then
+  log ""
+  log "=== Skipped headless claude -p probes (--quick) ==="
+  log "Re-run with --live to test OAuth + Gmail tools exactly as rwe-catchup does."
+fi
+
+if [[ "${RUN_DOCTOR}" -eq 1 ]] && command -v claude >/dev/null 2>&1; then
+  phase "claude doctor"
+  claude doctor 2>&1 | tee "${ARTIFACT_DIR}/claude-doctor.txt" || true
+fi
+
+log ""
+log "=== Summary ==="
+log "Artifacts: ${ARTIFACT_DIR}"
+log "Failures: ${ISSUES}  Warnings: ${WARNS}"
+if [[ "${ISSUES}" -gt 0 ]]; then
+  log ""
+  log "Common fixes:"
+  log "  claude /login"
+  log "  claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp"
+  log "  Open interactive claude once and approve Gmail connector OAuth"
+  log "  nlm login"
+  log "  Re-run: bin/rwe-connectivity-check.sh --live --verbose"
+  exit 1
+fi
+log "All required connectivity checks passed."
+exit 0

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -56,6 +56,12 @@ fi
 
 cd "${RWE_ROOT}"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
 CLAUDE_PROMPT=$'Read and follow skills/user/reading-list-builder/SKILL.md and run the DAILY FLOW (Steps 0-8) for today\'s date (use America/Los_Angeles for "today"). Do not run the weekly audio flow.'
 
 # Full claude debug capture (unfiltered — a category filter like "mcp" broke
@@ -82,11 +88,7 @@ if ! echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
   --debug \
   --debug-file "${DEBUG_FILE}"; then
   echo "ERROR: daily flow failed. MCP debug log: ${DEBUG_FILE}"
-  if [[ -f "${DEBUG_FILE}" ]]; then
-    echo "--- last 40 lines of MCP debug log ---"
-    tail -40 "${DEBUG_FILE}"
-    echo "--- end debug log excerpt ---"
-  fi
+  rwe_tail_debug_log "${DEBUG_FILE}" "MCP debug log"
   exit 1
 fi
 

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -45,6 +45,16 @@ echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") rwe-run ==="
 
 "${RWE_ROOT}/scripts/install-local.sh"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
+if ! rwe_check_claude_oauth; then
+  exit 1
+fi
+
 STATE_DIR="${HOME}/.local/state/reading-with-ears"
 mkdir -p "${STATE_DIR}"
 SENTINEL="${STATE_DIR}/done-$(date +%F)"
@@ -55,12 +65,6 @@ if [[ -f "${SENTINEL}" ]]; then
 fi
 
 cd "${RWE_ROOT}"
-
-if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
-  echo "Aborting — fix Claude auth blockers above, then re-run."
-  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
-  exit 1
-fi
 
 CLAUDE_PROMPT=$'Read and follow skills/user/reading-list-builder/SKILL.md and run the DAILY FLOW (Steps 0-8) for today\'s date (use America/Los_Angeles for "today"). Do not run the weekly audio flow.'
 

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -16,7 +16,7 @@ RWE_ROOT="${REPO_ROOT}/reading-with-ears"
 # $ZSH_VERSION, zsh-only syntax) is not valid here. For `claude` / `python3` / `nlm` on
 # PATH in launchd or cron, use ~/.profile, ~/.bash_profile, launchd EnvironmentVariables,
 # or conda `conda init bash` — not only ~/.zshrc.
-export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+# PATH: rwe-common.sh appends homebrew/local fallbacks; does not prepend them.
 
 if [[ "${1:-}" == "--catch-up" ]]; then
   shift

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -84,11 +84,7 @@ echo "ANTHROPIC_API_KEY in shell (first 20 chars): ${ANTHROPIC_API_KEY:0:20}${AN
 # shell has that var set (e.g. for a prior rwe-weekly/week_that_was.py run in the
 # same terminal), claude refuses to start with an auth-conflict error — scrub it
 # for this invocation regardless of what the parent shell has exported.
-if ! echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
-  --permission-mode bypassPermissions \
-  --strict-mcp-config \
-  --mcp-config "${RWE_ROOT}/automation/mcp-headless.json" \
-  --add-dir "${RWE_ROOT}" \
+if ! echo "${CLAUDE_PROMPT}" | rwe_claude_headless "${RWE_ROOT}" \
   --debug \
   --debug-file "${DEBUG_FILE}"; then
   echo "ERROR: daily flow failed. MCP debug log: ${DEBUG_FILE}"

--- a/bin/rwe-run.sh
+++ b/bin/rwe-run.sh
@@ -54,6 +54,7 @@ fi
 if ! rwe_check_claude_oauth; then
   exit 1
 fi
+rwe_claude_version_warn 2>&1 | while read -r line; do [[ -n "${line}" ]] && echo "${line}"; done
 
 STATE_DIR="${HOME}/.local/state/reading-with-ears"
 mkdir -p "${STATE_DIR}"

--- a/bin/rwe-weekly-audio
+++ b/bin/rwe-weekly-audio
@@ -74,11 +74,7 @@ echo "ANTHROPIC_API_KEY in shell (first 20 chars): ${ANTHROPIC_API_KEY:0:20}${AN
 # claude -p uses the claude.ai/Pro session, not ANTHROPIC_API_KEY — scrub it in
 # case the caller's shell has it set, which otherwise makes claude refuse to start
 # with an auth-conflict error.
-if ! echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
-  --permission-mode bypassPermissions \
-  --strict-mcp-config \
-  --mcp-config "${RWE_ROOT}/automation/mcp-headless.json" \
-  --add-dir "${RWE_ROOT}" \
+if ! echo "${CLAUDE_PROMPT}" | rwe_claude_headless "${RWE_ROOT}" \
   --debug \
   --debug-file "${DEBUG_FILE}"; then
   echo "ERROR: weekly audio flow failed. MCP debug log: ${DEBUG_FILE}"

--- a/bin/rwe-weekly-audio
+++ b/bin/rwe-weekly-audio
@@ -53,6 +53,10 @@ if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
   exit 1
 fi
 
+if ! rwe_check_claude_oauth; then
+  exit 1
+fi
+
 CLAUDE_PROMPT="Read and follow skills/user/reading-list-builder/SKILL.md and run the WEEKLY AUDIO FLOW (Steps W1-W4) for ISO week ${WEEK_ARG}. Do not run the daily flow."
 
 # Full claude debug capture (unfiltered — a category filter like "mcp" broke

--- a/bin/rwe-weekly-audio
+++ b/bin/rwe-weekly-audio
@@ -15,7 +15,7 @@ REPO_ROOT="$(rwe_repo_root "${HERE}")"
 RWE_ROOT="${REPO_ROOT}/reading-with-ears"
 
 # Do not source ~/.zshrc — see note in rwe-run.sh.
-export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-}"
+# PATH: rwe-common.sh appends homebrew/local fallbacks; does not prepend them.
 
 SKILL_VERSION_REQUIRED="3.0"
 SKILL_FILE="${RWE_ROOT}/skills/user/reading-list-builder/SKILL.md"

--- a/bin/rwe-weekly-audio
+++ b/bin/rwe-weekly-audio
@@ -47,6 +47,12 @@ echo "=== $(date "+%Y-%m-%dT%H:%M:%S%z") rwe-weekly-audio week=${WEEK_ARG} ==="
 
 cd "${RWE_ROOT}"
 
+if ! rwe_audit_claude_auth "${REPO_ROOT}"; then
+  echo "Aborting — fix Claude auth blockers above, then re-run."
+  echo "Run: bin/rwe-auth-check.sh --test-api --doctor"
+  exit 1
+fi
+
 CLAUDE_PROMPT="Read and follow skills/user/reading-list-builder/SKILL.md and run the WEEKLY AUDIO FLOW (Steps W1-W4) for ISO week ${WEEK_ARG}. Do not run the daily flow."
 
 # Full claude debug capture (unfiltered — a category filter like "mcp" broke
@@ -72,11 +78,7 @@ if ! echo "${CLAUDE_PROMPT}" | env -u ANTHROPIC_API_KEY claude -p \
   --debug \
   --debug-file "${DEBUG_FILE}"; then
   echo "ERROR: weekly audio flow failed. MCP debug log: ${DEBUG_FILE}"
-  if [[ -f "${DEBUG_FILE}" ]]; then
-    echo "--- last 40 lines of MCP debug log ---"
-    tail -40 "${DEBUG_FILE}"
-    echo "--- end debug log excerpt ---"
-  fi
+  rwe_tail_debug_log "${DEBUG_FILE}" "MCP debug log"
   exit 1
 fi
 

--- a/reading-with-ears/automation/mcp-headless.json
+++ b/reading-with-ears/automation/mcp-headless.json
@@ -1,9 +1,5 @@
 {
   "mcpServers": {
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
-    },
     "notebooklm": {
       "type": "stdio",
       "command": "uvx",

--- a/reading-with-ears/automation/mcp-headless.json
+++ b/reading-with-ears/automation/mcp-headless.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "gmail": {
+      "type": "http",
+      "url": "https://gmailmcp.googleapis.com/mcp/v1"
+    },
     "notebooklm": {
       "type": "stdio",
       "command": "uvx",

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -77,6 +77,22 @@ Authenticate the `nlm` CLI:
 nlm login
 ```
 
+### Claude Code auth for headless runs (`rwe-run`, `rwe-catchup`, `rwe-weekly-audio`)
+
+These scripts invoke `claude -p` with your **claude.ai subscription (OAuth)**. They scrub
+`ANTHROPIC_API_KEY` from the shell, but Claude Code also reads keys from settings files —
+`~/.claude/settings.json` (global) and `~/.claude.json` (config) are **different files**.
+
+If catch-up fails immediately with `Invalid API key · Fix external API key`, run:
+
+```bash
+bin/rwe-auth-check.sh --test-api --doctor
+```
+
+Remove any `ANTHROPIC_API_KEY` from settings `env` blocks and any `apiKeyHelper` entries.
+That error is Claude Code auth, not Gmail or NotebookLM MCP (MCP failures appear as `[MCP]`
+lines in `~/logs/reading-with-ears/catchup-debug-*.log`).
+
 ---
 
 ## 4. Install shell wrappers

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -93,6 +93,10 @@ Remove any `ANTHROPIC_API_KEY` from settings `env` blocks and any `apiKeyHelper`
 That error is Claude Code auth, not Gmail or NotebookLM MCP (MCP failures appear as `[MCP]`
 lines in `~/logs/reading-with-ears/catchup-debug-*.log`).
 
+Headless runs also require an active **claude.ai OAuth session** (`claude /login`). The
+scripts scrub your shell API key with `env -u`; without OAuth you will see
+`Not logged in · Please run /login`.
+
 ---
 
 ## 4. Install shell wrappers

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -94,6 +94,21 @@ claude mcp remove gmail 2>/dev/null || true
 claude mcp add --transport http --scope user gmail https://gmailmcp.googleapis.com/mcp/v1
 ```
 
+**Headless auth:** claude.ai Connectors alone may not expose Gmail in `claude -p`
+(other connectors like Calendar may load without Gmail). Complete user-scoped login:
+
+```bash
+claude mcp login gmail
+```
+
+Or interactively: `claude` → `/mcp` → select **gmail** → **Authenticate**.
+
+Verify headless sees Gmail:
+
+```bash
+bin/rwe-connectivity-check.sh --live --verbose
+```
+
 **NotebookLM CLI:**
 
 ```bash

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -74,9 +74,25 @@ deprecated `gmail.mcp.claude.com` HTTP endpoint (404 as of 2026).
    claude mcp remove gmail   # only if it points at gmail.mcp.claude.com and shows Failed
    ```
 
-Headless runs (`rwe-catchup`, `rwe-run`) load **notebooklm** from
-`reading-with-ears/automation/mcp-headless.json` and rely on your **claude.ai Gmail**
-connector for mail tools. Do not use `--strict-mcp-config` — it blocks the connector.
+Headless runs (`rwe-catchup`, `rwe-run`) load **notebooklm + Gmail HTTP** from
+`reading-with-ears/automation/mcp-headless.json` and also honor **claude.ai Gmail**
+connectors when `ENABLE_CLAUDEAI_MCP_SERVERS=true` (set automatically by the scripts).
+
+**Claude Code version:** Gmail tools in `claude -p` require **2.1.180+**. On older versions
+(e.g. 2.1.87), `claude mcp list` shows Gmail as Connected but headless runs see zero tools.
+Upgrade:
+
+```bash
+claude install
+claude --version   # should be 2.1.180 or newer
+```
+
+Register the Google Gmail MCP endpoint (replaces deprecated `gmail.mcp.claude.com`):
+
+```bash
+claude mcp remove gmail 2>/dev/null || true
+claude mcp add --transport http --scope user gmail https://gmailmcp.googleapis.com/mcp/v1
+```
 
 **NotebookLM CLI:**
 

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -63,15 +63,22 @@ If you used the old names and paths:
 
 ## 3. MCP authentication
 
-Register the Gmail MCP at user scope so it works in non-interactive (`-p`) mode:
+**Gmail (read/search):** Enable the **claude.ai Gmail** connector — not `gmail-send`, not the
+deprecated `gmail.mcp.claude.com` HTTP endpoint (404 as of 2026).
 
-```bash
-claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp
-```
+1. Open Claude Code or claude.ai → **Settings → Connectors**
+2. Connect **Gmail** (`https://gmailmcp.googleapis.com/mcp/v1`) and complete OAuth
+3. Verify: `claude mcp list` should show `claude.ai Gmail: … ✓ Connected`
+4. Remove any broken legacy registration if present:
+   ```bash
+   claude mcp remove gmail   # only if it points at gmail.mcp.claude.com and shows Failed
+   ```
 
-Then open an interactive Claude Code session and authorize each connector via OAuth (browser flow, one-time per connector).
+Headless runs (`rwe-catchup`, `rwe-run`) load **notebooklm** from
+`reading-with-ears/automation/mcp-headless.json` and rely on your **claude.ai Gmail**
+connector for mail tools. Do not use `--strict-mcp-config` — it blocks the connector.
 
-Authenticate the `nlm` CLI:
+**NotebookLM CLI:**
 
 ```bash
 nlm login

--- a/reading-with-ears/docs/install.md
+++ b/reading-with-ears/docs/install.md
@@ -97,6 +97,15 @@ Headless runs also require an active **claude.ai OAuth session** (`claude /login
 scripts scrub your shell API key with `env -u`; without OAuth you will see
 `Not logged in · Please run /login`.
 
+**Full connectivity test** (toolchain, auth, MCP registry, headless Gmail probes):
+
+```bash
+bin/rwe-connectivity-check.sh --live --verbose
+# Artifacts: ~/logs/reading-with-ears/connectivity-<timestamp>/
+```
+
+Use `--quick` to skip slow `claude -p` probes; `--deep` adds `claude doctor`.
+
 ---
 
 ## 4. Install shell wrappers

--- a/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
+++ b/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
@@ -251,17 +251,17 @@ if feature_enabled mcp; then
 if ! have claude; then
   warn "Claude CLI not on PATH — cannot check or register Gmail MCP (enable claude feature or install)."
 else
-  if claude mcp list 2>/dev/null | grep -qi 'gmail'; then
-    ok "Gmail MCP registered (claude mcp list)"
-  else
-    warn "Gmail MCP not listed — run: claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp"
-    if [[ "${APPLY}" -eq 1 ]]; then
-      if claude mcp add --transport http --scope user gmail https://gmail.mcp.claude.com/mcp 2>/dev/null; then
-        ok "Registered Gmail MCP (complete OAuth in an interactive claude session if prompted)."
-      else
-        note "claude mcp add failed or already configured under another name — run manually (install.md §3)."
-      fi
+  if claude mcp list 2>/dev/null | grep -qiE 'claude\.ai Gmail|gmailmcp\.googleapis'; then
+    if claude mcp list 2>/dev/null | grep -i 'Gmail' | grep -qi 'Connected'; then
+      ok "claude.ai Gmail connector connected"
+    else
+      bad "Gmail connector listed but not connected — complete OAuth in Settings → Connectors"
     fi
+  else
+    bad "claude.ai Gmail connector not found — enable Gmail in Claude Settings → Connectors (see install.md §3)"
+  fi
+  if claude mcp list 2>/dev/null | grep -E 'gmail\.mcp\.claude\.com' | grep -qi 'Failed'; then
+    warn "Legacy gmail.mcp.claude.com registration failed (deprecated) — run: claude mcp remove gmail"
   fi
 fi
 fi

--- a/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
+++ b/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
@@ -227,7 +227,7 @@ fi
 if feature_enabled permissions; then
 bin_dir="${REPO_ROOT}/bin"
 if [[ -d "${bin_dir}" ]]; then
-  for x in rwe-common.sh rwe-run.sh rwe-publish rwe-catchup.sh rwe-auth-check.sh; do
+  for x in rwe-common.sh rwe-run.sh rwe-publish rwe-catchup.sh rwe-auth-check.sh rwe-connectivity-check.sh; do
     [[ -f "${bin_dir}/${x}" ]] || continue
     if [[ ! -x "${bin_dir}/${x}" ]]; then
       warn "${bin_dir}/${x} is not executable — fixing chmod +x"

--- a/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
+++ b/reading-with-ears/scripts/verify-reading-with-ears-setup.sh
@@ -149,6 +149,15 @@ fi
 if feature_enabled claude; then
 if have claude; then
   ok "claude CLI ($(claude --version 2>/dev/null | head -1 || echo present))"
+  auth_check="${REPO_ROOT}/bin/rwe-auth-check.sh"
+  if [[ -x "${auth_check}" ]]; then
+    if bash "${auth_check}" >/dev/null 2>&1; then
+      ok "Claude OAuth preflight (rwe-auth-check.sh) — no blockers"
+    else
+      bad "Claude auth blockers detected — run: bin/rwe-auth-check.sh --test-api --doctor"
+      note "Headless rwe-run / rwe-catchup need claude.ai OAuth, not ANTHROPIC_API_KEY in settings files."
+    fi
+  fi
 else
   bad "claude CLI not found (required for rwe-run.sh)"
   if [[ "${APPLY}" -eq 1 ]] && have npm; then
@@ -218,7 +227,7 @@ fi
 if feature_enabled permissions; then
 bin_dir="${REPO_ROOT}/bin"
 if [[ -d "${bin_dir}" ]]; then
-  for x in rwe-common.sh rwe-run.sh rwe-publish rwe-catchup.sh; do
+  for x in rwe-common.sh rwe-run.sh rwe-publish rwe-catchup.sh rwe-auth-check.sh; do
     [[ -f "${bin_dir}/${x}" ]] || continue
     if [[ ! -x "${bin_dir}/${x}" ]]; then
       warn "${bin_dir}/${x} is not executable — fixing chmod +x"

--- a/reading-with-ears/skills/user/reading-list-builder/SKILL.md
+++ b/reading-with-ears/skills/user/reading-list-builder/SKILL.md
@@ -77,13 +77,26 @@ If no feeds are enabled, report and stop.
 
 If no date is given, use today. For a range, use the earliest day as the start.
 
-Search each enabled feed's labels individually (one call per label):
+Search each enabled feed's labels individually (one call per label).
+
+**Gmail tool names vary by MCP source** — use ToolSearch if needed, then call whichever
+search tool is available:
+
+| Source | Typical search tool | Typical read tool |
+|--------|--------------------|--------------------|
+| claude.ai Gmail connector | `search_threads` | `get_thread` |
+| Legacy / local Gmail MCP | `gmail_search_messages` | `gmail_read_message` |
+| Some local MCP packages | `gmail_list_messages` | `gmail_read_message` |
+
+Query syntax is Gmail search (labels, `after:`, `before:`) regardless of tool name.
+
+Single-day catch-up example (adjust tool name to what ToolSearch finds):
 
 ```
-gmail_search_messages(q="label:<gmail_label> after:YYYY/MM/DD")
+search_threads(query="label:<gmail_label> after:YYYY/MM/DD before:YYYY/MM/DD+1")
 ```
 
-Single past date (catch-up): add a `before:` bound to scope exactly that day:
+Or legacy form:
 
 ```
 gmail_search_messages(q="label:<gmail_label> after:YYYY/MM/DD before:YYYY/MM/DD+1")
@@ -96,11 +109,9 @@ If zero emails found across all labels, tell user and stop.
 
 ## STEP 2: Fetch Full Email Content
 
-For each email returned, fetch the full message:
-
-```
-gmail_read_message(messageId=<id>)
-```
+For each email returned, fetch the full message using the read tool that matches
+your Gmail MCP (`get_thread`, `gmail_read_message`, etc.). Pass the message or
+thread ID from the search results.
 
 Fetch ALL emails before doing anything else. Keep tool calls front-loaded.
 Record the received date for each email (from message headers).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `bin/rwe-connectivity-check.sh` — layered diagnostics for reading-with-ears headless runs, with increasing depth:

| Level | What it tests |
|-------|----------------|
| `--quick` | Toolchain, auth settings, `claude mcp list`, network, notebooklm uvx (no `claude -p`) |
| default (`standard`) | Above + headless OAuth PONG probe (same flags as `rwe-catchup`) |
| `--live` | Above + Gmail ToolSearch probe + live `gmail_search_messages` for `--date` |
| `--deep` / `--doctor` | Above + `claude doctor` |

All runs write artifacts to `~/logs/reading-with-ears/connectivity-<timestamp>/` (debug logs, stdout, mcp-list, auth-check output).

`rwe-catchup.sh` failure message now points at this script.

## Run on laptop

```bash
git fetch && git checkout cursor/rwe-connectivity-check-001e
bin/rwe-connectivity-check.sh --live --verbose --date 2026-06-23
```

Paste the artifact dir path if Gmail tools probe fails — it reproduces the exact headless session catch-up uses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0289afc9-c134-42de-ac4b-2f98c446001e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0289afc9-c134-42de-ac4b-2f98c446001e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

