### PR TITLE
Research: workmap prior-art pass (2 sources + synthesis)

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,11 @@
+# Research
+
+Prior-art / competitive research passes that de-risk a design doc or RFC
+before it leaves Draft. Each topic gets independent findings from two or
+more sources (this session plus at least one other tool or person)
+against the same brief, then a synthesis.
+
+## Topics
+
+- [`workmap/`](workmap/) — self-monitoring activity map
+  ([dhk/adventures-in-ai#39](https://github.com/dhk/adventures-in-ai/issues/39))

--- a/docs/research/workmap/README.md
+++ b/docs/research/workmap/README.md
@@ -1,0 +1,26 @@
+# Research: Workmap
+
+Prior-art research pass for [dhk/adventures-in-ai#39](https://github.com/dhk/adventures-in-ai/issues/39)
+(Design: Workmap — self-monitoring activity map).
+
+## Read order
+
+1. [`brief.md`](brief.md) — the research questions, each traced to a
+   section of the design doc.
+2. [`findings/`](findings/) — one file per source, submitted independently.
+   See [`findings/README.md`](findings/README.md) for the submission
+   convention.
+3. [`handoff-prompt.md`](handoff-prompt.md) — self-contained copy of the
+   brief for a tool or person without repo access.
+4. `synthesis.md` (once at least two sources' findings are in) — where
+   sources agree, where they conflict, what only one source caught, and
+   what's still unanswered.
+
+## Why findings stay independent until synthesis
+
+Each source (this session, another tool, a person) answers the brief
+without seeing any other source's findings first. Independent findings
+occasionally miss things, but a synthesis of anchored/converged answers is
+worse — one source seeing another's framing first tends to just repeat it
+rather than genuinely cross-check it. Findings only get compared at the
+synthesis step, after everyone has committed to their own answers.

--- a/docs/research/workmap/brief.md
+++ b/docs/research/workmap/brief.md
@@ -1,0 +1,94 @@
+# Research brief: Workmap
+
+**Design doc:** [dhk/adventures-in-ai#39 — Design: Workmap](https://github.com/dhk/adventures-in-ai/issues/39)
+**Topic slug:** `workmap`
+
+Workmap is a proposed self-monitoring activity map: a Theme → Project →
+Thread hierarchy (GitHub issues/PRs, branches/worktrees, Claude sessions),
+where each Thread carries `status` / `do-next` / `go-here`, rendered as a
+zoomable D3 hierarchy and kept fresh by auto-discovery plus manual override.
+
+Every question below traces back to a specific section of issue #39. Answer
+each one on its own — don't skip ahead to "how would I build this," this
+brief is prior-art and landscape research, not implementation design.
+
+## 1. Is there existing prior art for the whole concept?
+
+> Design doc, "Problem" section: "a single place to see... what's actually
+> going on right now" across repos/issues/PRs/sessions.
+
+Are there existing tools, products, or well-known personal setups that
+already solve "one map of all my active work across many
+repos/projects/threads"? Include both dev-focused tools (multi-repo PR/issue
+dashboards, GitHub project-board alternatives) and general personal-PKM /
+second-brain tools adapted for this use, if genuinely comparable.
+
+## 2. Status inference from GitHub issue/PR state
+
+> Design doc, "Data sources" section, auto-discovered/GitHub: "review
+> state, last-comment author (a good proxy for 'waiting on me' vs 'waiting
+> on them')." Also Open Question #2: "the concrete algorithm for inferring
+> `status` from GitHub API state... needs real examples, not guesses."
+
+Do existing tools or libraries already classify a GitHub issue/PR's "waiting
+on me" vs. "waiting on them" vs. "stale" status from the API? What signals
+do they use beyond review-requested/changes-requested/last-commenter (e.g.
+CI state, assignee, label conventions)? Cite anything with a public
+algorithm or open-source implementation.
+
+## 3. Local multi-repo / worktree state crawling
+
+> Design doc, "Data sources" section, auto-discovered/local git state:
+> "branches, worktrees... and how stale each is... across
+> `~/Documents/dev/*`."
+
+Are there existing CLI tools or scripts that scan across many local git
+repos/worktrees and report branch staleness, uncommitted work, or
+divergence from `main`? How do they define "stale," and do they handle
+`git worktree` specifically (not just plain clones)?
+
+## 4. Mining Claude Code session transcripts for status
+
+> Design doc, "Data sources" section, auto-discovered/Claude sessions, and
+> "Prior art in this codebase" section: `work-ledger` and `ivy-archive`
+> already parse `~/.claude/projects/**/*.jsonl`.
+
+Beyond `work-ledger` and `ivy-archive` (already known, don't re-research
+those two), is there other prior art — from Anthropic, the Claude Code
+community, or adjacent agent-session tooling (Cursor, Aider, etc.) — for
+extracting structured "what state did this session end in" data from
+session transcripts or logs?
+
+## 5. D3 zoomable-hierarchy patterns for status dashboards
+
+> Design doc, "Visualization" section: "A D3 zoomable hierarchy (zoomable
+> treemap or radial/icicle layout)... Each thread node shows status
+> (color-coded), with do-next/go-here as a hover tooltip or side panel."
+> Also Open Question #5, re: reuse vs. bespoke.
+
+What are the established D3 (or D3-adjacent, e.g. Observable Plot)
+patterns for a zoomable treemap/icicle/radial layout with per-node status
+color and click-to-drill-down + detail panel? Are there off-the-shelf
+examples or libraries close enough to fork rather than build from scratch?
+
+## 6. Hybrid auto-discovery + manual-override conflict resolution
+
+> Design doc, "Data sources" section, manual overrides: "Auto-discovery
+> fills gaps; manual entries always win on conflict." Also Open Question
+> #6: "file format, and how staleness of a manual override itself is
+> surfaced."
+
+In other tools that combine an auto-generated data layer with manual
+hand-edits that must survive regeneration (config-as-code with local
+overrides, generated docs with manual annotations, dotfile managers, etc.),
+what patterns exist for (a) the override file format, (b) merge/precedence
+rules, and (c) flagging an override as stale (e.g. written before the
+underlying auto-discovered state changed)?
+
+## Non-goals for this research pass
+
+- Don't design the workmap's implementation (schema, code structure, repo
+  layout) — that's for the design doc / a future RFC, not this brief.
+- Don't answer issue #39's Open Questions #1, #3, #4 (where the output
+  lives, repo scope, and regen triggers) — those are this-user-specific
+  product decisions, not things prior art can resolve.

--- a/docs/research/workmap/findings/README.md
+++ b/docs/research/workmap/findings/README.md
@@ -1,0 +1,47 @@
+# Findings — submission convention
+
+## Naming
+
+One file per source: `<source-slug>-findings.md`. The source slug is short
+and identifies who/what produced it, e.g. `claude-findings.md`,
+`chatgpt-findings.md`, `gemini-findings.md`, `dave-findings.md`.
+
+## Format
+
+Copy [`TEMPLATE.md`](TEMPLATE.md) and fill it in — one section per brief
+question, in the same order as `brief.md`, each with:
+
+- A table: `Entry | What it is | Workmap concept overlap | Verdict`
+- A `Notes` block below the table for rationale, caveats, and detail
+
+Followed by a final `## Open gaps` section covering anything the brief
+asked that you couldn't find a good answer to.
+
+### Verdict — closed set, no exceptions
+
+Every table row's `Verdict` column must be exactly one of:
+
+- `adopt/reference` — directly usable, or a pattern worth copying
+- `differentiate` — relevant, but workmap should do this differently, and
+  why goes in Notes
+- `ignore` — surfaced by the search but not actually relevant
+
+Don't invent new labels. Don't put rationale in the Verdict cell — a
+one-word verdict plus a Notes explanation, not `adopt/reference (because it
+has X)`.
+
+### No empty tables
+
+If a question turns up nothing, the table still gets one row:
+`none found | — | — | ignore`, with the reason (what you searched, why you
+believe it's genuinely absent) in Notes. Silence in a table reads as "not
+researched," not as "researched and found nothing" — those are different
+and the reader needs to know which one happened.
+
+## Submitting without repo write access
+
+If you don't have write access to this repo, use
+[`../handoff-prompt.md`](../handoff-prompt.md) as your starting prompt, then
+paste your completed findings (matching `TEMPLATE.md`) back to the person
+who gave you the prompt — they'll commit it as
+`<your-source-slug>-findings.md`.

--- a/docs/research/workmap/findings/TEMPLATE.md
+++ b/docs/research/workmap/findings/TEMPLATE.md
@@ -1,0 +1,59 @@
+<!--
+Copy this file to <source-slug>-findings.md and fill it in.
+See ../findings/README.md for the format rules (verdict is a closed set,
+no empty tables, rationale goes in Notes not the Verdict cell).
+-->
+
+# Workmap research findings — `<source-slug>`
+
+## 1. Is there existing prior art for the whole concept?
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| | | | |
+
+**Notes:**
+
+## 2. Status inference from GitHub issue/PR state
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| | | | |
+
+**Notes:**
+
+## 3. Local multi-repo / worktree state crawling
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| | | | |
+
+**Notes:**
+
+## 4. Mining Claude Code session transcripts for status
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| | | | |
+
+**Notes:**
+
+## 5. D3 zoomable-hierarchy patterns for status dashboards
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| | | | |
+
+**Notes:**
+
+## 6. Hybrid auto-discovery + manual-override conflict resolution
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| | | | |
+
+**Notes:**
+
+## Open gaps
+
+-

--- a/docs/research/workmap/findings/claude-findings.md
+++ b/docs/research/workmap/findings/claude-findings.md
@@ -1,0 +1,79 @@
+# Workmap research findings — `claude`
+
+## 1. Is there existing prior art for the whole concept?
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| [Canopy (juliensimon/canopy)](https://github.com/juliensimon/canopy) | Native macOS app for running parallel Claude Code sessions across git worktrees: auto-resume, merge & finish, token dashboard | Manages the exact "many concurrent AI-agent sessions across worktrees" slice of workmap's scope directly | adopt/reference |
+| [canopy (isacssw/canopy)](https://github.com/isacssw/canopy) | Typed multi-repo MCP server + terminal UI for AI coding agents: `canopy status`, `state`, `triage`, `resume`, `preflight` | `canopy state`/`resume` is close to workmap's `status`/`go-here` fields, scoped to sessions+worktrees only (no GitHub issues, no theme hierarchy, no D3) | adopt/reference |
+| [gh-dash (dlvhdr/gh-dash)](https://github.com/dlvhdr/gh-dash) | Terminal UI showing user-defined, per-repo sections of PRs/issues across many repos | Cross-repo aggregation + custom status sections, no worktree/session layer | adopt/reference |
+| [DashGit (javiertuya/dashgit)](https://github.com/javiertuya/dashgit) | Dashboard consolidating open issues, PRs, review requests, branches, and statuses across GitHub + GitLab in one view | Closest single "one view of all my open threads" match; no theme grouping, no session data, no zoomable viz | adopt/reference |
+| [Repo Dashboard (Alberto Roura)](https://albertoroura.com/repo-dashboard-local-github-visibility-tool/) | Local-first tool, no setup beyond a GitHub token, aggregates issues/PRs/branches | Matches workmap's "local, low-friction, auto-discovered" design goal | adopt/reference |
+| [gh-dashboard (debba)](https://github.com/debba/gh-dashboard) | Kanban board + repo "insights" (Strong/Watch/Risky status per repo) + daily digest with an executive summary | The per-repo derived status label and daily digest are close analogues to workmap's Project-level rollup status and a "what changed" digest | adopt/reference |
+| [GitKraken Launchpad](https://www.gitkraken.com/features/launchpad) | Commercial unified dashboard for PRs/issues/tasks across GitHub, GitLab, Bitbucket, Jira | Multi-provider aggregation at team/commercial scale; no worktree/session tracking, no do-next/go-here concept | differentiate |
+| [Graphite Insights / PR dashboard](https://graphite.com/guides/github-pr-dashboard) | Org-wide "universal inbox" of PRs needing your attention | PR-only, no issues/branches/sessions, no theme/project hierarchy | differentiate |
+| [Obsidian Canvas](https://www.obsibrain.com/blog/obsidian-canvas-complete-guide) used as a project dashboard (with Dataview/Kanban embeds) | Manually built, pannable/zoomable board of project notes and embedded queries | Matches the "zoom into clusters" UX goal, but is manually curated, not auto-discovered from GitHub/git/sessions | differentiate |
+
+**Notes:** The single biggest finding here is `Canopy` (two unrelated projects share the name — `juliensimon/canopy` and `isacssw/canopy` — both aimed at exactly "many parallel Claude Code sessions across worktrees, one view, resume support"). This overlaps enough with workmap's Thread=session concept that the design doc should explicitly say why workmap isn't just "point Canopy at your repos" — e.g. Canopy doesn't ingest GitHub issues/PRs or do theme-level rollups or a D3 zoomable view, but the session-state/resume piece may be directly reusable or worth evaluating as a dependency rather than reimplementing. DashGit and Repo Dashboard are the closest matches for the GitHub-aggregation half; none of the entries found combine GitHub + local git + AI-session state in one hierarchy the way workmap proposes — that three-way combination looks like the genuinely novel part.
+
+## 2. Status inference from GitHub issue/PR state
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| [GitHub search qualifiers](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests) (`review-requested:@me`, `involves:@me -author:@me`, `author:@me`, `is:open`) | GitHub's own first-party search syntax for issue/PR state | This *is* the concrete classification algorithm workmap needs — status buckets are qualifier combinations, not a bespoke heuristic | adopt/reference |
+| [gh-dash section config using the same qualifiers](https://www.gh-dash.dev/configuration/examples/) | gh-dash's own config examples build "Needs My Review" (`is:open review-requested:@me`) and "Waiting for Author" (`is:open involves:@me -author:@me`) sections from those qualifiers | Directly shows the qualifier-combination pattern applied to build the exact "waiting on me / waiting on them" buckets workmap wants | adopt/reference |
+| [`gh search prs --review-requested=@me`](https://cli.github.com/manual/gh_search_prs) | GitHub CLI's native flag wrapping the same qualifier | Same algorithm, CLI-native form, easy to shell out to instead of hitting the REST/GraphQL API directly | adopt/reference |
+| [Octobox](https://github.com/github/octobox) | GitHub-official (now archived) notification-triage app; tags notifications with PR/issue state, CI status, labels | Looked like a strong candidate but its actual "waiting on me" classification logic wasn't surfaced in what I could find — may need a source-read, not just docs, to confirm it has one | ignore |
+
+**Notes:** No source found a bespoke inference algorithm beyond composing GitHub's own search qualifiers — that's good news for workmap: the "concrete algorithm" issue #39 asks for (Open Question #2) is largely "which qualifier combination maps to which status label," not a novel classifier. CI state and label conventions (also asked about in the brief) weren't clearly covered by any single source — that's a gap, see below.
+
+## 3. Local multi-repo / worktree state crawling
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| [Canopy worktree dashboard](https://medium.com/@ashmitbbiswas/git-worktrees-are-great-managing-them-across-3-repos-is-not-12262be5ddb0) | Single command showing every feature/repo, dirty file counts, ahead/behind status, which branches are checked out where | Near-exact match for workmap's "local git state" auto-discovery source | adopt/reference |
+| [git-worktree-cli (jeffersongoncalves)](https://github.com/jeffersongoncalves/git-worktree-cli) | Audits worktrees, checks whether their branches are merged into main, prunes stale worktree records | Gives a concrete, citable definition of "stale": branch merged and/or remote-tracking ref gone | adopt/reference |
+| [Bulk cleaning stale git worktrees post (brtkwr.com)](https://brtkwr.com/posts/2026-03-06-bulk-cleaning-stale-git-worktrees/) | Blog post/script defining a worktree as stale when its remote tracking branch no longer exists | Same staleness definition from a second independent source — corroborates rather than duplicates the entry above | adopt/reference |
+| [worktree-cli (fnebenfuehr)](https://github.com/fnebenfuehr/worktree-cli), [wtree](https://github.com/ozeron/wtree), [git-worktree-manager (nanasess)](https://github.com/nanasess/git-worktree-manager) | Simpler worktree create/switch/remove CLIs | CRUD-focused, not dashboard/status-reporting tools — useful only as "what verbs exist," not as a status-crawling pattern | ignore |
+
+**Notes:** "Stale" converges on one clean, citable definition across two independent sources: the worktree's branch has no live remote-tracking ref (deleted after merge) or is already merged into `main`. That's directly usable as the `stale` status value in workmap's Thread status enum, separate from `git worktree list --porcelain`'s own staleness (administrative files pointing at a removed directory), which is a different, narrower kind of "stale."
+
+## 4. Mining Claude Code session transcripts for status
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| [`continue-claude-work` skill](https://skills-anthropic.vercel.app/skill/continue-claude-work) | A Claude skill that reconstructs actionable context from a session: latest compact summary, pending work, known errors, current workspace state | Near-exact match for what workmap needs to derive `do-next`/`go-here` from a session transcript | adopt/reference |
+| [cli-continues (yigitkonur/cli-continues)](https://github.com/yigitkonur/cli-continues) | Parses 16 different AI coding tools' native session formats (JSONL/JSON/SQLite/YAML, including Claude Code) and extracts recent messages, file changes, tool activity, and reasoning to resume in another tool | Directly relevant multi-format parsing prior art if workmap ever needs to track sessions from tools beyond Claude Code | adopt/reference |
+| ["clerk" tool](https://dev.to/vulcan_shen_acdbffa0285d2/clerk-auto-summarize-your-claude-code-sessions-4m87) | Auto-summarizes Claude Code sessions; returns past summaries and transcript paths | Same problem as workmap's session-thread summarization, narrower scope (summarize only, not classify status) | adopt/reference |
+| [claude-code-history-viewer (jhlee0409)](https://github.com/jhlee0409/claude-code-history-viewer) | Desktop app to browse and analyze Claude Code conversation history | Useful as a UI-pattern reference for a session detail view, not for status extraction itself | differentiate |
+| [Simon Willison — extracting detailed transcripts from Claude Code](https://simonw.substack.com/p/a-new-way-to-extract-detailed-transcripts) | Background piece on the JSONL transcript format and extraction technique | Useful format documentation, not a status-classification tool | reference material — closest verdict: differentiate |
+
+**Notes:** This is the area with the most direct, close prior art relative to workmap's own stated intent to reuse `work-ledger`/`ivy-archive` rather than reinvent — `continue-claude-work` in particular looks close enough to workmap's `do-next`/`go-here` derivation that it's worth reading its actual implementation (not just the description) before writing new extraction logic.
+
+## 5. D3 zoomable-hierarchy patterns for status dashboards
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| [Observable: Zoomable treemap (@d3/zoomable-treemap)](https://observablehq.com/@d3/zoomable-treemap) | Canonical D3 example: click any cell to zoom in, click the top bar to zoom out, via rescaling the x/y domains | Directly matches the "zoomable treemap" option in the design doc's Visualization section | adopt/reference |
+| [Observable: Zoomable icicle (@d3/zoomable-icicle)](https://observablehq.com/@d3/zoomable-icicle) | Shows three layers of a hierarchy at a time; click a node to zoom in, click the left column to zoom out | Even closer match than the treemap to a Theme→Project→Thread three-level structure shown a level at a time | adopt/reference |
+| [Zoomable Icicle gist (mbostock)](https://gist.github.com/mbostock/1005873) | D3 creator's original reference implementation of the zoomable icicle | Canonical source implementation to fork from | adopt/reference |
+| Various forks/templates (andyburnett, john-guerra, ganeshv gist, codepen "Zoomable Treemap v4") | Community forks of the same Observable examples | Redundant with the canonical Observable notebooks above, no incremental pattern | ignore |
+
+**Notes:** Both canonical layouts (zoomable treemap, zoomable icicle) are maintained, documented, forkable Observable notebooks — the design doc's "treemap or radial/icicle" framing maps directly onto these two, and the icicle in particular already implements "show N layers, click to drill down" which is exactly the interaction workmap describes. This strongly supports Open Question #5 leaning toward forking rather than building bespoke.
+
+## 6. Hybrid auto-discovery + manual-override conflict resolution
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| [Terraform/OpenTofu override files](https://developer.hashicorp.com/terraform/language/files/override) | A separate `*_override.tf` file whose values always take precedence over the base config, merged at load time with documented merge semantics | Directly matches workmap's "separate manual-override file, manual always wins" design | adopt/reference |
+| [Docker Compose override files](https://docker.recipes/docs/compose-overrides) | `docker-compose.override.yml` layered on top of a base `docker-compose.yml` | Same base+override layering pattern from a second, very widely-used tool | adopt/reference |
+| [doctoc's generated-section markers](https://github.com/thlorenz/doctoc) (`<!-- START doctoc generated TOC -->` … `<!-- END doctoc generated TOC -->`) | Regeneration only touches content between two HTML-comment markers in the same file; everything outside the markers (i.e. manual content) is left untouched | A genuinely different pattern from the separate-override-file approach: instead of two files merged, one file with an auto-owned region and a manually-owned region | adopt/reference |
+| [chezmoi machine-specific templating](https://www.chezmoi.io/user-guide/manage-machine-to-machine-differences/) | Templates rendered per-machine from local config data; later directives override earlier ones | Solves a same-repo-different-machine problem, not an auto-generated-vs-manually-edited problem — precedence mechanics are adjacent but the use case doesn't match | differentiate |
+
+**Notes:** Two structurally different, both well-established patterns are available: (a) separate override file merged over generated output (Terraform/Compose), or (b) marker-delimited manual region inside the same generated file (doctoc). Workmap's design doc already leans toward (a) ("a small YAML/JSON file... manual entries always win"), which is the more common and better-documented of the two for structured (non-prose) data — (b) is more natural for the free-text `go-here`/`do-next` fields specifically, so a hybrid (structured overrides in a sidecar file, but `go-here` text editable in a marked region) may be worth considering.
+
+## Open gaps
+
+- No source directly addressed **staleness-flagging of a manual override itself** (issue #39's Open Question #6b: surfacing that a hand-written `do-next` is 3 weeks old relative to newer auto-discovered state). Searched for generated/manual-merge tools that timestamp or expire manual annotations specifically and found only general "last verified" / annotation-merge tooling unrelated to this exact problem — this looks like it may be a genuinely under-addressed gap rather than something I failed to find, but a second source should confirm before treating it as novel.
+- **CI status and label-convention signals** for status inference (part of Question 2's "beyond review-requested/changes-requested/last-commenter") weren't clearly covered by any single source — every tool found composes GitHub's built-in search qualifiers, and none of the sources documented incorporating CI/label state into a status label in a generalizable way.
+- Didn't evaluate any tool by actually installing/running it — this pass is docs/README-level only, per the brief's non-goals. A follow-up pass (or the synthesis step) should flag if hands-on testing of Canopy, DashGit, or `continue-claude-work` specifically is worth doing before workmap's design doc is finalized, given how close those three are to the proposed scope.

--- a/docs/research/workmap/findings/perplexity-findings.md
+++ b/docs/research/workmap/findings/perplexity-findings.md
@@ -1,0 +1,177 @@
+# Workmap research findings — `perplexity`
+
+## 1. Prior art for the whole concept ("one map of all my active work")
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| GitHub native Issues/PR dashboards + saved views | Built-in cross-repo issue/PR lists with up to 25 saved search-based views[^1] | Covers auto-discovery of GitHub state but flat list only, no hierarchy, no status inference beyond raw fields, no manual overrides | differentiate |
+| DashGit | Browser-only dashboard aggregating issues, PRs, review requests, branches, build status across GitHub/GitLab repos, with a "manager repo" for follow-up reminders[^2] | Same auto-discovery goal (GitHub API crawl, multi-repo), has a "follow-up reminder" concept close to do-next/manual annotation, but flat tabbed UI, no Theme→Project→Thread hierarchy, no local git/worktree or AI-agent layer | differentiate |
+| octopeek | Keyboard-driven TUI unifying PR/issue inbox across repos by role (author/reviewer/assignee)[^3] | Overlaps on "what needs my attention across many repos" but terminal-only, no hierarchy/visualization, no local or agent-session data | differentiate |
+| Repo Dashboard (rouralberto) | Local-first Node app showing a three-column (issues/PRs/branches) view per selected org/repos[^4] | Matches "local-first personal tool" instinct and includes branches, but no worktree/agent data, no manual override layer, flat table only | differentiate |
+| gh-dashboard (debba) | Self-hosted dashboard pulling REST+GraphQL data: issues, PRs, commits, Actions runs, stars, mentions per repo, with server-side token handling[^5] | Broad auto-discovery breadth is comparable, but again flat/tabular, single-source (GitHub only, no worktree/agent), no explicit status taxonomy or override file | differentiate |
+| git-pull-request-dashboard, github-pr-dashboard, PR Radar, camelAI GitHub dashboards | Various open-source/commercial multi-repo PR trackers (CI status, review state, age)[^6][^7][^8][^9] | All solve the "PR portion" of Workmap's Thread layer; none add issues+branches+agent sessions in one hierarchy or the manual-override mechanism | differentiate |
+| GitKraken Workspaces | Commercial multi-repo grouping tool showing open PRs, insights (throughput, merge rate), filters across a defined repo set[^10][^11] | Closest commercial analogue to "Theme/Project" grouping of many repos with PR-level detail, but no branch-level worktree awareness, no AI-agent transcript ingestion, no D3 hierarchy visualization, closed-source | differentiate |
+| ZenHub / CodeTree | Multi-repo issue/board tools layered on top of GitHub, letting teams manage issues across repos in one board[^12] | Solves cross-repo issue aggregation for teams, but oriented around kanban boards, not personal solo-maintainer status/resume workflows, and no local/agent state | ignore |
+| Grafana GitHub Organization dashboard | Prebuilt Grafana dashboard visualizing issue/PR counts and active/inactive states across an org via a GitHub data source[^13] | Demonstrates color-coded "active vs needs attention" states similar to Workmap's status coloring, but it's aggregate metrics, not a per-thread drill-down map | ignore |
+
+**Notes:** No tool found combines all four data sources Workmap targets (GitHub API, local git/worktree, AI-agent session transcripts, manual overrides) into a single hierarchical, drill-downable, status-colored view. The closest analogues are multi-repo PR/issue dashboards (DashGit, gh-dashboard, GitKraken Workspaces), all of which stop at "list of items with filters" rather than a Theme→Project→Thread zoomable hierarchy, and none ingest AI coding-agent session state. On the PKM/second-brain side, searches for "second brain" or "PKM" tools adapted to this exact use case (Obsidian/Notion-based dev work trackers) surfaced only generic task-plugin ecosystems (e.g., Obsidian Dataview) used for note-querying, not GitHub/git/agent-state aggregation — genuinely adjacent but not comparable enough to list as direct prior art beyond the pattern noted in Question 6. Workmap's specific combination (hierarchy + tri-field status/do-next/go-here schema + hybrid auto+manual data + dual visualization modes) appears to be a novel synthesis rather than a re-implementation of an existing product.[^14]
+
+## 2. Status inference from GitHub issue/PR state
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| Pull Reminders (pullreminders/backlog) | SaaS + open-sourced issue tracker with a documented "waiting on author" vs "waiting on reviewer" algorithm, including SQL and pseudocode for stale-review detection[^15] | Directly matches the status field's core problem: distinguishing "waiting-on-review" from "waiting-on-user-input"/stale using non-dismissed reviews vs. current requested-reviewer list and review-request timestamps | adopt/reference |
+| Rust Forge triage procedure (S-waiting-on-* labels) | Documented human triage workflow using explicit status labels (waiting-on-review, waiting-on-author, waiting-on-t-lang, waiting-on-bors, etc.) plus rules for flipping labels based on activity type (CI failure, new review, new commit)[^16] | Provides a battle-tested taxonomy and transition rules very close to Workmap's "status: waiting-on-review / waiting-on-user-input / in-progress / stale" set, including "no activity in N days → escalate" logic | adopt/reference |
+| Suricata GitHub PR workflow doc | Documents draft-vs-ready, changes-requested-vs-approved states and gives concrete `gh pr list` / search-qualifier filters (`review:changes-requested`, `review:approved`, `review:none`) for deriving state via GitHub CLI[^17] | Gives directly reusable GitHub CLI/API filter queries for the crawler component (review decision, draft state) | adopt/reference |
+| gh-wait (k1LoW) | GitHub CLI extension that polls PR/issue/discussion/workflow-run state and fires an action when a specific condition (approved, CI completed, commented) is met[^18] | Encodes discrete, checkable state-transition signals (approved, CI-completed, commented) that map onto Workmap's status enum, and its self-comment filtering (ignoring the user's own comments/approvals when deciding "waiting on me") is a directly relevant signal-refinement pattern | adopt/reference |
+| GitHub's own review-decision field (`reviewDecision`) and REST/GraphQL review/CI status endpoints | Native API fields (`REVIEW_REQUIRED`, `APPROVED`, `CHANGES_REQUESTED`, check-run conclusions, `mergeable_state`) | These are the raw signals every tool above is built on; Workmap's crawler would consume the same fields directly | adopt/reference |
+| Trigger.tools GitHub PR Review Router | A commercial low-code "automation" that surfaces "what each PR is waiting on" for reviewers/authors[^19] | Same problem framing but no public algorithm or code shown, closed/no-code platform | ignore |
+
+**Notes:** The clearest, publicly documented algorithms combine (a) GitHub's native `reviewDecision` and check-run/CI status, (b) whether a reviewer still has an open review request versus having already submitted a non-dismissed review, and (c) last-actor/last-comment attribution with self-action filtering. None of these tools produce a "stale" classification purely from GitHub state without an explicit human-triage cadence (Rust's is manual, 15-day threshold); Workmap would need to combine last-updated timestamp thresholds itself, as no crawler-side "stale" auto-classifier with a public spec was found beyond simple "sort by updated-asc" filters.[^15][^18][^16][^17]
+
+## 3. Local multi-repo / worktree state crawling
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| Grove (gw) | Python CLI managing git worktree-based workspaces spanning multiple repos; `gw status <workspace>` reports git status across all repos in a named workspace[^20] | Directly addresses "local multi-repo worktree state crawling," explicitly worktree-native (not just clones) | adopt/reference |
+| Mars | Multi-repo workspace manager (`mars.yaml`) with `mars status` showing dirty files, branch info, and sync state across tagged repo groups, plus shared Claude/agent config per workspace[^21] | Overlaps closely with Workmap's Project grouping and even shares "agent config" per repo group, but is clone-based, not worktree-first, and no explicit staleness metric | differentiate |
+| RepoFleet | CLI for creating/switching/removing branches across multiple repos simultaneously with a unified terminal status dashboard of uncommitted changes and current branch per repo[^22] | Matches "branch divergence/uncommitted work across many repos" reporting goal | differentiate |
+| deadbranch | Rust CLI defining "stale" as branches with no commits in the last 30 days (configurable), used for safe cleanup rather than status reporting[^23] | Gives one concrete, adoptable numeric default for "stale" branch age threshold | adopt/reference |
+| Ad hoc branch-aging bash scripts (e.g., CodePulse guide) | Shell scripts computing branch age via `git for-each-ref` + last-commit timestamp, bucketed into fresh/aging/stale/fossilized (7/30/90-day thresholds)[^24] | Gives a directly reusable, simple staleness algorithm and threshold scheme that a crawler can replicate without new tooling | adopt/reference |
+| GitHub native "stale branch" label | GitHub itself flags branches with no recent activity in the branch listing UI[^24] | Confirms staleness-by-inactivity is an established convention, but it's UI-only, not a queryable local signal | ignore |
+
+**Notes:** None of the surfaced worktree-aware tools (Grove, Mars) publish an explicit "staleness" definition — they report current state (dirty/clean, ahead/behind) rather than classifying age-based staleness; the age-threshold pattern instead comes from branch-cleanup tools (deadbranch, ad hoc scripts) that were not built with worktree support and assume plain clones. Workmap would need to combine a worktree-aware status crawl (Grove/Mars style, using `git worktree list --porcelain` semantics) with a separately-sourced age-threshold rule (deadbranch/CodePulse style) since no single existing tool does both.[^23][^24]
+
+## 4. Mining AI coding-agent session transcripts/logs for status
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| continue-claude-work skill | A published Claude Skill with a bundled script (`extract_resume_context.py`) that parses `~/.claude/projects/*.jsonl`, finds the last compaction boundary, classifies session end reason (completed / interrupted / error_cascade / abandoned), extracts pending work, files touched, and git state, producing a structured "briefing" for resuming[^25] | This is the single closest piece of prior art to Workmap's "mine agent session transcripts for status/do-next/go-here": it already implements JSONL parsing, end-state classification, and pending-work extraction from Claude Code sessions specifically | adopt/reference |
+| Claude Code native `--resume` / `/resume` and session JSONL storage | Claude Code persists every session continuously as local JSONL transcripts under `~/.claude/projects/`, and provides `--resume`/`--continue` to replay them[^26][^27][^28] | Confirms the raw data source Workmap would crawl exists and is documented, but native resume replays the whole transcript rather than emitting structured status/next-action fields | differentiate |
+| Claude Code session-handoff skill (gist, edwilde) | A SKILL.md prompt template instructing Claude to write a structured Markdown "session summary" (goal, completed, in-progress, blocking issues, next steps, restoration procedure) at end of session[^29] | Directly matches Workmap's status/do-next/go-here schema conceptually — it's a manual/LLM-generated version of exactly those three fields, written by the agent itself rather than mined after the fact | adopt/reference |
+| KeepGoing (keepgoing.dev) | A third-party tool that connects to Claude Code, gathers session context from git activity plus session notes, and gives a "recap" on return to a project[^28] | Same goal as Workmap's agent-session ingestion layer (turn scattered agent activity into a resumable status), but it's an external hosted product rather than a documented open algorithm | differentiate |
+| Cursor / Aider / Windsurf session logs | Search for public, structured "session end-state" extraction specs from these tools' logs turned up no equivalent open-source implementation; Aider keeps a `.aider.chat.history.md` and `.aider.input.history` but no known structured state-extraction tool was found for it | Partial data-source overlap (Aider does persist chat history to a file that could be crawled) but no existing "extract resumable status" tooling | ignore |
+
+**Notes:** Prior art here is genuinely present but narrow: only the Claude Code ecosystem has both (a) a stable, documented JSONL transcript format and (b) at least one open community tool (continue-claude-work) that parses it into structured resumable state, plus a prompt-engineering pattern (handoff skill) for having the agent self-report state in the exact status/do-next/go-here shape. For Cursor, Aider, and Windsurf specifically, repeated searches ("Cursor session transcript structured extraction," "Aider session log resume state," "Windsurf agent log parse status") returned no comparable public algorithm or tool — this is a genuine gap, not an oversight, likely because those tools either don't persist transcripts in as durable/documented a format or the ecosystem around them hasn't produced a public parser yet.[^29][^25]
+
+## 5. D3 zoomable-hierarchy patterns for status dashboards
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| Observable "Zoomable treemap" (d3/zoomable-treemap) | Canonical D3 example: click-to-zoom treemap using `d3.hierarchy` + custom tiling, breadcrumb-style zoom-out via top bar[^30] | This is the direct off-the-shelf pattern for Workmap's treemap rendering mode, including the zoom/breadcrumb interaction Workmap wants for drill-down | adopt/reference |
+| Observable "Zoomable icicle" | Canonical D3 example using `d3.partition()` for an icicle layout with click-to-zoom-in and click-top-to-zoom-out[^31][^32] | Direct match for the "icicle" layout option Workmap lists as an alternative to treemap; same interaction model, well documented and forkable (gists exist for multiple D3 versions)[^32][^33] | adopt/reference |
+| Observable "Zoomable sunburst" (D3 gallery) | Radial equivalent of the icicle, same partition-layout approach rendered as arcs[^34] | Direct match for the "radial" layout option Workmap lists | adopt/reference |
+| D3 Gallery Vanilla JS (takanori-fujiwara) | A full port of every Observable D3 example (including zoomable treemap/icicle/sunburst, collapsible tree, zoomable circle packing) into plain JS usable outside Observable's runtime, with source on GitHub[^34] | Solves the practical friction of adapting Observable-notebook code to a standalone app — directly forkable base for Workmap's implementation | adopt/reference |
+| Pangea Proxima Treemap component | A reusable, parameterized D3 Treemap component (data/value/label/tile/group props) built for reuse across dashboards rather than a single notebook demo[^35] | Closer to a "library" than a demo — a good structural reference for building a reusable status-colored treemap component with a `group`/color accessor | adopt/reference |
+| Click-to-drill-down + separate detail panel (as opposed to in-place zoom-only) | No single canonical example combines a zoomable hierarchy with a *separate* side detail panel on click, in the sources found; existing examples handle "zoom" and "tooltip on hover" but the side-panel-on-click pattern is assembled by combining a zoom example with a standard "click node → update side div" handler, not something with dedicated prior art | Directly what Workmap needs (drill zoom + persistent detail panel), but must be composed from the zoom examples plus ordinary DOM event handling rather than found as one packaged example | differentiate |
+
+**Notes:** All three layout variants Workmap considers (treemap, icicle, radial/sunburst) have mature, well-documented, directly-forkable Observable/D3 reference implementations using the same `d3.hierarchy`/`d3.partition` primitives, so this is the strongest "adopt, don't rebuild" area of the whole prior-art review. Per-node status coloring is a trivial extension of these examples (swap the existing depth/size color scale for a categorical scale keyed on a `status` field) and was not found as a distinct blocking problem in any source. The detail-panel-on-click UX is the one piece that needs original composition rather than forking, since it's a straightforward but not pre-packaged combination of the zoom examples with a standard click-to-update-panel handler.[^34][^30][^32]
+
+## 6. Hybrid auto-discovery + manual-override conflict resolution
+
+| Entry | What it is | Workmap concept overlap | Verdict |
+|---|---|---|---|
+| Terraform override files (`*_override.tf` / `override.tf`) | Native mechanism where files with a special suffix/name are loaded last and merged attribute-by-attribute into blocks with the same header from the main config, with later-loaded overrides taking precedence and nested blocks replaced wholesale rather than deep-merged[^36] | This is a directly analogous, well-specified precedence model: "override always wins," matching Workmap's "manual entries always win on conflict" rule, and shows the tradeoff of block-replace vs. attribute-merge granularity that Workmap will need to choose between | adopt/reference |
+| chezmoi templates + `chezmoi diff`/`status`/merge workflow | Dotfile manager where generated ("applied") files are produced from source templates; local drift is detected via `chezmoi status`/`diff`, and a documented conflict-resolution workflow captures local edits before pulling remote template changes, forcing explicit reconciliation rather than silent overwrite[^37][^38] | Directly relevant to "flagging an override as stale": chezmoi's model treats any manual edit to a generated file as *drift* to be captured and either kept or discarded, which is the closest documented pattern for detecting when a manual override predates a template/regeneration | adopt/reference |
+| Kustomize overlays/patches (`patchesStrategicMerge`, `patches`) | Base config + ordered overlay patches, where overlay patches apply after and on top of base-generated resources, with well-defined ordering/merge semantics for lists vs. scalars[^39] | Provides an alternative precedence model (ordered patch layers rather than single override file) worth considering if Workmap ever needs partial-field overrides rather than whole-Thread overrides | differentiate |
+| "DO NOT EDIT" banner convention (protobuf generated code, Debian lintian `generated-file` tag, dotfiles "do not edit below this line") | Ubiquitous convention of a comment banner marking generated vs. hand-edited regions in the same file[^40][^41][^42] | Establishes the informal, widely-recognized alternative to a separate override *file*: marking regions in a single file. Relevant as a rejected-alternative pattern since Workmap's brief already specifies a separate manual-override file rather than inline markers | differentiate |
+| JSON Merge Patch / JSON Patch (RFC 7386 / RFC 6902) style semantics (as used by kustomize's `patchesJson6902`) | Standardized formats for expressing "apply this diff on top of a base document," with explicit rules for null-deletes-key vs. replace-value | Gives a standardized, off-the-shelf schema option for the override file's merge semantics rather than inventing a bespoke format | adopt/reference |
+| Staleness flagging via file mtime/checksum comparison (general pattern seen in build tools, e.g., Terraform's own state/plan diffing, Make-style mtime checks) | No tool in this search implements exactly "flag manual override as stale if written before the underlying auto-discovered state changed," but the closest documented instance is chezmoi's status/diff detecting when the *applied* file has drifted from what the *source* would generate, which is the inverse of Workmap's stale-override problem[^37] | Confirms this specific direction (override-vs-current-truth staleness, rather than generated-vs-source drift) is not solved off the shelf; a bespoke timestamp/hash comparison between the override entry and the crawler's last-seen state for that Thread would need to be built | ignore |
+
+**Notes:** Precedence rules ("manual always wins") and merge-file formats are well precedented (Terraform overrides, kustomize patches, JSON Merge Patch), and the closest real analogue to detecting *drift* between generated and hand-edited state is chezmoi's diff/status workflow — though chezmoi flags drift in the opposite direction (local file diverging from the managed template) rather than Workmap's need (a manual override becoming stale relative to newly observed auto-discovered ground truth, e.g., a "waiting-on-review" override left in place after the PR was actually merged). No tool found implements that specific override-staleness detection directly; it appears to be a genuine gap requiring bespoke logic (e.g., storing a "last-verified-against" timestamp or hash per override entry and diffing against the crawler's fresh read).[^36][^39][^37][^38]
+
+## Open gaps
+
+- No public, open-source tool combines GitHub API state, local git/worktree state, and AI-agent transcript state into one hierarchical personal dashboard — Workmap's overall concept appears to be a genuine synthesis rather than a re-implementation, confirmed via multiple searches on "personal work map," "multi-repo PR issue dashboard," and PKM-adjacent terms.
+- No public algorithm was found for classifying a GitHub PR/issue as "stale" purely from API signals (as opposed to a fixed manual review cadence, as in Rust's 15-day triage rule); this remains a threshold Workmap will have to define itself.
+- No structured session-state extraction tooling was found for Cursor, Aider, or Windsurf specifically (searched directly); only the Claude Code ecosystem has a documented transcript format and community parser (continue-claude-work).
+- No off-the-shelf example combines a D3 zoomable hierarchy with a persistent side detail panel on click (only zoom-only or tooltip-only patterns exist); this will require composing existing zoom examples with standard DOM event handling.
+- No existing tool implements "flag a manual override as stale because the underlying auto-discovered state has since changed" (as distinct from detecting drift in a generated file itself, which chezmoi does solve) — this appears to be a genuine, unaddressed gap in the prior art surveyed.
+
+---
+
+## References
+
+1. [Viewing all issues and pull requests - GitHub Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/viewing-all-of-your-issues-and-pull-requests) - The Issues and Pull Request dashboards list the open issues and pull requests you've created, as wel...
+
+2. [GitHub - javiertuya/dashgit: DashGit - A Dashboard for GitHub and GitLab repositories. Consolidates in a single view all your open issues, PRs, review requests, branches and statuses. Combine and merge dependency updates from dependabot PRs.](https://github.com/javiertuya/dashgit) - DashGit - A Dashboard for GitHub and GitLab repositories. Consolidates in a single view all your ope...
+
+3. [octopeek 0.3.0](https://docs.rs/crate/octopeek/latest)
+
+4. [Repo Dashboard - A Local GitHub Visibility Tool](https://albertoroura.com/repo-dashboard-local-github-visibility-tool/) - When you're working across multiple repositories in an organization, keeping track of what's happeni...
+
+5. [I built a local GitHub dashboard because managing many public/private repos was getting messy.](https://www.reddit.com/r/webdev/comments/1t1lfia/i_built_a_local_github_dashboard_because_managing/) - I built a local GitHub dashboard because managing many public/private repos was getting messy.
+
+6. [GitHub - AKharytonchyk/git-pull-request-dashboard](https://github.com/AKharytonchyk/git-pull-request-dashboard) - The GitHub PR Dashboard offers a comprehensive view of PRs, making it an essential resource for effi...
+
+7. [GitHub - rschuft/github-pr-dashboard: See pull requests at a glance, across multiple repos](http://github.com/rschuft/github-pr-dashboard) - See pull requests at a glance, across multiple repos - rschuft/github-pr-dashboard
+
+8. [PR Radar – GitHub, GitLab & Bitbucket PRs](https://chromewebstore.google.com/detail/pr-radar-%E2%80%93-github-gitlab/hkombgibegjffiadmekpiabdakkoidmh) - Track PRs, CI status, code reviews & deployments across GitHub, GitLab and Bitbucket. No backend, fr...
+
+9. [GitHub Dashboard Builder — AI Analytics](https://camelai.com/github) - Build DORA dashboards, PR trackers, and release notes from your GitHub repos with AI.
+
+10. [How to track issues and PRs in many GitHub repositories](https://stackoverflow.com/questions/66985197/how-to-track-issues-and-prs-in-many-github-repositories) - I work on many GitHub repositories ( > 10 ) with fairly small user bases. I sometimes lose track of ...
+
+11. [Git Workspaces: Multi-Repo Management Made Easy](https://www.gitkraken.com/features/workspaces) - Manage multiple Git repositories simultaneously with Workspaces. Group related repos, perform bulk o...
+
+12. [Managing issues across multiple github repositories](https://stackoverflow.com/questions/69709469/managing-issues-across-multiple-github-repositories) - I am managing issues and projects in multiple GitHub repositories within a GitHub organization. Each...
+
+13. [GitHub Organization | Grafana Labs](https://grafana.com/grafana/dashboards/14461-github-organization/)
+
+14. [Issues 619](https://github.com/blacksmithgu/obsidian-dataview/issues) - A data index and query language over Markdown files, for https://obsidian.md/. - blacksmithgu/obsidi...
+
+15. [As a user, I would like PRs to be "waiting on author" after a certain number of ...](https://github.com/pullreminders/backlog/issues/103) - Pull Reminders handles ・ when someone leaves a review, the review request ・ the pull request goes to...
+
+16. [Triage Procedure - Rust Forge](https://forge.rust-lang.org/release/triage-procedure.html) - Supplemental documentation for contributing to The Rust Programming Language
+
+17. [29.2.3. GitHub Pull Request Workflow](https://docs.suricata.io/en/latest/devguide/contributing/github-pr-workflow.html)
+
+18. [待つツールを作って活用している ( gh-wait / gh-copilot-review )](https://k1low.hatenablog.com/entry/2026/04/17/083000) - 最近はCoding Agentを使って開発をしています。複数のCoding Agentを立ち上げて、それらと複数のタスクを並行して進めるようになりました。 一方で、感覚として「待つ」ことが多くなった気...
+
+19. [GitHub PR Review Router - AI Agent Automations](https://www.trigger.tools/automations/github-pr-review-router/) - Shows what each open PR is waiting on, so reviewers and authors know where attention should go next.
+
+20. [Grove — a CLI that manages git worktree workspaces across multiple repos](https://www.reddit.com/r/Python/comments/1s3id30/grove_a_cli_that_manages_git_worktree_workspaces/) - Grove — a CLI that manages git worktree workspaces across multiple repos
+
+21. [Mars | Multi-Repo Workspace Manager](https://dean0x.github.io/x/mars/) - Multi-repo workspace manager for teams. Tag repos, run parallel operations, and share Claude config,...
+
+22. [I built a CLI tool (RepoFleet) to manage Git branches across multiple ...](https://www.reddit.com/r/git/comments/1uq4pxh/i_built_a_cli_tool_repofleet_to_manage_git/) - I built a CLI tool (RepoFleet) to manage Git branches across multiple repositories simultaneously. M...
+
+23. [I built deadbranch — a Rust CLI tool to safely clean up those 50+ stale git branches cluttering your repo](https://www.reddit.com/r/git/comments/1qtcae0/i_built_deadbranch_a_rust_cli_tool_to_safely/) - I built deadbranch — a Rust CLI tool to safely clean up those 50+ stale git branches cluttering your...
+
+24. [Git Branch Aging Report: Finding and Cleaning Stale Branches](https://codepulsehq.com/guides/git-branch-aging-report) - Stale branches are hidden technical debt. Track branch aging, identify fossilized code, and automate...
+
+25. [continue-claude-work](https://skills-anthropic.vercel.app/skill/continue-claude-work) - claude --resume replays the full session transcript into the context window. For long sessions this ...
+
+26. [Manage sessions - Claude Code Docs](https://code.claude.com/docs/en/sessions) - Resume a session Sessions are saved continuously to local transcript files as you work, so you can r...
+
+27. [Resume old sessions · Issue #371 · anthropics/claude-code](https://github.com/anthropics/claude-code/issues/371) - Right now closing a terminal window with a long chat is a pretty serious commitment. If I want to wo...
+
+28. [Does Claude Code have any way to access previous ...](https://www.reddit.com/r/ClaudeCode/comments/1rvagol/does_claude_code_have_any_way_to_access_previous/) - I am working on a long term project and I want Claude Code to be able to read what happened in past ...
+
+29. [Claude Code handoff skill - session state & handoff ... - Github-Gist](https://gist.github.com/edwilde/cb2bf5f8851ea1d79ddc19995eec8b5b) - Claude Code handoff skill - session state & handoff document generator - SKILL.md
+
+30. [Zoomable treemap / D3](https://observablehq.com/@d3/zoomable-treemap) - This treemap supports zooming: click any cell to zoom in, or the top to zoom out. This custom tiling...
+
+31. [Zoomable Icicle Javascript Example - The Observable Forum](https://talk.observablehq.com/t/zoomable-icicle-javascript-example/6974) - Why don't this show anything on the screen and there is no error? <!DOCTYPE html> <html> <head> <tit...
+
+32. [Zoomable Icicle (d3 v4)](https://gist.github.com/a35c0f4f32400755a6a9b976be834ab3) - Zoomable Icicle (d3 v4). Download ZIP Zoomable Icicle (d3 v4) , "TreeMapLayout": 9191 }, Click anywh...
+
+33. [D3 Responsive Zoomable Treemap (D3 v4+)](https://gist.github.com/Tak113/aab0f2944a44de4e5aeda8c0578d0bce) - D3 Responsive Zoomable Treemap (D3 v4+). GitHub Gist: instantly share code, notes, and snippets.
+
+34. [D3 Gallery Vanilla JS](https://takanori-fujiwara.github.io/d3-gallery-javascript/)
+
+35. [Treemap | Pangea Proxima](https://observablehq.observablehq.cloud/pangea/d3/treemap)
+
+36. [Override Files - Configuration Language | Terraform](https://developer.hashicorp.com/terraform/language/files/override) - Override files merge additional settings into existing configuration objects. Learn how to use overr...
+
+37. [working-with-chezmoi - Claude Skills](https://claude-plugins.dev/skills/@jlindley/jlindley-skills/working-with-chezmoi) - Use when working with any configuration file outside of project directories in ~/Code (unless alread...
+
+38. [Chezmoi Guide: Manage Dotfiles Across Multiple Machines](https://www.deployhq.com/guides/chezmoi) - Learn how to use chezmoi to manage dotfiles across multiple machines. Covers installation, templates...
+
+39. [Does the order in which the patches are defined matter? · Issue #727 · kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize/issues/727) - I'm trying to create an overrides patch to be applied last. It works a majority of the time but some...
+
+40. [Change "DO NOT EDIT BELOW THIS LINE" to "DO NOT EDIT ABOVE THIS LINE" · Issue #151 · thoughtbot/dotfiles](https://github.com/thoughtbot/dotfiles/issues/151) - I believe it was @jessieay who noticed she wanted to override a setting somewhere (.gitconfig?) but ...
+
+41. [Lintian Tag: generated-file - Debian](https://lintian.debian.org/tags/generated-file.html) - Explanation for the lintian tag generated-file
+
+42. [Proto Best Practices](https://protobuf.dev/best-practices/dos-donts/) - Ensure that options in .proto file do not result in generation of code which violate the style guide...

--- a/docs/research/workmap/handoff-prompt.md
+++ b/docs/research/workmap/handoff-prompt.md
@@ -1,0 +1,106 @@
+You are doing prior-art / competitive research to de-risk a design doc
+called "Workmap." Answer the questions below independently — you have not
+seen and should not seek out any other source's answers to this same
+brief. Web search is expected; don't rely on your own recall alone.
+
+## Context
+
+Workmap is a proposed personal tool: a self-monitoring activity map for
+someone with many concurrent projects/repos/issues/PRs/AI-agent sessions
+going at once. It's structured as a Theme → Project → Thread hierarchy
+(where a Thread is a single GitHub issue, PR, git branch/worktree, or AI
+coding-agent session). Every Thread carries three fields:
+
+- `status` — what it's currently blocked on (e.g. waiting-on-review,
+  waiting-on-user-input, in-progress, stale)
+- `do-next` — the single next concrete action
+- `go-here` — instructions to resume/continue the work
+
+Data is meant to come from a hybrid of auto-discovery (crawling GitHub API
+state, local git/worktree state, and AI-agent session transcripts) plus a
+manual-override file for cases the crawler can't infer, with manual entries
+always winning on conflict. It's meant to render as a zoomable D3
+hierarchy (treemap or radial/icicle), color-coded by status, with a
+click-to-drill-down detail panel — plus a flat filterable-table fallback
+view for quick scanning.
+
+## Your task
+
+Answer each question below. For each, list concrete entries (named tools,
+libraries, articles, projects — not vague categories), and for each entry
+give: what it is, how it overlaps with the workmap concept described
+above, and a verdict.
+
+**Verdict must be exactly one of:** `adopt/reference` (directly usable or a
+pattern worth copying), `differentiate` (relevant, but workmap should do
+this differently — say why in your notes), or `ignore` (surfaced but not
+actually relevant). Do not invent other verdict labels.
+
+**If a question turns up nothing after a real search, say so explicitly**
+(what you searched, why you believe it's genuinely absent) rather than
+leaving it blank.
+
+### 1. Is there existing prior art for the whole concept?
+
+Are there existing tools, products, or well-known personal setups that
+already solve "one map of all my active work across many
+repos/projects/threads"? Include both dev-focused tools (multi-repo
+PR/issue dashboards, GitHub project-board alternatives) and general
+personal-PKM/second-brain tools adapted for this use, if genuinely
+comparable.
+
+### 2. Status inference from GitHub issue/PR state
+
+Do existing tools or libraries already classify a GitHub issue/PR's
+"waiting on me" vs. "waiting on them" vs. "stale" status from the GitHub
+API? What signals do they use beyond review-requested /
+changes-requested / last-commenter (e.g. CI state, assignee, label
+conventions)? Cite anything with a public algorithm or open-source
+implementation.
+
+### 3. Local multi-repo / worktree state crawling
+
+Are there existing CLI tools or scripts that scan across many local git
+repos/worktrees and report branch staleness, uncommitted work, or
+divergence from `main`? How do they define "stale," and do they handle
+`git worktree` specifically (not just plain clones)?
+
+### 4. Mining AI coding-agent session transcripts/logs for status
+
+Is there prior art — from Anthropic/Claude Code, or adjacent AI coding-agent
+tooling (Cursor, Aider, Windsurf, etc.) — for extracting structured "what
+state did this session end in" data from agent session transcripts or
+logs, for the purpose of resuming or tracking work?
+
+### 5. D3 zoomable-hierarchy patterns for status dashboards
+
+What are the established D3 (or D3-adjacent, e.g. Observable Plot)
+patterns for a zoomable treemap/icicle/radial layout with per-node status
+color and click-to-drill-down + detail panel? Are there off-the-shelf
+examples or libraries close enough to fork rather than build from scratch?
+
+### 6. Hybrid auto-discovery + manual-override conflict resolution
+
+In other tools that combine an auto-generated data layer with manual
+hand-edits that must survive regeneration (config-as-code with local
+overrides, generated docs with manual annotations, dotfile managers, etc.),
+what patterns exist for (a) the override file format, (b) merge/precedence
+rules, and (c) flagging an override as stale (e.g. written before the
+underlying auto-discovered state changed)?
+
+## Non-goals
+
+Don't design the implementation (schema, code structure, repo layout) —
+just report what already exists. Don't try to answer "where should the
+output live," "what repo scope," or "what triggers a regen" — those are
+product decisions specific to the requester, not things prior art can
+resolve.
+
+## Output format
+
+Return one section per question above, in order, each with a table:
+
+`Entry | What it is | Workmap concept overlap | Verdict`
+
+followed by a Notes paragraph, and a final "Open gaps" section for
+anything you couldn't resolve. Plain markdown, no other format needed.

--- a/docs/research/workmap/synthesis.md
+++ b/docs/research/workmap/synthesis.md
@@ -1,0 +1,246 @@
+# Synthesis: Workmap research
+
+Sources: [`claude-findings.md`](findings/claude-findings.md) (web search, this
+session) and [`perplexity-findings.md`](findings/perplexity-findings.md)
+(Perplexity, pasted in independently). Two sources, gathered without either
+seeing the other's answers first.
+
+**A methodology note before the substance:** the two sources apply the
+`adopt/reference` vs. `differentiate` verdict noticeably differently.
+Claude's pass tends to mark any close analogue `adopt/reference` even when
+it only covers part of the problem; Perplexity reserves `adopt/reference`
+for things that solve a specific sub-problem precisely, and uses
+`differentiate` more often for "close but not reusable as-is." Read the
+*Notes* prose in each findings file as the primary signal — the verdict
+labels alone aren't directly comparable across the two docs.
+
+## 1. Prior art for the whole concept
+
+**Agreement:** Both sources independently converge on the strongest
+conclusion of the whole research pass: **no existing tool combines GitHub
+API state, local git/worktree state, and AI-agent session state into one
+hierarchical, drill-downable view.** Both also independently name DashGit,
+Repo Dashboard (rouralberto), and gh-dashboard (debba) as the closest
+GitHub-side analogues — three-way agreement on the same three tools from
+two fully independent searches is a strong signal these are the right
+GitHub-dashboard prior art to look at.
+
+**Conflict — and the most important one in this pass:** Claude found
+**Canopy** (two unrelated projects sharing the name, `juliensimon/canopy`
+and `isacssw/canopy`) — tools specifically for managing many parallel
+Claude Code sessions across git worktrees, with commands like `status`,
+`state`, `resume`. Perplexity's search never surfaced Canopy at all. This
+matters because Canopy overlaps directly with workmap's Thread=session
+concept — the "no tool combines all three data sources" conclusion both
+sources reached should be read as "no tool combines all three, but Canopy
+gets two of three (worktree + session) and DashGit-style tools get GitHub."
+The design doc should explicitly address why workmap isn't "Canopy plus a
+GitHub crawler bolted on."
+
+**What only one source caught:**
+- Claude only: Canopy (both projects), `gh-dash` (dlvhdr — a well-known
+  tool Perplexity's search missed entirely), Obsidian Canvas as a
+  zoomable-but-manual PKM comparison.
+- Perplexity only: octopeek, several more PR-only trackers (git-pull-request-dashboard,
+  github-pr-dashboard, PR Radar, camelAI), GitKraken *Workspaces* (distinct
+  from the Launchpad product Claude found), ZenHub/CodeTree, a Grafana
+  GitHub-org dashboard.
+
+**Mapped to issue #39:** Both sources support treating workmap's
+three-source combination as genuinely novel, not a re-implementation —
+this directly answers the implicit "are we reinventing something"
+question behind the whole research commission. It does not resolve Open
+Question #1 (where the output lives) or #3 (repo scope) — those remain
+user-specific product decisions, as the brief said they would.
+
+## 2. Status inference from GitHub issue/PR state
+
+**Agreement:** Both sources converge on the same underlying answer: there
+is no bespoke classification algorithm to build — every tool found
+composes GitHub's own native signals (search qualifiers / `reviewDecision`
+/ CI check-run state). Neither source found a public "stale" auto-classifier
+based on GitHub API state alone.
+
+**Perplexity's pass is substantially stronger here.** Claude's findings
+stopped at "the qualifiers exist and gh-dash composes them." Perplexity
+found actual documented algorithms with more precision:
+- **Pull Reminders** (`pullreminders/backlog`) has published SQL/pseudocode
+  for waiting-on-author vs. waiting-on-reviewer, using non-dismissed
+  reviews vs. current requested-reviewer list.
+- **Rust Forge's triage procedure** gives a battle-tested label taxonomy
+  (`S-waiting-on-review`, `S-waiting-on-author`, etc.) with explicit
+  transition rules per activity type.
+- **`gh-wait`** (k1LoW) has a directly useful refinement neither source's
+  other entries mention: **filtering out the user's own comments/approvals**
+  when deciding "waiting on me" — a subtle but important signal-cleaning
+  step workmap's crawler would need and might otherwise miss.
+
+**What's genuinely unanswered:** Neither source found a public
+"stale-from-inactivity" classifier for issues/PRs specifically (as opposed
+to Rust's fixed manual 15-day triage cadence). This directly answers issue
+#39's Open Question #2 in part (the qualifier-composition approach is the
+algorithm) but leaves the specific staleness threshold as something workmap
+has to define itself — both sources agree on this gap independently.
+
+## 3. Local multi-repo / worktree state crawling
+
+**Zero tool overlap between the two sources** — worth noting on its own:
+Claude found Canopy's worktree dashboard, `git-worktree-cli`, and a blog
+post on bulk-cleaning stale worktrees; Perplexity found Grove, Mars,
+RepoFleet, `deadbranch`, and a CodePulse branch-aging guide. Neither
+source named a single tool the other one found. That non-overlap suggests
+this space is large and fragmented enough that a third pass would likely
+turn up still more tools — treat both lists as partial, not exhaustive.
+
+**A conflict worth resolving, not just noting:** the two sources define
+"stale" differently, and both definitions are probably needed as separate
+status values rather than one bucket:
+- Claude's sources (`git-worktree-cli`, the brtkwr.com post) define stale
+  as **branch merged and/or its remote-tracking ref gone** — i.e., the work
+  is *done*, the worktree is just administrative debt.
+- Perplexity's sources (`deadbranch`, CodePulse) define stale as
+  **no commits within a configurable age threshold** (deadbranch defaults
+  to 30 days; CodePulse buckets at 7/30/90 days) — i.e., the work is
+  *abandoned or paused*, not necessarily finished.
+
+These are opposite implications for workmap's `status` field (one means
+"safe to archive," the other means "needs a nudge or a decision") — the
+design doc should treat them as two distinct signals, not collapse them
+into a single `stale` value.
+
+**What only one source caught:** Perplexity's **Mars** find is worth
+elevating specifically — it's a multi-repo workspace manager that already
+shares "Claude/agent config" per tagged repo group, which is closer to
+workmap's Project-level grouping + agent-session awareness than anything
+in Claude's Q3 list. Worth a closer read before designing workmap's own
+grouping mechanism.
+
+## 4. Mining AI coding-agent session transcripts for status
+
+**Strong agreement, independently corroborated:** both sources
+independently landed on **`continue-claude-work`** as the single closest
+piece of prior art — high-confidence signal this is the right thing to
+read before writing new extraction logic. Perplexity's version is more
+detailed and more useful (names the actual script, `extract_resume_context.py`,
+and its session-end classification: `completed` / `interrupted` /
+`error_cascade` / `abandoned`) — treat Perplexity's description as the
+higher-fidelity one to act on.
+
+**A direct factual conflict that needs verification, not just noting:**
+Perplexity's pass explicitly searched for Cursor/Aider/Windsurf equivalents
+and reported finding nothing — a deliberate, stated negative result, not
+silence. But Claude's pass separately found **`cli-continues`**
+(`yigitkonur/cli-continues`), which claims to parse **16 different AI
+coding tools' native session formats** (JSONL/JSON/SQLite/YAML) — including,
+implicitly, tools beyond Claude Code — specifically to extract resumable
+state for handoff between tools. These two findings directly contradict
+each other on whether structured session-state extraction exists outside
+the Claude Code ecosystem. **This should be checked by hand** (read
+`cli-continues`'s actual source, not just its README description) before
+either claim is trusted — it's possible `cli-continues`'s "16 tools" claim
+is aspirational/thin for non-Claude formats, which would resolve the
+conflict in Perplexity's favor, but that needs confirming.
+
+**What only one source caught:** Perplexity's **session-handoff skill**
+gist (edwilde) — a prompt template that has the agent *write* a structured
+status/next-steps/restoration-procedure summary at the end of a session,
+rather than mining it after the fact. This is a much closer match to
+workmap's own Phase 2 plan ("sessions update their own thread's status as
+a side effect of work happening") than any mining-based tool, and deserves
+more weight in the design doc than either source's verdict label alone
+suggests.
+
+## 5. D3 zoomable-hierarchy patterns
+
+**Strong agreement:** both sources name the same two canonical Observable
+examples (zoomable treemap, zoomable icicle) as directly forkable, and —
+independently, in different words — both conclude that **no existing
+example combines the zoom interaction with a persistent side detail
+panel**; every example found does either zoom-only or hover-tooltip-only.
+Two independent searches reaching the same specific negative conclusion is
+good evidence this is a real gap to design around, not a search miss.
+
+**Perplexity's pass is more thorough here** and adds three things Claude's
+didn't find, all genuinely useful:
+- The **zoomable sunburst** (radial layout) — fills in the "radial" option
+  the design doc explicitly lists alongside treemap/icicle, which Claude's
+  search missed.
+- **D3 Gallery Vanilla JS** (takanori-fujiwara) — solves a practical
+  problem neither source flagged as a risk until Perplexity found the
+  fix: Observable notebook code doesn't run standalone as-is, and this is
+  a full port of the same examples into plain JS.
+- **Pangea Proxima's Treemap component** — an actual reusable,
+  parameterized component (data/value/label/tile/group props) rather than
+  a single-purpose demo, a better structural starting point than forking
+  a notebook directly.
+
+**Mapped to issue #39:** this strongly resolves Open Question #5 in favor
+of forking existing D3 examples rather than building bespoke — across two
+independent passes, nothing suggested the visualization needs novel D3
+work beyond composing the zoom examples with a standard click-to-panel
+handler and adding a status color scale.
+
+## 6. Hybrid auto-discovery + manual-override conflict resolution
+
+**Agreement on the core precedence pattern:** both sources independently
+found Terraform's override-file mechanism (separate file, always wins,
+loaded last) as the closest analogue to workmap's "manual entries always
+win" rule.
+
+**A productive disagreement about chezmoi:** Claude marked chezmoi
+`differentiate`, reasoning it solves a different problem (same-repo,
+different-machine templating, not generated-vs-manually-edited data).
+Perplexity marked chezmoi `adopt/reference`, but for a narrower and more
+precise reason: its `diff`/`status` workflow treats any manual edit to a
+generated file as *drift* to be explicitly reconciled — which is the
+closest documented mechanic to workmap's *staleness-detection* sub-problem,
+even though chezmoi's drift direction is the inverse of what workmap needs
+(local file diverging from a managed template, vs. workmap's manual
+override becoming stale relative to newly observed ground truth). Claude's
+verdict wasn't wrong about chezmoi's overall precedence model, but
+Perplexity's read is more useful for this specific sub-problem — worth
+re-reading chezmoi's diff mechanism specifically for the comparison
+technique (timestamp vs. content hash), not for its overall approach.
+
+**What only one source caught:** Perplexity found **Kustomize
+overlays/patches** and **JSON Merge Patch / JSON Patch (RFC 7386 / RFC
+6902)** — both give a standardized, off-the-shelf schema option for the
+override file's merge semantics that neither Terraform's nor Claude's
+doctoc-marker finding addresses (those establish *that* overrides should
+win, not a portable *format* for expressing partial-field overrides).
+
+**Strongly corroborated open gap:** both sources, independently and
+explicitly, concluded that **no existing tool flags a manual override as
+stale because the underlying auto-discovered truth has since changed**
+(e.g., a hand-written "waiting-on-review" override left in place after the
+PR actually merged). This is issue #39's Open Question #6 in its exact
+form. Two independent research passes reaching the same specific gap is
+strong evidence this is genuinely unsolved elsewhere, not a search
+failure — workmap's design doc / a future RFC needs to invent this
+mechanism rather than borrow one (a per-override "last-verified-against"
+timestamp or hash, diffed against the crawler's fresh read each run, is
+the shape both sources independently sketch as the likely answer).
+
+## What's genuinely unanswered, across both passes
+
+1. **Override staleness detection** (Q6) — confirmed as an open problem by
+   both sources; no prior art to borrow, needs original design.
+2. **CI status / label-convention signals** for status inference beyond
+   review-requested/changes-requested — Claude flagged this as
+   unaddressed; Perplexity's Pull Reminders and Rust Forge entries partly
+   fill this in (activity-type-based label transitions) but neither source
+   found a general, tool-agnostic pattern for folding CI/label state into
+   a status value.
+3. **Whether structured session-state extraction genuinely doesn't exist
+   for Cursor/Aider/Windsurf**, or whether `cli-continues` already does it
+   and Perplexity's search simply missed that tool — needs a manual check
+   of `cli-continues`'s source before treating either claim as settled.
+4. **A numeric staleness threshold for GitHub issues/PRs specifically**
+   (as opposed to local branches, where Perplexity's sources gave concrete
+   30-day / 7-30-90-day defaults) — neither source found a public default
+   for this.
+
+None of the above were answerable from documentation alone; a third
+source, or hands-on testing of Canopy, `continue-claude-work`, and
+`cli-continues` specifically, would be the next step if more confidence is
+wanted before the design doc is finalized.


### PR DESCRIPTION
## Summary
- Scaffolds a research pass on the workmap design (issue #39): brief, findings structure, handoff prompt
- Two independent findings docs — this session's web search, and Perplexity (pasted in) — answering the same 6-question brief without seeing each other's work
- A synthesis comparing both: agreements, conflicts, what only one source caught, and what's genuinely unanswered

## Changes
- `docs/research/README.md` — new top-level research topic index
- `docs/research/workmap/brief.md` — 6 research questions, each traced to a section of issue #39
- `docs/research/workmap/README.md` — read-order index for this topic
- `docs/research/workmap/handoff-prompt.md` — self-contained prompt for sources without repo access
- `docs/research/workmap/findings/README.md` + `TEMPLATE.md` — submission convention (closed-set verdicts, no empty tables)
- `docs/research/workmap/findings/claude-findings.md` — this session's independent findings
- `docs/research/workmap/findings/perplexity-findings.md` — Perplexity's independent findings
- `docs/research/workmap/synthesis.md` — cross-source comparison and open gaps

## Test plan
- [ ] Skim `synthesis.md` for the flagged conflict (Perplexity found no Cursor/Aider/Windsurf session-extraction tooling; Claude's pass found `cli-continues` claiming to cover 16 tools) — worth a manual check before relying on either claim
- [ ] Confirm the Canopy prior-art finding (two same-named projects overlapping workmap's session+worktree scope) doesn't change the design doc's direction

## Related
Related to #39