### PR TITLE
Document work-ledger usage tracking and the cross-session Drive ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,43 @@ NotebookLM notebooks → audio overview → Element.fm podcast. Config in
 `reading-with-ears/config/feeds.json`. Data store in
 `dhkondata/reading-db/`.
 
+## work-ledger usage tracking
+
+[`dhk/work-ledger`](https://github.com/dhk/work-ledger) watches Claude Code
+session transcripts (`~/.claude/projects/*/*.jsonl`) for cost/token usage.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dhk/work-ledger/main/scripts/install.sh | bash
+```
+
+- `work-ledger --once` — snapshot of the most recently active session
+- `work-ledger chapters --all` — cost rollup across every session found
+- `work-ledger export --out <file>.json` — anonymized aggregate export
+  (totals + chapter-category rollups only, no chapter titles/transcript
+  paths/session IDs)
+- `chapters` and `export` (chaptering) and `limits` call the Anthropic API
+  directly, separate from the Claude Code session's own auth — set
+  `ANTHROPIC_API_KEY` first, or `ant auth login` if the Anthropic CLI is
+  installed. Not preset in claude.ai remote environments; export it for the
+  session or add it as a persistent env var in the environment's settings.
+- In a claude.ai remote/cloud environment, `~/.claude/projects/` typically
+  holds only the current session's transcript (fresh container each time),
+  so `--all`/`chapters --all` mostly reduces to one session there.
+
+### Cross-session ledger (Google Drive)
+
+Each session/container is ephemeral with no shared filesystem, so
+`work-ledger export` output is collected in a shared Drive folder rather
+than a local file:
+
+- Folder: [Claude Session Ledger](https://drive.google.com/drive/folders/18FaRSPtdLn3SMbJvtUNQvFoee-RGRXmx)
+- Convention: one JSON file per session, named `YYYY-MM-DD-<short-topic>.json`
+- The Drive MCP tools can create files but not edit one in place, hence
+  one-file-per-session instead of a single appended log — assemble/chart
+  across sessions by importing the whole folder (e.g. into a Sheet)
+- The folder's own `README.md` documents this convention for anyone
+  landing there cold
+
 ## MCP servers connected in typical sessions
 
 - Gmail (`mcp__Gmail__*`)


### PR DESCRIPTION
## Summary
- Adds a `work-ledger` section to `CLAUDE.md`: install command, key subcommands (`--once`, `chapters --all`, `export`), and the `ANTHROPIC_API_KEY` requirement for chapters/export/limits (not preset in claude.ai remote environments)
- Documents the cross-session usage ledger: a shared Google Drive folder ([Claude Session Ledger](https://drive.google.com/drive/folders/18FaRSPtdLn3SMbJvtUNQvFoee-RGRXmx)) holding one anonymized `work-ledger export` JSON per session, since ephemeral containers have no shared filesystem and the Drive MCP tools can't append to an existing file in place

## Test plan
- [ ] Skim the new `CLAUDE.md` section for accuracy against `work-ledger --help`


---
_Generated by [Claude Code](https://claude.ai/code/session_01HUgNG4WtDnd8D9vJaaPgK1)_