### PR TITLE
Add CODEOWNERS (documentation only)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Every path in this repo, by default.
+# Not a hard merge gate (required_approving_review_count is 0 to avoid a
+# self-approval deadlock for a solo maintainer) -- this documents who is
+# authorized and auto-requests review, without blocking self-merged PRs.
+* @dhk


### PR DESCRIPTION
Documents @dhk as the sole owner/reviewer across the repo. Not a hard merge gate — required_approving_review_count stays at 0 to avoid a self-approval deadlock (GitHub blocks approving your own PR). Auto-requests review and makes authorization explicit.