### PR TITLE
Add review-document skill (single-doc + doc-package modes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ A personal collection of Claude Code skills, analytics tooling, and reading/audi
 pipeline experiments. Skills live in `skills/` (repo-level) and
 `reading-with-ears/skills/` (reading pipeline specific).
 
+## Local environment
+
+- User's repos all live at `~/Documents/dev/<repo-name>` locally (e.g.
+  `~/Documents/dev/adventures-in-ai`, `~/Documents/dev/skill-map`). Use this
+  path when giving local checkout/install commands instead of a placeholder.
+
 ## Skills in this repo
 
 | Skill | Path | Install |
@@ -23,11 +29,28 @@ Claude Code picks them up automatically from that directory.
 
 ## review-document (most recently added)
 
-Full-lifecycle document reviewer: review → score against a six-axis rubric
-(`skills/user/review-document/reference/rubric.md`) → offer severity-tiered
-edits → apply only on confirmation. For written documents (reports, proposals,
-memos, READMEs, specs) — not source code (`redpen`) and not a Claude Agent
-Skill's own `SKILL.md` (`skill-doctor`, in the `dhk/skill-map` repo).
+Two-mode document reviewer: review → score → offer severity-tiered edits →
+apply only on confirmation.
+
+- **Mode A — single document** (`skills/user/review-document/reference/rubric.md`):
+  one report/proposal/memo/README/spec, scored on 6 axes.
+- **Mode B — doc package** (`skills/user/review-document/reference/doc-package-rubric.md`):
+  a whole repo's documentation surface, scored against 4 audience journeys
+  (encounter/understand/use/extend-maintain-develop) plus a hygiene pass. The
+  hygiene checks (duplicate canonical docs, stale committed artifacts, broken
+  links, missing index, drifted numbers) are derived directly from the
+  `dhk/skill-map` docs cleanup done in this session (see PR #15 there).
+
+Declares `allowed-tools: Read, Grep, Glob, Edit, Write` — Mode B needs Grep/Glob
+to survey a repo and Write to create a new index file if one is missing.
+
+Not for source code (`redpen`) or a Claude Agent Skill's own `SKILL.md`
+(`skill-doctor`, in `dhk/skill-map`).
+
+Recommended install: keep this repo as the source of truth and symlink into
+`~/.claude/skills/review-document` rather than copying, since it's
+general-purpose (useful outside this repo) — e.g.
+`ln -s ~/Documents/dev/adventures-in-ai/skills/user/review-document ~/.claude/skills/review-document`.
 
 ## run-analytics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,18 +14,24 @@ pipeline experiments. Skills live in `skills/` (repo-level) and
 
 ## Skills in this repo
 
-| Skill | Path | Install |
-|---|---|---|
-| `run-analytics` | `skills/user/run-analytics/` | see INSTALL.md |
-| `redpen` | `skills/redpen/` | see INSTALL.md |
-| `git-push-handoff` | `skills/user/git-push-handoff/` | manual copy |
-| `review-document` | `skills/user/review-document/` | manual copy |
-| `multi-model-review` | `reading-with-ears/skills/user/multi-model-review/` | manual copy |
-| `personal-podcast` | `reading-with-ears/skills/user/personal-podcast/` | manual copy |
-| `reading-list-builder` | `reading-with-ears/skills/user/reading-list-builder/` | manual copy |
+Every skill installs the same way: put its directory into
+`~/.claude/skills/<name>/`. Claude Code picks it up automatically — no
+restart needed. Symlink from this repo rather than copying, so there's one
+source of truth and no drift when the skill is updated:
 
-Skills are installed by copying their `SKILL.md` to `~/.claude/skills/<name>/SKILL.md`.
-Claude Code picks them up automatically from that directory.
+```bash
+ln -s ~/Documents/dev/adventures-in-ai/<path> ~/.claude/skills/<name>
+```
+
+| Skill | Path | Notes |
+|---|---|---|
+| `run-analytics` | `skills/user/run-analytics/` | Has its own INSTALL.md with a curl one-shot (installs without cloning the repo) |
+| `redpen` | `skills/redpen/` | Has its own INSTALL.md with a curl one-shot; `--tickets`/`--pr` require GitHub MCP connected |
+| `git-push-handoff` | `skills/user/git-push-handoff/` | — |
+| `review-document` | `skills/user/review-document/` | Must include `reference/` — SKILL.md links to it, symlinking the whole directory (not just SKILL.md) covers this |
+| `multi-model-review` | `reading-with-ears/skills/user/multi-model-review/` | Requires Codex registered as an MCP server (`claude mcp add codex -- npx codex mcp-server`) |
+| `personal-podcast` | `reading-with-ears/skills/user/personal-podcast/` | — |
+| `reading-list-builder` | `reading-with-ears/skills/user/reading-list-builder/` | — |
 
 ## review-document (most recently added)
 
@@ -46,11 +52,6 @@ to survey a repo and Write to create a new index file if one is missing.
 
 Not for source code (`redpen`) or a Claude Agent Skill's own `SKILL.md`
 (`skill-doctor`, in `dhk/skill-map`).
-
-Recommended install: keep this repo as the source of truth and symlink into
-`~/.claude/skills/review-document` rather than copying, since it's
-general-purpose (useful outside this repo) — e.g.
-`ln -s ~/Documents/dev/adventures-in-ai/skills/user/review-document ~/.claude/skills/review-document`.
 
 ## run-analytics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,20 @@ source of truth and no drift when the skill is updated:
 ln -s ~/Documents/dev/adventures-in-ai/<path> ~/.claude/skills/<name>
 ```
 
-| Skill | Path | Notes |
-|---|---|---|
-| `run-analytics` | `skills/user/run-analytics/` | Has its own INSTALL.md with a curl one-shot (installs without cloning the repo) |
-| `redpen` | `skills/redpen/` | Has its own INSTALL.md with a curl one-shot; `--tickets`/`--pr` require GitHub MCP connected |
-| `git-push-handoff` | `skills/user/git-push-handoff/` | — |
-| `review-document` | `skills/user/review-document/` | Must include `reference/` — SKILL.md links to it, symlinking the whole directory (not just SKILL.md) covers this |
-| `multi-model-review` | `reading-with-ears/skills/user/multi-model-review/` | Requires Codex registered as an MCP server (`claude mcp add codex -- npx codex mcp-server`) |
-| `personal-podcast` | `reading-with-ears/skills/user/personal-podcast/` | — |
-| `reading-list-builder` | `reading-with-ears/skills/user/reading-list-builder/` | — |
+| Skill | Path | Status | Notes |
+|---|---|---|---|
+| `run-analytics` | `skills/user/run-analytics/` | Merged via PR #19 (`440f36e`) — the only skill here built on a feature branch; `claude/run-analytics-meta-skill-b2mum2` still exists post-merge | Has its own INSTALL.md with a curl one-shot |
+| `redpen` | `skills/redpen/` | On `main`, direct commit (no PR), last touched 2026-06-14 | Has its own INSTALL.md with a curl one-shot; `--tickets`/`--pr` require GitHub MCP connected |
+| `git-push-handoff` | `skills/user/git-push-handoff/` | On `main`, direct commit (no PR), last touched 2026-03-29 | — |
+| `review-document` | `skills/user/review-document/` | **Open — PR #31, not yet merged** | Must include `reference/` — SKILL.md links to it, symlinking the whole directory (not just SKILL.md) covers this |
+| `multi-model-review` | `reading-with-ears/skills/user/multi-model-review/` | On `main`, direct commit (no PR), last touched 2026-04-05 | Requires Codex registered as an MCP server (`claude mcp add codex -- npx codex mcp-server`) |
+| `personal-podcast` | `reading-with-ears/skills/user/personal-podcast/` | On `main`, direct commit (no PR), last touched 2026-04-08 | — |
+| `reading-list-builder` | `reading-with-ears/skills/user/reading-list-builder/` | On `main`, direct commit (no PR), last touched 2026-05-20 | — |
+
+Most of these were committed straight to `main` in ad-hoc sessions, not via a
+feature branch — `run-analytics` is the exception, and `review-document` is
+still mid-PR. "Last touched" is the most recent commit that changed the
+skill's `SKILL.md`, not necessarily when it was first added.
 
 ## review-document (most recently added)
 
@@ -54,9 +59,6 @@ Not for source code (`redpen`) or a Claude Agent Skill's own `SKILL.md`
 (`skill-doctor`, in `dhk/skill-map`).
 
 ## run-analytics
-
-**Status:** Merged to main (PR #19, commit `440f36e`).
-**Branch:** `claude/run-analytics-meta-skill-b2mum2` — merged, feature branch still exists.
 
 ### What it does
 Two-mode meta-skill for analytics studies:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ pipeline experiments. Skills live in `skills/` (repo-level) and
 | `run-analytics` | `skills/user/run-analytics/` | see INSTALL.md |
 | `redpen` | `skills/redpen/` | see INSTALL.md |
 | `git-push-handoff` | `skills/user/git-push-handoff/` | manual copy |
+| `review-document` | `skills/user/review-document/` | manual copy |
 | `multi-model-review` | `reading-with-ears/skills/user/multi-model-review/` | manual copy |
 | `personal-podcast` | `reading-with-ears/skills/user/personal-podcast/` | manual copy |
 | `reading-list-builder` | `reading-with-ears/skills/user/reading-list-builder/` | manual copy |
@@ -20,7 +21,15 @@ pipeline experiments. Skills live in `skills/` (repo-level) and
 Skills are installed by copying their `SKILL.md` to `~/.claude/skills/<name>/SKILL.md`.
 Claude Code picks them up automatically from that directory.
 
-## run-analytics (most recently worked on)
+## review-document (most recently added)
+
+Full-lifecycle document reviewer: review → score against a six-axis rubric
+(`skills/user/review-document/reference/rubric.md`) → offer severity-tiered
+edits → apply only on confirmation. For written documents (reports, proposals,
+memos, READMEs, specs) — not source code (`redpen`) and not a Claude Agent
+Skill's own `SKILL.md` (`skill-doctor`, in the `dhk/skill-map` repo).
+
+## run-analytics
 
 **Status:** Merged to main (PR #19, commit `440f36e`).
 **Branch:** `claude/run-analytics-meta-skill-b2mum2` — merged, feature branch still exists.

--- a/skills/user/review-document/SKILL.md
+++ b/skills/user/review-document/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: review-document
+description: >
+  Reviews a written document — report, proposal, memo, blog post, README,
+  spec — scores it against a quality rubric, and offers specific edits to
+  apply on confirmation. Use when asked to review, critique, grade, or
+  improve the writing quality of a document. Not for reviewing source code
+  (use redpen) or a Claude Agent Skill's SKILL.md (use skill-doctor, in the
+  skill-map repo).
+---
+
+# Review Document
+
+Full lifecycle, one document at a time: **review → score → offer changes**.
+Never apply an edit without confirmation.
+
+## Step 0 — Intake
+
+- Identify what's being reviewed: a file path, or pasted text.
+- Identify document type + audience if not obvious from content/context
+  (report, proposal, README, blog post, memo, spec, email, handoff note...).
+  If genuinely ambiguous, ask ONE question covering both — don't guess quietly,
+  but don't ask if it's inferable (a PRD reads as a PRD).
+- Read `reference/rubric.md` — six axes, weighted per document type.
+
+## Step 1 — Review
+
+Read the whole document once before writing anything. Note, with line or
+section references:
+
+- Structural issues (missing sections, wrong order, buried lede)
+- Unsupported claims / logic gaps
+- Unclear or padded passages
+- Tone or terminology inconsistencies
+- Anything a reader would stumble on
+
+Cite specifics. "The intro is weak" is not a finding; "paragraph 2 promises a
+recommendation the doc never delivers" is.
+
+## Step 2 — Score
+
+Apply `reference/rubric.md`. Score each of the 6 axes (0–100), take the
+weighted overall for the document's type, assign a grade. Present as a
+compact table — axis, score, one-line reason — not paragraphs of hedging.
+
+Grades: A ≥85 ship it · B 70–84 solid, minor gaps · C 55–69 usable, needs a
+pass · D 40–54 significant rework · F <40 not ready.
+
+## Step 3 — Offer changes
+
+Group findings by severity — **critical** (breaks the doc's purpose) /
+**major** (weakens it materially) / **minor** (polish). Same three tiers on
+every finding. No padding, no "great work" filler.
+
+For each finding, give the actual suggested rewrite, not "make this clearer":
+
+> **[major] Section 3** — claims a 40% improvement with no source.
+> Fix: cite the benchmark, or soften to "in early testing" if unverified.
+
+## Step 4 — Confirm and apply
+
+Ask which to apply: all / critical+major only / none — never apply silently.
+
+- Reviewing a real file → apply via Edit, then re-state the score for what
+  changed.
+- Reviewing pasted text → return the revised document inline.
+
+## Behavior rules
+
+- Don't pad findings with praise — same policy as this repo's `redpen` skill,
+  for the same reason: this is a red pen, not a compliment sandwich.
+- Don't rewrite the whole document when a scoped edit will do.
+- If the document is a type the rubric doesn't cover well (poetry, legal
+  contracts, code comments), say so before scoring rather than force-fitting
+  a bad grade.

--- a/skills/user/review-document/SKILL.md
+++ b/skills/user/review-document/SKILL.md
@@ -124,8 +124,12 @@ directory (minor-to-major depending on size), broken internal links (minor).
 
 ### Step 4 — Confirm and apply
 
-Ask which to apply. Some doc-package fixes create a new file (an index)
-rather than edit an existing one — say so explicitly before doing it.
+Before asking, list every file this would touch, grouped by severity tier —
+and mark which are edits to an existing file vs. a new one (an index,
+typically). Then confirm per tier: all / critical+major only / none — same
+three-way choice as Mode A, but the user sees the full file list first, not
+just a count. A repo-wide batch is a bigger blast radius than Mode A's single
+document; one "yes" shouldn't hide how many files that covers.
 
 ## Output
 

--- a/skills/user/review-document/SKILL.md
+++ b/skills/user/review-document/SKILL.md
@@ -1,20 +1,39 @@
 ---
 name: review-document
 description: >
-  Reviews a written document — report, proposal, memo, blog post, README,
-  spec — scores it against a quality rubric, and offers specific edits to
-  apply on confirmation. Use when asked to review, critique, grade, or
-  improve the writing quality of a document. Not for reviewing source code
-  (use redpen) or a Claude Agent Skill's SKILL.md (use skill-doctor, in the
-  skill-map repo).
+  Reviews written documentation — a single document (report, proposal, memo,
+  README, spec) or a repo's whole doc package (everything someone needs to
+  encounter, understand, use, and extend/maintain/develop against a project)
+  — scores it against a rubric, and offers specific edits to apply on
+  confirmation. Use when asked to review, critique, grade, or improve a
+  document, or to audit a repo's documentation coverage. Not for reviewing
+  source code (use redpen) or a Claude Agent Skill's SKILL.md (use
+  skill-doctor, in the skill-map repo).
+license: MIT
+allowed-tools: Read, Grep, Glob, Edit, Write
 ---
 
 # Review Document
 
-Full lifecycle, one document at a time: **review → score → offer changes**.
-Never apply an edit without confirmation.
+Two modes, same lifecycle: **review → score → offer changes → confirm &
+apply**. Never apply an edit — or create a file — without confirmation.
 
-## Step 0 — Intake
+- **Mode A — Single document**: one report, proposal, memo, README, or spec.
+- **Mode B — Doc package**: every doc a repo presents to someone who needs to
+  encounter, understand, use, or extend/maintain/develop against it.
+
+## Data handling
+
+Either mode may operate on documents containing PII, financial figures, or
+other sensitive content the user pastes in or points at. Never echo sensitive
+values (names, SSNs, account numbers, credentials) verbatim in the findings
+report — reference them by location ("paragraph 3, second sentence") instead
+of quoting them. If a document appears to contain regulated data (PHI/PII/
+financial), say so before scoring rather than silently processing it.
+
+## Mode A — Single document
+
+### Step 0 — Intake
 
 - Identify what's being reviewed: a file path, or pasted text.
 - Identify document type + audience if not obvious from content/context
@@ -23,7 +42,7 @@ Never apply an edit without confirmation.
   but don't ask if it's inferable (a PRD reads as a PRD).
 - Read `reference/rubric.md` — six axes, weighted per document type.
 
-## Step 1 — Review
+### Step 1 — Review
 
 Read the whole document once before writing anything. Note, with line or
 section references:
@@ -37,7 +56,7 @@ section references:
 Cite specifics. "The intro is weak" is not a finding; "paragraph 2 promises a
 recommendation the doc never delivers" is.
 
-## Step 2 — Score
+### Step 2 — Score
 
 Apply `reference/rubric.md`. Score each of the 6 axes (0–100), take the
 weighted overall for the document's type, assign a grade. Present as a
@@ -46,7 +65,7 @@ compact table — axis, score, one-line reason — not paragraphs of hedging.
 Grades: A ≥85 ship it · B 70–84 solid, minor gaps · C 55–69 usable, needs a
 pass · D 40–54 significant rework · F <40 not ready.
 
-## Step 3 — Offer changes
+### Step 3 — Offer changes
 
 Group findings by severity — **critical** (breaks the doc's purpose) /
 **major** (weakens it materially) / **minor** (polish). Same three tiers on
@@ -57,7 +76,7 @@ For each finding, give the actual suggested rewrite, not "make this clearer":
 > **[major] Section 3** — claims a 40% improvement with no source.
 > Fix: cite the benchmark, or soften to "in early testing" if unverified.
 
-## Step 4 — Confirm and apply
+### Step 4 — Confirm and apply
 
 Ask which to apply: all / critical+major only / none — never apply silently.
 
@@ -65,11 +84,60 @@ Ask which to apply: all / critical+major only / none — never apply silently.
   changed.
 - Reviewing pasted text → return the revised document inline.
 
+## Mode B — Doc package
+
+Reviews everything a repo presents across four audience journeys:
+**encounter** (what is this, why does it matter — in under a minute),
+**understand** (how/why it works), **use** (install, run, consume it),
+**extend/maintain/develop** (contribute, modify, run it as a developer).
+
+### Step 0 — Intake
+
+- Identify the target: a GitHub `owner/repo` or a local path.
+- Collect the doc surface: README, CONTRIBUTING, INSTALL/SETUP, CHANGELOG,
+  LICENSE, the `docs/` tree (recursively), CLAUDE.md/AGENTS.md, issue/PR
+  templates, ADRs, any index file already inside `docs/`.
+- Read `reference/doc-package-rubric.md` — the four-journey checklist and the
+  hygiene checks.
+
+### Step 1 — Map
+
+For each file, note: which journey(s) it serves, and its hygiene status —
+current, stale (superseded but still committed), duplicate (two files
+claiming the same canonical content), or orphaned (nothing links to it, it
+links to nothing).
+
+### Step 2 — Score
+
+Per `reference/doc-package-rubric.md`: a completeness score per journey (does
+it have an adequate, current, non-duplicated entry point?) plus an overall
+hygiene score (dedup, staleness, broken links, navigability). Present as a
+table: journey, score, entry point(s), gap.
+
+### Step 3 — Offer changes
+
+Same severity tiers as Mode A. Typical findings: a journey with no entry
+point at all (critical), two files claiming to be the same canonical doc
+(major), a stale artifact still committed — a closed PR's review notes, an
+old session snapshot (major), a missing index when there are 10+ docs in one
+directory (minor-to-major depending on size), broken internal links (minor).
+
+### Step 4 — Confirm and apply
+
+Ask which to apply. Some doc-package fixes create a new file (an index)
+rather than edit an existing one — say so explicitly before doing it.
+
+## Output
+
+End with: the per-mode score table, findings grouped by severity with the
+proposed fix for each, which fixes were applied, and — Mode B only — a
+one-line per-journey verdict ("Use: solid. Extend: no entry point at all.").
+
 ## Behavior rules
 
 - Don't pad findings with praise — same policy as this repo's `redpen` skill,
   for the same reason: this is a red pen, not a compliment sandwich.
-- Don't rewrite the whole document when a scoped edit will do.
+- Don't rewrite the whole document (or repo) when a scoped edit will do.
 - If the document is a type the rubric doesn't cover well (poetry, legal
   contracts, code comments), say so before scoring rather than force-fitting
   a bad grade.

--- a/skills/user/review-document/reference/doc-package-rubric.md
+++ b/skills/user/review-document/reference/doc-package-rubric.md
@@ -1,0 +1,58 @@
+# Doc-Package Rubric
+
+Scopes to everything a repo's documentation presents to someone who needs to
+**encounter**, **understand**, **use**, or **extend/maintain/develop** the
+project. Four journey scores + one hygiene score, each 0–100.
+
+## The four journeys
+
+1. **Encounter** — a stranger with no context lands on the repo. Does the
+   README's first paragraph say what this is, why it matters, and who it's
+   for — in under a minute, no digging required?
+2. **Understand** — someone wants the shape of the system: architecture,
+   design rationale, key decisions and why they were made (not just what the
+   code does — a reader can already see that).
+3. **Use** — someone wants to install, run, or consume it: install steps,
+   a working example, API/CLI reference, troubleshooting for the obvious
+   failure modes.
+4. **Extend / maintain / develop** — someone wants to contribute or modify
+   it: a CONTRIBUTING guide, local dev setup, test/lint commands, where
+   things live, and — if decisions aren't obvious from the code — why they
+   were made that way.
+
+## Grades (per journey and overall)
+
+| Grade | Score | Meaning |
+|---|---|---|
+| A | ≥85 | A newcomer succeeds at this journey without asking a human |
+| B | 70–84 | Succeeds with minor friction |
+| C | 55–69 | Succeeds only by piecing together multiple files |
+| D | 40–54 | Likely gives up or asks a human |
+| F | <40 | No entry point exists |
+
+## Hygiene checks (apply across the whole doc surface, not per-journey)
+
+These aren't about any one file being badly written — they're about the
+*set* of docs working together. Checked in order of how often they show up:
+
+- **Duplicate/conflicting canonical docs** — two files claiming to define the
+  same spec/rubric/process, with no indication which one is current.
+- **Stale artifacts still committed** — closed-out PR review notes, one-off
+  session snapshots, superseded drafts. If it documented a decision that's
+  now resolved, it belongs in git history, not the working tree.
+- **Broken internal links** — a doc links to a file that doesn't exist
+  (renamed, deleted, or never actually created).
+- **No index when there are many docs** — a `docs/` directory with 10+ files
+  and no file telling a reader which is which, or which are auto-generated
+  vs. hand-written vs. planning material.
+- **Numbers that don't match the current state** — a headline stat quoted in
+  prose that's drifted from the generated source of truth (if one exists).
+
+## Common failure pattern
+
+The **Extend/maintain** journey is the one most often scored F — READMEs get
+written for the "encounter" and "use" journeys (they're what outside visitors
+see first) and CONTRIBUTING/dev-setup docs get skipped because the author
+already knows how to run their own project. Check this journey first; it's
+usually the cheapest to fix (a CONTRIBUTING.md with dev setup + test/lint
+commands) and the most commonly missing.

--- a/skills/user/review-document/reference/rubric.md
+++ b/skills/user/review-document/reference/rubric.md
@@ -1,0 +1,71 @@
+# Document Review Rubric
+
+Six axes, each 0–100, weighted per document type. Same grading philosophy as
+the rubric in `dhk/skill-map`: derived from what good documents in each genre
+actually do, not a generic writing-class checklist.
+
+## The six axes
+
+1. **Purpose & audience fit** — states what it's for and who it's for;
+   matches the reader's actual knowledge level.
+2. **Structure & flow** — logical order, scannable headings/sections, no
+   orphaned or redundant sections, right length for the job.
+3. **Argument & evidence** — claims are supported; no unearned leaps;
+   addresses the obvious counterargument where one exists.
+4. **Clarity & concision** — plain language, no unexplained jargon, no
+   padding, active voice by default.
+5. **Actionability / completeness** — reader knows what to do next, or the
+   doc delivers everything its own opening promised.
+6. **Tone & consistency** — one voice throughout, appropriate formality,
+   consistent terminology (doesn't call the same thing two names).
+
+## Grades
+
+| Grade | Score | Meaning |
+|---|---|---|
+| A | ≥85 | Ready to ship |
+| B | 70–84 | Solid, minor gaps |
+| C | 55–69 | Usable, needs a revision pass |
+| D | 40–54 | Significant rework |
+| F | <40 | Not ready |
+
+## Weighting by document type
+
+Default weight is even (1/6 each, ~16.7 points per axis). Adjust for these
+common types:
+
+| Type | Emphasize | De-emphasize |
+|---|---|---|
+| Business proposal / memo | Actionability (clear ask/decision), Structure | Tone |
+| Technical spec / PRD | Completeness, Argument & evidence (constraints, edge cases) | — |
+| Blog post / newsletter | Clarity, Tone (voice, hook) | Actionability |
+| README / how-to doc | Structure (scannable), Actionability (can the reader do the thing) | Argument & evidence |
+| Status update / handoff note | Actionability, Concision | Tone |
+
+If the document doesn't fit a listed type, use even weighting and say so in
+the report.
+
+## What "good" looks like per axis (calibration anchors)
+
+- **Purpose & audience fit, A-level** — the first paragraph tells you what
+  this is and who should read it, without a throat-clearing preamble.
+- **Structure, A-level** — you could skim just the headings and get the shape
+  of the argument.
+- **Argument & evidence, A-level** — every load-bearing claim has a number, a
+  citation, or an explicit "unverified — flag before publishing."
+- **Clarity, A-level** — a reader outside the immediate context could follow
+  it on one read.
+- **Actionability, A-level** — the reader's next step is stated, not implied.
+- **Tone, A-level** — reads like one person wrote it, even if several people
+  did.
+
+## Common defects (check these first — cheap to fix, high leverage)
+
+- Buried ask / no clear next step (actionability)
+- Claims with no source and no hedge ("this will save $2M" with nothing
+  behind it)
+- Section order that doesn't match how a reader actually needs the
+  information (context before ask, not the ask buried in paragraph 4)
+- Terminology drift — same concept, three different names across one
+  document
+- Padding — sentences that restate the previous sentence with more words


### PR DESCRIPTION
## Summary
- Adds `skills/user/review-document/SKILL.md` — two-mode document reviewer: review → score → offer severity-tiered edits → apply only on confirmation.
  - **Mode A — single document**: one report/proposal/memo/README/spec, scored on 6 axes (`reference/rubric.md`).
  - **Mode B — doc package**: a whole repo's documentation surface, scored against 4 audience journeys — encounter/understand/use/extend-maintain-develop — plus a hygiene pass (`reference/doc-package-rubric.md`). The hygiene checks (duplicate canonical docs, stale committed artifacts, broken links, missing index, drifted numbers) are derived directly from the `dhk/skill-map` docs cleanup done earlier this session.
- Ran `skill-doctor` (from `dhk/skill-map`) against this skill twice and applied its findings both times:
  - **Round 1** (B, ~84): added `license`, `allowed-tools: Read, Grep, Glob, Edit, Write`, a **Data handling** section (never echo PII/financial/regulated values verbatim), and a consolidated `## Output` section.
  - **Round 2**, after Mode B was added (A, ~90): tightened Mode B's confirm-and-apply gate — it now lists every file it would touch, grouped by severity tier, before asking, since a repo-wide batch has a much bigger blast radius than Mode A's single-document edit.
- Updates `CLAUDE.md`:
  - Adds `review-document` to the skill index, with a **Local environment** note (repos live at `~/Documents/dev/<repo>`).
  - Standardizes the skill table: one stated install method (symlink, not copy — avoids drift) instead of two inconsistent phrasings for the same action; a **Notes** column for what genuinely differs per skill (verified by reading each skill's files, not assumed); a **Status** column reflecting actual git history per skill (checked via `list_commits --path` — only `run-analytics` was built via a feature-branch PR, everything else is direct-to-`main`).

## Design notes
- Scoped explicitly to *written documents* — anti-trigger in the description rules out source code (`redpen`) and a Claude Agent Skill's own `SKILL.md` (`skill-doctor`, `dhk/skill-map`), so there's no overlap with existing tools.
- Two-mode structure mirrors the precedent `run-analytics` already sets in this repo (standard/discovery modes), rather than introducing a new pattern.

## Test plan
- [x] `skill-doctor` static-pass rubric re-verified against the final file content (not just described) before merge — frontmatter/triggering/disclosure/structure/safety all pass, no open safety or data blockers
- [x] Confirmed no other doc in this repo references the old single-value Install column format
- [ ] Try it locally: `ln -s ~/Documents/dev/adventures-in-ai/skills/user/review-document ~/.claude/skills/review-document` then run `/review-document` against a real doc, and against a repo for Mode B
