### PR TITLE
feat: land the session-consolidation implementation (design merged in #41, code never did)

### DIFF
--- a/session-consolidation/README.md
+++ b/session-consolidation/README.md
@@ -1,0 +1,68 @@
+# session-consolidation
+
+Sweeps local Claude Code session transcripts (`~/.claude/projects/*/*.jsonl`),
+clusters related ones, classifies each (active / completed / stale / orphaned /
+superseded), and proposes a tiered action list — safe to archive, needs a
+decision, keep as-is. Nothing is archived without explicit approval, and
+"archive" always means *move*, never delete. See
+[`docs/session-consolidation-design.md`](../docs/session-consolidation-design.md)
+in the repo root for the full design.
+
+## Layout
+
+- `session_consolidation/core.py` — all logic (sweep/cluster/classify/propose/archive).
+  No dependencies beyond the standard library.
+- `session_consolidation/cli.py` — CLI, imports `core.py` directly. No server needed.
+- `session_consolidation/mcp_server.py` — MCP server wrapping the same core
+  functions as tools, for any MCP host (Claude Desktop, another agent, or this
+  Claude Code skill via MCP instead of shelling out). Requires the `mcp` package.
+- `web/viewer.html` — static, dependency-free viewer. Open it directly or drop
+  a report JSON onto the page; no server process.
+- `tests/test_core.py` — pytest suite over `core.py`.
+- `../skills/user/session-consolidation/SKILL.md` — the Claude Code skill,
+  shells out to the CLI.
+
+## CLI usage
+
+```bash
+cd session-consolidation
+python3 -m session_consolidation.cli report --since 30d --out report.json
+```
+
+Prints a human-readable tiered summary to stderr and writes the full JSON to
+`report.json` (drop that file onto `web/viewer.html` to browse it visually).
+
+Archiving is always a separate, explicit step:
+
+```bash
+# dry run -- shows what would move, moves nothing
+python3 -m session_consolidation.cli archive --report report.json --approve-tier safe_to_archive
+
+# actually move the safe-to-archive sessions (reversible: they land under ~/.claude/projects-archive/)
+python3 -m session_consolidation.cli archive --report report.json --approve-tier safe_to_archive --yes
+
+# approve specific sessions individually (works for any tier, e.g. needs_a_decision after you've looked)
+python3 -m session_consolidation.cli archive --report report.json --approve <session_id> --yes
+```
+
+Bulk-approval (`--approve-tier`) only accepts `safe_to_archive` — sessions in
+`needs_a_decision` must be approved one at a time via `--approve <id>`.
+
+## MCP server (optional)
+
+Only needed if something other than this CLI should call the same logic —
+Claude Desktop, another agent, etc. Requires the `mcp` package:
+
+```bash
+pip install -r requirements.txt
+claude mcp add session-consolidation -- python3 -m session_consolidation.mcp_server
+```
+
+Exposes `sweep_sessions`, `propose_actions`, and `archive_sessions` as MCP tools.
+
+## Running tests
+
+```bash
+pip install pytest
+python3 -m pytest session-consolidation/tests/
+```

--- a/session-consolidation/requirements.txt
+++ b/session-consolidation/requirements.txt
@@ -1,0 +1,3 @@
+# Only needed for the optional MCP server (session_consolidation/mcp_server.py).
+# core.py and cli.py have no third-party dependencies.
+mcp>=1.0

--- a/session-consolidation/session_consolidation/__init__.py
+++ b/session-consolidation/session_consolidation/__init__.py
@@ -1,0 +1,3 @@
+"""session-consolidation: sweep, cluster, classify, and (on approval) archive
+local Claude Code session transcripts. See core.py for the implementation and
+docs/session-consolidation-design.md (repo root) for the design."""

--- a/session-consolidation/session_consolidation/cli.py
+++ b/session-consolidation/session_consolidation/cli.py
@@ -1,0 +1,181 @@
+"""CLI for session-consolidation. Imports core.py directly -- no MCP server
+process required for sweep/report; only needed if you want other MCP hosts
+to call the same logic (see mcp_server.py).
+
+Usage:
+    session-consolidation report [--since 30d] [--out report.json]
+    session-consolidation archive --report report.json --approve-tier safe_to_archive --yes
+    session-consolidation archive --report report.json --approve <session_id> [<session_id> ...] --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import core
+
+TIER_LABELS = {
+    core.TIER_SAFE: "Safe to archive",
+    core.TIER_DECISION: "Needs a decision",
+    core.TIER_KEEP: "Keep as-is",
+}
+
+
+def _parse_since(value: str):
+    if value is None or value.lower() == "all":
+        return None
+    value = value.lower().strip()
+    if value.endswith("d"):
+        value = value[:-1]
+    return int(value)
+
+
+def _print_report_summary(report: dict, file=sys.stderr):
+    summary = report["summary"]
+    since_label = f"{report['since_days']}d" if report["since_days"] is not None else "all"
+    print(
+        f"Swept {summary['total_sessions']} session(s) across {summary['total_clusters']} "
+        f"cluster(s) under {report['projects_dir']} "
+        f"(since={since_label}, stale_days={report['stale_days']})",
+        file=file,
+    )
+    for tier in (core.TIER_SAFE, core.TIER_DECISION, core.TIER_KEEP):
+        print(f"  {TIER_LABELS[tier]}: {summary[tier]}", file=file)
+    print(file=file)
+
+    for c in report["clusters"]:
+        print(f"Cluster {c['cluster_id']}  ({c['project_dir']}, {c['session_count']} session(s))", file=file)
+        for s in c["sessions"]:
+            print(
+                f"  [{s['tier']}] {s['classification']:<11} {s['session_id'][:12]}  "
+                f"{s['reason']}",
+                file=file,
+            )
+            topic = s["first_user_message"].splitlines()[0][:80] if s["first_user_message"] else "(no topic captured)"
+            print(f"      \"{topic}\"", file=file)
+        print(file=file)
+
+
+def cmd_sweep(args):
+    directory = Path(args.projects_dir) if args.projects_dir else core.DEFAULT_PROJECTS_DIR
+    sessions = core.sweep(directory, _parse_since(args.since))
+    payload = {"count": len(sessions), "sessions": [vars(s) for s in sessions]}
+    _write_json(payload, args.out)
+    if args.out:
+        print(f"Wrote {len(sessions)} session(s) to {args.out}", file=sys.stderr)
+
+
+def cmd_report(args):
+    directory = Path(args.projects_dir) if args.projects_dir else core.DEFAULT_PROJECTS_DIR
+    report = core.build_report(
+        projects_dir=directory,
+        since_days=_parse_since(args.since),
+        stale_days=args.stale_days,
+    )
+    if not args.quiet:
+        _print_report_summary(report)
+    _write_json(report, args.out)
+    if args.out:
+        print(f"Wrote report to {args.out}", file=sys.stderr)
+
+
+def cmd_archive(args):
+    report = json.loads(Path(args.report).read_text())
+
+    by_id = {}
+    for c in report["clusters"]:
+        for s in c["sessions"]:
+            by_id[s["session_id"]] = s
+
+    targets = []
+    if args.approve_tier:
+        targets = [s for s in by_id.values() if s["tier"] == args.approve_tier]
+        if args.approve_tier != core.TIER_SAFE:
+            print(
+                f"Refusing to bulk-approve tier '{args.approve_tier}': only "
+                f"'{core.TIER_SAFE}' can be approved in bulk. Use --approve <id> "
+                f"for individual sessions in other tiers.",
+                file=sys.stderr,
+            )
+            return 1
+    elif args.approve:
+        missing = [sid for sid in args.approve if sid not in by_id]
+        if missing:
+            print(f"Unknown session id(s) in report: {', '.join(missing)}", file=sys.stderr)
+            return 1
+        targets = [by_id[sid] for sid in args.approve]
+    else:
+        print("Nothing to do: pass --approve <id...> or --approve-tier safe_to_archive", file=sys.stderr)
+        return 1
+
+    if not targets:
+        print("No matching sessions to archive.", file=sys.stderr)
+        return 0
+
+    print(f"{'Archiving' if args.yes else 'Would archive'} {len(targets)} session(s):", file=sys.stderr)
+    for s in targets:
+        print(f"  [{s['classification']}] {s['session_id']}  {s['path']}", file=sys.stderr)
+
+    if not args.yes:
+        print("\nDry run only -- re-run with --yes to actually move these files.", file=sys.stderr)
+        return 0
+
+    archive_dir = Path(args.archive_dir) if args.archive_dir else core.DEFAULT_ARCHIVE_DIR
+    results = core.archive_sessions(
+        [s["path"] for s in targets],
+        archive_dir=archive_dir,
+        reason=args.reason or f"approved via CLI ({args.approve_tier or 'explicit ids'})",
+    )
+    for r in results:
+        print(f"  {r['status']}: {r['session_id']} -> {r.get('path')}", file=sys.stderr)
+    return 0
+
+
+def _write_json(payload: dict, out: str):
+    text = json.dumps(payload, indent=2)
+    if out:
+        Path(out).write_text(text)
+    else:
+        print(text)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="session-consolidation")
+    parser.add_argument("--projects-dir", default=None, help="Override ~/.claude/projects")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_sweep = sub.add_parser("sweep", help="Raw session inventory, no clustering/classification")
+    p_sweep.add_argument("--since", default="30d", help="e.g. 7d, 30d, all (default: 30d)")
+    p_sweep.add_argument("--out", default=None, help="Write JSON here instead of stdout")
+    p_sweep.set_defaults(func=cmd_sweep)
+
+    p_report = sub.add_parser("report", help="Full sweep -> cluster -> classify -> propose pipeline")
+    p_report.add_argument("--since", default="30d", help="e.g. 7d, 30d, all (default: 30d)")
+    p_report.add_argument("--stale-days", type=int, default=core.STALE_DAYS)
+    p_report.add_argument("--out", default=None, help="Write JSON report here (also feeds the web viewer)")
+    p_report.add_argument("--quiet", action="store_true", help="Suppress the human-readable summary")
+    p_report.set_defaults(func=cmd_report)
+
+    p_archive = sub.add_parser("archive", help="Archive approved sessions from a prior report (move, never delete)")
+    p_archive.add_argument("--report", required=True, help="Path to a report JSON from `report --out`")
+    p_archive.add_argument("--approve", nargs="+", metavar="SESSION_ID", help="Explicit session ids to archive")
+    p_archive.add_argument("--approve-tier", choices=[core.TIER_SAFE], help="Bulk-approve every session in this tier (safe_to_archive only)")
+    p_archive.add_argument("--archive-dir", default=None, help="Override ~/.claude/projects-archive")
+    p_archive.add_argument("--reason", default=None, help="Recorded in the archive manifest")
+    p_archive.add_argument("--yes", action="store_true", help="Actually move files; omit for a dry run")
+    p_archive.set_defaults(func=cmd_archive)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args) or 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/session-consolidation/session_consolidation/core.py
+++ b/session-consolidation/session_consolidation/core.py
@@ -1,0 +1,415 @@
+"""Core sweep/cluster/classify/propose/archive logic for session-consolidation.
+
+Plain functions, no MCP/CLI/web dependencies. The CLI and the MCP server both
+import this module directly so the logic lives in exactly one place. See
+docs/session-consolidation-design.md in the repo root for the design this
+implements.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+DEFAULT_ARCHIVE_DIR = Path.home() / ".claude" / "projects-archive"
+DEFAULT_MANIFEST_PATH = Path.home() / ".claude" / "session-consolidation-log.jsonl"
+
+STALE_DAYS = 14
+CLUSTER_WINDOW_DAYS = 14
+
+TIER_SAFE = "safe_to_archive"
+TIER_DECISION = "needs_a_decision"
+TIER_KEEP = "keep_as_is"
+
+_KEYWORD_STOPWORDS = {
+    "this", "that", "with", "have", "from", "they", "will", "would", "there",
+    "their", "what", "about", "which", "when", "make", "like", "time", "just",
+    "know", "take", "into", "your", "some", "could", "them", "then", "than",
+    "look", "only", "come", "over", "also", "back", "after", "should", "session",
+    "sessions", "want", "need", "help", "please", "thanks", "okay",
+}
+
+
+@dataclass
+class Session:
+    session_id: str
+    path: str
+    project_dir: Optional[str]
+    git_branch: Optional[str]
+    first_user_message: str
+    last_message: str
+    message_count: int
+    start_time: Optional[str]
+    end_time: Optional[str]
+    files_touched: list = field(default_factory=list)
+    git_commands: list = field(default_factory=list)
+    committed: bool = False
+
+
+@dataclass
+class Cluster:
+    cluster_id: str
+    project_dir: Optional[str]
+    sessions: list  # list[Session]
+
+
+@dataclass
+class ClassifiedSession:
+    cluster_id: str
+    session: Session
+    classification: str
+    reason: str
+
+
+def _extract_text(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return " ".join(parts)
+    return ""
+
+
+def _iter_records(path: Path):
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _parse_ts(ts: Optional[str]) -> Optional[float]:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _keywords(text: str) -> set:
+    words = re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{3,}", text.lower())
+    return {w for w in words if w not in _KEYWORD_STOPWORDS}
+
+
+def parse_session(path: Path) -> Optional[Session]:
+    """Parse a single .jsonl transcript into a Session summary, or None if empty."""
+    session_id = path.stem
+    project_dir = None
+    git_branch = None
+    first_user_message = ""
+    last_message = ""
+    message_count = 0
+    start_time = None
+    end_time = None
+    files_touched = set()
+    git_commands = []
+    committed = False
+
+    for record in _iter_records(path):
+        rtype = record.get("type")
+        if rtype not in ("user", "assistant"):
+            continue
+        message_count += 1
+
+        ts = record.get("timestamp")
+        if ts:
+            if start_time is None:
+                start_time = ts
+            end_time = ts
+
+        if project_dir is None and record.get("cwd"):
+            project_dir = record["cwd"]
+        if git_branch is None and record.get("gitBranch"):
+            git_branch = record["gitBranch"]
+
+        message = record.get("message") or {}
+        content = message.get("content")
+
+        if rtype == "user" and not first_user_message:
+            text = _extract_text(content)
+            if text:
+                first_user_message = text
+
+        if rtype == "assistant":
+            text = _extract_text(content)
+            if text:
+                last_message = text
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict) or block.get("type") != "tool_use":
+                        continue
+                    name = block.get("name")
+                    tool_input = block.get("input") or {}
+                    if name in ("Edit", "Write", "NotebookEdit"):
+                        file_path = tool_input.get("file_path")
+                        if file_path:
+                            files_touched.add(file_path)
+                    elif name == "Bash":
+                        cmd = (tool_input.get("command") or "").strip()
+                        if not cmd:
+                            continue
+                        if "git commit" in cmd:
+                            committed = True
+                        if cmd.startswith("git ") or " git " in cmd:
+                            git_commands.append(cmd[:200])
+
+    if message_count == 0:
+        return None
+
+    return Session(
+        session_id=session_id,
+        path=str(path),
+        project_dir=project_dir,
+        git_branch=git_branch,
+        first_user_message=first_user_message.strip()[:500],
+        last_message=last_message.strip()[:500],
+        message_count=message_count,
+        start_time=start_time,
+        end_time=end_time,
+        files_touched=sorted(files_touched),
+        git_commands=git_commands[-10:],
+        committed=committed,
+    )
+
+
+def sweep(projects_dir: Path = DEFAULT_PROJECTS_DIR, since_days: Optional[int] = 30) -> list:
+    """Find and parse session transcripts under projects_dir.
+
+    Returns [] (not an error) when the directory is absent -- expected on
+    cloud/ephemeral environments with no local session history.
+    """
+    projects_dir = Path(projects_dir)
+    if not projects_dir.exists():
+        return []
+
+    cutoff = None
+    if since_days is not None:
+        cutoff = time.time() - since_days * 86400
+
+    sessions = []
+    for path in sorted(projects_dir.glob("*/*.jsonl")):
+        if cutoff is not None and path.stat().st_mtime < cutoff:
+            continue
+        session = parse_session(path)
+        if session:
+            sessions.append(session)
+    return sessions
+
+
+def cluster(sessions: list) -> list:
+    """Group sessions plausibly split across sessions: same project, recency,
+    and shared touched files or first-message keywords."""
+    by_project = {}
+    for s in sessions:
+        key = s.project_dir or "(unknown project)"
+        by_project.setdefault(key, []).append(s)
+
+    clusters = []
+    for project_dir, group in by_project.items():
+        group = sorted(group, key=lambda s: _parse_ts(s.start_time) or 0)
+        used = [False] * len(group)
+        for i, s in enumerate(group):
+            if used[i]:
+                continue
+            used[i] = True
+            member_idxs = [i]
+            acc_keywords = _keywords(s.first_user_message)
+            acc_files = set(s.files_touched)
+            acc_time = _parse_ts(s.start_time) or 0
+
+            for j in range(i + 1, len(group)):
+                if used[j]:
+                    continue
+                other = group[j]
+                other_time = _parse_ts(other.start_time) or 0
+                if other_time and acc_time and other_time - acc_time > CLUSTER_WINDOW_DAYS * 86400:
+                    continue
+                other_keywords = _keywords(other.first_user_message)
+                other_files = set(other.files_touched)
+                shares_file = bool(acc_files & other_files)
+                shares_keywords = len(acc_keywords & other_keywords) >= 2
+                if shares_file or shares_keywords:
+                    member_idxs.append(j)
+                    used[j] = True
+                    acc_files |= other_files
+                    acc_keywords |= other_keywords
+                    acc_time = max(acc_time, other_time)
+
+            members = [group[k] for k in member_idxs]
+            cluster_id = f"{project_dir}::{members[0].session_id[:8]}"
+            clusters.append(Cluster(cluster_id=cluster_id, project_dir=project_dir, sessions=members))
+
+    return clusters
+
+
+def _classify_one(session: Session, now: float, stale_days: int):
+    end_ts = _parse_ts(session.end_time)
+    age_days = (now - end_ts) / 86400 if end_ts else None
+    is_recent = age_days is not None and age_days <= stale_days
+    idle = f"idle {int(age_days)} day(s)" if age_days is not None else "idle for an unknown period"
+
+    if is_recent:
+        return "active", f"activity within the last {int(age_days)} day(s)"
+    if session.committed:
+        return "completed", "includes a git commit"
+    if session.files_touched:
+        return "orphaned", f"touched {len(session.files_touched)} file(s), no commit found, {idle}"
+    return "stale", f"no file changes or commits, {idle}"
+
+
+def classify(clusters: list, now: Optional[float] = None, stale_days: int = STALE_DAYS) -> list:
+    """Classify every session in every cluster. Active and orphaned sessions
+    are never silently marked superseded -- only completed/stale ones are,
+    when a later session in the same cluster carries the work forward."""
+    if now is None:
+        now = time.time()
+
+    results = []
+    for c in clusters:
+        base = [(s, *_classify_one(s, now, stale_days)) for s in c.sessions]
+        if len(c.sessions) > 1:
+            latest = max(c.sessions, key=lambda s: _parse_ts(s.end_time) or 0)
+            for idx, (s, cls, reason) in enumerate(base):
+                if s is not latest and cls in ("completed", "stale"):
+                    base[idx] = (
+                        s,
+                        "superseded",
+                        f"{reason}; superseded by a later session in the same cluster ({latest.session_id[:8]})",
+                    )
+        for s, cls, reason in base:
+            results.append(ClassifiedSession(cluster_id=c.cluster_id, session=s, classification=cls, reason=reason))
+    return results
+
+
+def tier_for(classification: str) -> str:
+    if classification in ("stale", "superseded"):
+        return TIER_SAFE
+    if classification == "orphaned":
+        return TIER_DECISION
+    return TIER_KEEP  # active, completed
+
+
+def build_report(
+    projects_dir: Path = DEFAULT_PROJECTS_DIR,
+    since_days: Optional[int] = 30,
+    stale_days: int = STALE_DAYS,
+) -> dict:
+    """Run the full sweep -> cluster -> classify -> propose pipeline and
+    return one JSON-serializable report -- the shape the CLI writes and the
+    web viewer reads."""
+    sessions = sweep(projects_dir, since_days)
+    clusters = cluster(sessions)
+    classified = classify(clusters, stale_days=stale_days)
+
+    by_cluster = {}
+    for cs in classified:
+        by_cluster.setdefault(cs.cluster_id, []).append(cs)
+
+    tier_counts = {TIER_SAFE: 0, TIER_DECISION: 0, TIER_KEEP: 0}
+    cluster_reports = []
+    for c in clusters:
+        session_reports = []
+        for cs in by_cluster.get(c.cluster_id, []):
+            tier = tier_for(cs.classification)
+            tier_counts[tier] += 1
+            s = cs.session
+            session_reports.append(
+                {
+                    "session_id": s.session_id,
+                    "path": s.path,
+                    "classification": cs.classification,
+                    "reason": cs.reason,
+                    "tier": tier,
+                    "first_user_message": s.first_user_message,
+                    "last_message": s.last_message,
+                    "message_count": s.message_count,
+                    "start_time": s.start_time,
+                    "end_time": s.end_time,
+                    "git_branch": s.git_branch,
+                    "files_touched": s.files_touched,
+                    "committed": s.committed,
+                }
+            )
+        # Most recently active session first within a cluster.
+        session_reports.sort(key=lambda r: r["end_time"] or "", reverse=True)
+        cluster_reports.append(
+            {
+                "cluster_id": c.cluster_id,
+                "project_dir": c.project_dir,
+                "session_count": len(session_reports),
+                "sessions": session_reports,
+            }
+        )
+
+    cluster_reports.sort(key=lambda c: (c["project_dir"] or "", -c["session_count"]))
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "projects_dir": str(projects_dir),
+        "since_days": since_days,
+        "stale_days": stale_days,
+        "summary": {
+            "total_sessions": len(sessions),
+            "total_clusters": len(clusters),
+            TIER_SAFE: tier_counts[TIER_SAFE],
+            TIER_DECISION: tier_counts[TIER_DECISION],
+            TIER_KEEP: tier_counts[TIER_KEEP],
+        },
+        "clusters": cluster_reports,
+    }
+
+
+def archive_sessions(
+    session_paths: list,
+    archive_dir: Path = DEFAULT_ARCHIVE_DIR,
+    manifest_path: Path = DEFAULT_MANIFEST_PATH,
+    reason: str = "",
+) -> list:
+    """Move approved session transcripts to a mirrored path under archive_dir
+    (never delete) and append one manifest entry per move for auditability."""
+    archive_dir = Path(archive_dir)
+    manifest_path = Path(manifest_path)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for raw_path in session_paths:
+        src = Path(raw_path)
+        if not src.exists():
+            results.append({"session_id": src.stem, "status": "missing", "path": str(src)})
+            continue
+
+        dest_dir = archive_dir / src.parent.name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / src.name
+
+        shutil.move(str(src), str(dest))
+
+        entry = {
+            "session_id": src.stem,
+            "from": str(src),
+            "to": str(dest),
+            "reason": reason,
+            "archived_at": datetime.now(timezone.utc).isoformat(),
+        }
+        with manifest_path.open("a") as mf:
+            mf.write(json.dumps(entry) + "\n")
+
+        results.append({"session_id": src.stem, "status": "archived", "path": str(dest)})
+
+    return results

--- a/session-consolidation/session_consolidation/mcp_server.py
+++ b/session-consolidation/session_consolidation/mcp_server.py
@@ -1,0 +1,68 @@
+"""MCP server exposing session-consolidation's core as tools.
+
+Thin wrapper only -- all logic lives in core.py. Register with:
+
+    claude mcp add session-consolidation -- python3 -m session_consolidation.mcp_server
+
+Run directly for local/manual testing:
+
+    python3 -m session_consolidation.mcp_server
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from . import core
+
+mcp = FastMCP("session-consolidation")
+
+
+@mcp.tool()
+def sweep_sessions(projects_dir: Optional[str] = None, since_days: Optional[int] = 30) -> dict:
+    """Sweep local Claude Code session transcripts and return their metadata
+    (project, first/last message, files touched, commit activity) without
+    clustering or classifying them. Use for a raw inventory; prefer
+    propose_actions for the full sweep -> cluster -> classify -> propose
+    pipeline in one call."""
+    directory = Path(projects_dir) if projects_dir else core.DEFAULT_PROJECTS_DIR
+    sessions = core.sweep(directory, since_days)
+    return {
+        "count": len(sessions),
+        "sessions": [vars(s) for s in sessions],
+    }
+
+
+@mcp.tool()
+def propose_actions(projects_dir: Optional[str] = None, since_days: Optional[int] = 30, stale_days: int = core.STALE_DAYS) -> dict:
+    """Run the full session-consolidation pipeline: sweep transcripts,
+    cluster related sessions, classify each (active / completed / stale /
+    orphaned / superseded), and tier them into safe_to_archive /
+    needs_a_decision / keep_as_is. Returns a report; does not archive
+    anything -- call archive_sessions with explicit paths after the caller
+    (a human, via whatever surface is presenting this) approves."""
+    directory = Path(projects_dir) if projects_dir else core.DEFAULT_PROJECTS_DIR
+    return core.build_report(projects_dir=directory, since_days=since_days, stale_days=stale_days)
+
+
+@mcp.tool()
+def archive_sessions(session_paths: list, reason: str = "", archive_dir: Optional[str] = None) -> dict:
+    """Archive (move, never delete) the given session transcript file paths
+    to a mirrored location under archive_dir (default
+    ~/.claude/projects-archive/), logging each move to an append-only
+    manifest. Only call this with paths the user has explicitly approved --
+    seeing a propose_actions report is not approval to archive it."""
+    directory = Path(archive_dir) if archive_dir else core.DEFAULT_ARCHIVE_DIR
+    results = core.archive_sessions(session_paths, archive_dir=directory, reason=reason)
+    return {"results": results}
+
+
+def main():
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/session-consolidation/tests/test_core.py
+++ b/session-consolidation/tests/test_core.py
@@ -1,0 +1,169 @@
+import json
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from session_consolidation import core  # noqa: E402
+
+
+def _ts(days_ago: float) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _write_session(
+    project_dir: Path,
+    session_id: str,
+    project_cwd: str,
+    first_message: str,
+    start_days_ago: float,
+    end_days_ago: float,
+    files_touched=(),
+    committed=False,
+):
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    lines = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": first_message},
+            "timestamp": _ts(start_days_ago),
+            "cwd": project_cwd,
+            "gitBranch": "main",
+        }
+    ]
+    content = []
+    for fp in files_touched:
+        content.append({"type": "tool_use", "name": "Edit", "input": {"file_path": fp}})
+    if committed:
+        content.append({"type": "tool_use", "name": "Bash", "input": {"command": "git commit -m 'done'"}})
+    content.append({"type": "text", "text": "wrapping up"})
+    lines.append(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": content},
+            "timestamp": _ts(end_days_ago),
+            "cwd": project_cwd,
+        }
+    )
+    with path.open("w") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    return path
+
+
+def test_sweep_returns_empty_list_when_projects_dir_missing(tmp_path):
+    assert core.sweep(tmp_path / "does-not-exist") == []
+
+
+def test_parse_session_extracts_expected_fields(tmp_path):
+    path = _write_session(
+        tmp_path / "proj",
+        "abc123",
+        "/home/user/repo",
+        "fix the login bug in auth.py",
+        start_days_ago=1,
+        end_days_ago=1,
+        files_touched=["/home/user/repo/auth.py"],
+        committed=True,
+    )
+    session = core.parse_session(path)
+    assert session.session_id == "abc123"
+    assert session.project_dir == "/home/user/repo"
+    assert session.committed is True
+    assert session.files_touched == ["/home/user/repo/auth.py"]
+    assert "login bug" in session.first_user_message
+
+
+def test_cluster_groups_by_project_and_shared_file(tmp_path):
+    proj = tmp_path / "proj"
+    _write_session(proj, "s1", "/home/user/repo", "fix the login bug in auth.py",
+                    start_days_ago=5, end_days_ago=5, files_touched=["/home/user/repo/auth.py"])
+    _write_session(proj, "s2", "/home/user/repo", "continue fixing the login bug",
+                    start_days_ago=2, end_days_ago=2, files_touched=["/home/user/repo/auth.py"])
+    _write_session(proj, "s3", "/home/user/other-repo", "unrelated work on a different repo",
+                    start_days_ago=2, end_days_ago=2, files_touched=["/home/user/other-repo/x.py"])
+
+    sessions = core.sweep(tmp_path, since_days=None)
+    assert len(sessions) == 3
+    clusters = core.cluster(sessions)
+    # s1/s2 share project + file -> one cluster; s3 is a different project -> its own cluster
+    sizes = sorted(len(c.sessions) for c in clusters)
+    assert sizes == [1, 2]
+
+
+def test_classify_marks_older_completed_session_as_superseded(tmp_path):
+    proj = tmp_path / "proj"
+    _write_session(proj, "old", "/home/user/repo", "add the export feature",
+                    start_days_ago=18, end_days_ago=18, files_touched=["/home/user/repo/export.py"], committed=True)
+    _write_session(proj, "new", "/home/user/repo", "finish the export feature",
+                    start_days_ago=5, end_days_ago=5, files_touched=["/home/user/repo/export.py"], committed=True)
+
+    sessions = core.sweep(tmp_path, since_days=None)
+    clusters = core.cluster(sessions)
+    assert len(clusters) == 1
+    classified = core.classify(clusters, stale_days=14)
+    by_id = {cs.session.session_id: cs for cs in classified}
+    assert by_id["new"].classification == "active"
+    assert by_id["old"].classification == "superseded"
+
+
+def test_classify_orphaned_never_marked_superseded(tmp_path):
+    proj = tmp_path / "proj"
+    _write_session(proj, "old_orphan", "/home/user/repo", "start the export feature",
+                    start_days_ago=18, end_days_ago=18, files_touched=["/home/user/repo/export.py"], committed=False)
+    _write_session(proj, "new", "/home/user/repo", "finish the export feature",
+                    start_days_ago=5, end_days_ago=5, files_touched=["/home/user/repo/export.py"], committed=True)
+
+    sessions = core.sweep(tmp_path, since_days=None)
+    clusters = core.cluster(sessions)
+    classified = core.classify(clusters, stale_days=14)
+    by_id = {cs.session.session_id: cs for cs in classified}
+    # orphaned (uncommitted touched files) must always surface for a human decision,
+    # never get silently swept into "superseded" alongside stale/completed sessions.
+    assert by_id["old_orphan"].classification == "orphaned"
+    assert core.tier_for(by_id["old_orphan"].classification) == core.TIER_DECISION
+
+
+def test_build_report_tier_counts_and_shape(tmp_path):
+    proj = tmp_path / "proj"
+    _write_session(proj, "stale1", "/home/user/repo", "an abandoned experiment",
+                    start_days_ago=40, end_days_ago=40)
+    report = core.build_report(projects_dir=tmp_path, since_days=None, stale_days=14)
+    assert report["summary"]["total_sessions"] == 1
+    assert report["summary"][core.TIER_SAFE] == 1
+    assert report["clusters"][0]["sessions"][0]["classification"] == "stale"
+
+
+def test_archive_moves_file_and_writes_manifest(tmp_path):
+    proj = tmp_path / "proj"
+    path = _write_session(proj, "stale1", "/home/user/repo", "an abandoned experiment",
+                           start_days_ago=40, end_days_ago=40)
+    archive_dir = tmp_path / "archive"
+    manifest_path = tmp_path / "manifest.jsonl"
+
+    results = core.archive_sessions([str(path)], archive_dir=archive_dir, manifest_path=manifest_path, reason="stale, no commit")
+
+    assert results[0]["status"] == "archived"
+    assert not path.exists()
+    dest = Path(results[0]["path"])
+    assert dest.exists()
+    assert dest.parent.name == "proj"
+
+    manifest_lines = manifest_path.read_text().strip().splitlines()
+    assert len(manifest_lines) == 1
+    entry = json.loads(manifest_lines[0])
+    assert entry["session_id"] == "stale1"
+    assert entry["reason"] == "stale, no commit"
+
+
+def test_archive_reports_missing_file_without_raising(tmp_path):
+    results = core.archive_sessions(
+        [str(tmp_path / "gone.jsonl")],
+        archive_dir=tmp_path / "archive",
+        manifest_path=tmp_path / "manifest.jsonl",
+    )
+    assert results[0]["status"] == "missing"

--- a/session-consolidation/web/viewer.html
+++ b/session-consolidation/web/viewer.html
@@ -1,0 +1,571 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Session Consolidation Viewer</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    --bg: #f6f7f9;
+    --panel: #ffffff;
+    --text: #1a1d23;
+    --muted: #64748b;
+    --border: #dde2e9;
+    --accent: #2563eb;
+    --accent-bg: #eaf1ff;
+    --safe: #1a7f37;
+    --safe-bg: #e7f7ec;
+    --decision: #9a6700;
+    --decision-bg: #fff5da;
+    --keep: #4d5562;
+    --keep-bg: #eef0f2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #12151b;
+      --panel: #1b1f27;
+      --text: #e7e9ee;
+      --muted: #90a0b7;
+      --border: #2a3140;
+      --accent: #6ea8fe;
+      --accent-bg: #172338;
+      --safe: #4fd67a;
+      --safe-bg: #133321;
+      --decision: #e3b341;
+      --decision-bg: #382c0d;
+      --keep: #aeb4bd;
+      --keep-bg: #262a30;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #f6f7f9;
+    --panel: #ffffff;
+    --text: #1a1d23;
+    --muted: #64748b;
+    --border: #dde2e9;
+    --accent: #2563eb;
+    --accent-bg: #eaf1ff;
+    --safe: #1a7f37;
+    --safe-bg: #e7f7ec;
+    --decision: #9a6700;
+    --decision-bg: #fff5da;
+    --keep: #4d5562;
+    --keep-bg: #eef0f2;
+  }
+  :root[data-theme="dark"] {
+    --bg: #12151b;
+    --panel: #1b1f27;
+    --text: #e7e9ee;
+    --muted: #90a0b7;
+    --border: #2a3140;
+    --accent: #6ea8fe;
+    --accent-bg: #172338;
+    --safe: #4fd67a;
+    --safe-bg: #133321;
+    --decision: #e3b341;
+    --decision-bg: #382c0d;
+    --keep: #aeb4bd;
+    --keep-bg: #262a30;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 2rem 1.25rem 6rem;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; }
+  h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+  .subtitle { color: var(--muted); font-size: 0.9rem; margin-bottom: 1.5rem; }
+  .loader {
+    background: var(--panel);
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    padding: 1.25rem;
+    text-align: center;
+    color: var(--muted);
+    margin-bottom: 1.5rem;
+  }
+  .loader input { margin-top: 0.5rem; }
+  .summary {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .stat {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+  }
+  .stat b { display: block; font-size: 1.3rem; }
+  .stat.safe b { color: var(--safe); }
+  .stat.decision b { color: var(--decision); }
+  .stat.keep b { color: var(--keep); }
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.6rem 1rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .toolbar .group { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+  .toolbar label { display: flex; align-items: center; gap: 0.3rem; cursor: pointer; white-space: nowrap; }
+  .toolbar select {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.25rem 0.4rem;
+    font-size: 0.85rem;
+  }
+  .toolbar .buttons { margin-left: auto; display: flex; gap: 0.5rem; }
+  .toolbar button {
+    background: var(--accent-bg);
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .cluster {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    margin-bottom: 0.85rem;
+    overflow: hidden;
+  }
+  .cluster > summary {
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    list-style: none;
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: baseline;
+  }
+  .cluster > summary::-webkit-details-marker { display: none; }
+  .cluster > summary:before { content: "▸ "; color: var(--muted); }
+  .cluster[open] > summary:before { content: "▾ "; }
+  .cluster-title { font-weight: 600; text-wrap: balance; }
+  .cluster-path { color: var(--muted); font-size: 0.78rem; margin-top: 0.15rem; font-family: ui-monospace, monospace; }
+  .cluster-meta { font-weight: 400; color: var(--muted); font-size: 0.8rem; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  .sessions { border-top: 1px solid var(--border); }
+  .session {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    gap: 0.6rem;
+  }
+  .session:last-child { border-bottom: none; }
+  .session.hidden-by-filter { display: none; }
+  .session-select { padding-top: 0.15rem; }
+  .session-select input { width: 16px; height: 16px; cursor: pointer; }
+  .session-body { flex: 1; min-width: 0; }
+  .session-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.35rem;
+  }
+  .badge {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+  .badge.safe_to_archive { color: var(--safe); background: var(--safe-bg); }
+  .badge.needs_a_decision { color: var(--decision); background: var(--decision-bg); }
+  .badge.keep_as_is { color: var(--keep); background: var(--keep-bg); }
+  .session-id { font-family: ui-monospace, monospace; font-size: 0.82rem; color: var(--muted); font-variant-numeric: tabular-nums; }
+  .classification { font-size: 0.85rem; font-weight: 600; }
+  .reason { font-size: 0.85rem; color: var(--muted); margin-bottom: 0.35rem; }
+  .topic { font-size: 0.9rem; margin-bottom: 0.35rem; }
+  .times { font-size: 0.75rem; color: var(--muted); margin-bottom: 0.35rem; font-variant-numeric: tabular-nums; }
+  .files { font-size: 0.78rem; color: var(--muted); font-family: ui-monospace, monospace; }
+  .empty { color: var(--muted); text-align: center; padding: 2rem 0; }
+  .selection-bar {
+    position: fixed;
+    left: 0; right: 0; bottom: 0;
+    background: var(--panel);
+    border-top: 1px solid var(--border);
+    padding: 0.75rem 1.25rem;
+    box-shadow: 0 -4px 12px rgba(0,0,0,0.08);
+  }
+  .selection-bar.hidden { display: none; }
+  .selection-inner {
+    max-width: 920px;
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .selection-count { font-weight: 600; font-size: 0.85rem; white-space: nowrap; }
+  .selection-bar label { font-size: 0.8rem; display: flex; align-items: center; gap: 0.3rem; white-space: nowrap; }
+  #command-output {
+    flex: 1;
+    min-width: 240px;
+    font-family: ui-monospace, monospace;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.4rem 0.5rem;
+  }
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; }
+  }
+  .selection-bar button {
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    border-radius: 6px;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .selection-bar button.primary {
+    background: var(--accent-bg);
+    color: var(--accent);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Session Consolidation Viewer</h1>
+  <div class="subtitle">Load a report produced by <code>session-consolidation report --out report.json</code></div>
+
+  <div class="loader">
+    Drop a report JSON file below, or
+    <div><input type="file" id="file-input" accept="application/json,.json"></div>
+  </div>
+
+  <div id="summary" class="summary"></div>
+
+  <div id="toolbar" class="toolbar" style="display:none">
+    <div class="group">
+      <label><input type="checkbox" class="tier-filter" value="safe_to_archive" checked> Safe to archive</label>
+      <label><input type="checkbox" class="tier-filter" value="needs_a_decision" checked> Needs a decision</label>
+      <label><input type="checkbox" class="tier-filter" value="keep_as_is" checked> Keep as-is</label>
+    </div>
+    <div class="group">
+      <label for="sort-select">Sort</label>
+      <select id="sort-select">
+        <option value="end_desc">Last accessed, newest first</option>
+        <option value="end_asc">Last accessed, oldest first</option>
+        <option value="start_desc">Opened, newest first</option>
+        <option value="start_asc">Opened, oldest first</option>
+        <option value="duration_desc">Duration, longest first</option>
+        <option value="duration_asc">Duration, shortest first</option>
+      </select>
+    </div>
+    <div class="buttons">
+      <button id="select-all" type="button">Select all visible</button>
+      <button id="select-safe" type="button">Select safe-to-archive</button>
+    </div>
+  </div>
+
+  <div id="clusters"></div>
+  <div id="empty" class="empty">No report loaded yet.</div>
+</div>
+
+<div id="selection-bar" class="selection-bar hidden">
+  <div class="selection-inner">
+    <span class="selection-count" id="selection-count">0 selected</span>
+    <label><input type="checkbox" id="include-yes"> actually move files (--yes)</label>
+    <input type="text" id="command-output" readonly>
+    <button id="copy-command" class="primary" type="button">Copy command</button>
+    <button id="clear-selection" type="button">Clear</button>
+  </div>
+</div>
+
+<script>
+  const TIER_LABEL = {
+    safe_to_archive: "Safe to archive",
+    needs_a_decision: "Needs a decision",
+    keep_as_is: "Keep as-is",
+  };
+
+  let currentReport = null;
+  let reportFileName = "report.json";
+  const selectedIds = new Set();
+
+  function escapeHtml(str) {
+    const div = document.createElement("div");
+    div.textContent = str == null ? "" : String(str);
+    return div.innerHTML;
+  }
+
+  // Sessions have no stored title (that's a claude.ai/code product feature, not
+  // present in local transcripts) -- this derives the best available stand-in
+  // from the raw first message: collapse whitespace so a short first line
+  // doesn't waste the budget, drop a conversational filler opener, and cut at
+  // a word boundary instead of mid-word.
+  const TOPIC_FILLER = /^(ok|okay|hi|hey|hello|so|well|alright|great|thanks)[,.!]?\s+/i;
+
+  function deriveTopic(message, maxLen) {
+    if (!message) return "(no topic captured)";
+    let text = message.replace(/\s+/g, " ").trim().replace(TOPIC_FILLER, "");
+    if (!text) return "(no topic captured)";
+    if (text.length <= maxLen) return text;
+    const cut = text.slice(0, maxLen);
+    const lastSpace = cut.lastIndexOf(" ");
+    return (lastSpace > maxLen * 0.4 ? cut.slice(0, lastSpace) : cut).trim() + "…";
+  }
+
+  function mostRecentSession(cluster) {
+    return cluster.sessions.reduce((best, s) => {
+      if (!best) return s;
+      return (s.end_time || "") > (best.end_time || "") ? s : best;
+    }, null);
+  }
+
+  function durationMs(sess) {
+    const start = sess.start_time ? Date.parse(sess.start_time) : NaN;
+    const end = sess.end_time ? Date.parse(sess.end_time) : NaN;
+    if (isNaN(start) || isNaN(end)) return null;
+    return Math.max(0, end - start);
+  }
+
+  function formatDuration(ms) {
+    if (ms == null) return null;
+    const totalMin = Math.round(ms / 60000);
+    if (totalMin < 1) return "<1m";
+    if (totalMin < 60) return `${totalMin}m`;
+    const h = Math.floor(totalMin / 60), m = totalMin % 60;
+    if (h < 24) return m ? `${h}h ${m}m` : `${h}h`;
+    const d = Math.floor(h / 24), rh = h % 24;
+    return rh ? `${d}d ${rh}h` : `${d}d`;
+  }
+
+  function sortValue(sess, mode) {
+    if (mode === "duration_asc" || mode === "duration_desc") {
+      const ms = durationMs(sess);
+      return ms == null ? -1 : ms;
+    }
+    if (mode === "start_desc" || mode === "start_asc") return sess.start_time || "";
+    return sess.end_time || "";
+  }
+
+  function sortDirection(mode) {
+    return mode.endsWith("_asc") ? 1 : -1;
+  }
+
+  function compareByMode(a, b, mode) {
+    const dir = sortDirection(mode);
+    const aVal = sortValue(a, mode), bVal = sortValue(b, mode);
+    return aVal < bVal ? -dir : aVal > bVal ? dir : 0;
+  }
+
+  function clusterRepresentativeSession(cluster, mode) {
+    return cluster.sessions.reduce((best, s) => {
+      if (!best) return s;
+      return compareByMode(s, best, mode) < 0 ? s : best;
+    }, null);
+  }
+
+  function currentFilters() {
+    return new Set(
+      Array.from(document.querySelectorAll(".tier-filter:checked")).map(el => el.value)
+    );
+  }
+
+  function renderSummary(report) {
+    const s = report.summary;
+    document.getElementById("summary").innerHTML = `
+      <div class="stat"><b>${s.total_sessions}</b>sessions</div>
+      <div class="stat"><b>${s.total_clusters}</b>clusters</div>
+      <div class="stat safe"><b>${s.safe_to_archive}</b>${TIER_LABEL.safe_to_archive}</div>
+      <div class="stat decision"><b>${s.needs_a_decision}</b>${TIER_LABEL.needs_a_decision}</div>
+      <div class="stat keep"><b>${s.keep_as_is}</b>${TIER_LABEL.keep_as_is}</div>
+    `;
+  }
+
+  function renderClusters() {
+    if (!currentReport) return;
+
+    const mode = document.getElementById("sort-select").value;
+    const activeTiers = currentFilters();
+
+    const clustersEl = document.getElementById("clusters");
+    clustersEl.innerHTML = "";
+
+    const clusters = [...currentReport.clusters].sort((a, b) => {
+      const repA = clusterRepresentativeSession(a, mode);
+      const repB = clusterRepresentativeSession(b, mode);
+      return compareByMode(repA, repB, mode);
+    });
+
+    for (const cluster of clusters) {
+      const visibleSessions = cluster.sessions.filter(s => activeTiers.has(s.tier));
+      if (visibleSessions.length === 0) continue;
+
+      const details = document.createElement("details");
+      details.className = "cluster";
+      details.open = cluster.sessions.some(sess => sess.tier !== "keep_as_is");
+
+      const topicSession = mostRecentSession(cluster);
+      const topic = deriveTopic(topicSession && topicSession.first_user_message, 90);
+
+      const summary = document.createElement("summary");
+      summary.innerHTML = `
+        <span>
+          <div class="cluster-title">${escapeHtml(topic)}</div>
+          <div class="cluster-path">${escapeHtml(cluster.project_dir || "(unknown project)")}</div>
+        </span>
+        <span class="cluster-meta">${visibleSessions.length}/${cluster.session_count} shown</span>
+      `;
+      details.appendChild(summary);
+
+      const sessionsEl = document.createElement("div");
+      sessionsEl.className = "sessions";
+
+      const sorted = [...cluster.sessions].sort((a, b) => compareByMode(a, b, mode));
+
+      for (const sess of sorted) {
+        const row = document.createElement("div");
+        row.className = "session" + (activeTiers.has(sess.tier) ? "" : " hidden-by-filter");
+        const topicLine = deriveTopic(sess.first_user_message, 160);
+        const files = (sess.files_touched || []).slice(0, 6).join(", ");
+        const duration = formatDuration(durationMs(sess));
+        row.innerHTML = `
+          <div class="session-select">
+            <input type="checkbox" data-session-id="${escapeHtml(sess.session_id)}" ${selectedIds.has(sess.session_id) ? "checked" : ""}>
+          </div>
+          <div class="session-body">
+            <div class="session-head">
+              <span class="badge ${sess.tier}">${TIER_LABEL[sess.tier] || sess.tier}</span>
+              <span class="classification">${escapeHtml(sess.classification)}</span>
+              <span class="session-id">${escapeHtml(sess.session_id)}</span>
+            </div>
+            <div class="reason">${escapeHtml(sess.reason)}</div>
+            <div class="topic">&ldquo;${escapeHtml(topicLine)}&rdquo;</div>
+            <div class="times">opened ${escapeHtml(sess.start_time || "?")} &middot; last active ${escapeHtml(sess.end_time || "?")}${duration ? ` &middot; ${escapeHtml(duration)} duration` : ""}</div>
+            ${files ? `<div class="files">${escapeHtml(files)}${sess.files_touched.length > 6 ? " …" : ""}</div>` : ""}
+          </div>
+        `;
+        row.querySelector("input[type=checkbox]").addEventListener("change", (e) => {
+          if (e.target.checked) selectedIds.add(sess.session_id);
+          else selectedIds.delete(sess.session_id);
+          updateSelectionBar();
+        });
+        sessionsEl.appendChild(row);
+      }
+
+      details.appendChild(sessionsEl);
+      clustersEl.appendChild(details);
+    }
+  }
+
+  function updateSelectionBar() {
+    const bar = document.getElementById("selection-bar");
+    const count = selectedIds.size;
+    document.getElementById("selection-count").textContent = `${count} selected`;
+    bar.classList.toggle("hidden", count === 0);
+    if (count === 0) return;
+
+    const includeYes = document.getElementById("include-yes").checked;
+    const ids = Array.from(selectedIds).join(" ");
+    const cmd = `python3 -m session_consolidation.cli archive --report ${reportFileName} --approve ${ids}${includeYes ? " --yes" : ""}`;
+    document.getElementById("command-output").value = cmd;
+  }
+
+  function render(report, fileName) {
+    currentReport = report;
+    if (fileName) reportFileName = fileName;
+    document.getElementById("empty").style.display = "none";
+    document.getElementById("toolbar").style.display = "flex";
+    renderSummary(report);
+    renderClusters();
+    updateSelectionBar();
+  }
+
+  function loadFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const report = JSON.parse(reader.result);
+        selectedIds.clear();
+        render(report, file.name || "report.json");
+      } catch (e) {
+        alert("Could not parse this file as a session-consolidation report: " + e.message);
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  document.getElementById("file-input").addEventListener("change", (e) => {
+    if (e.target.files[0]) loadFile(e.target.files[0]);
+  });
+
+  document.body.addEventListener("dragover", (e) => e.preventDefault());
+  document.body.addEventListener("drop", (e) => {
+    e.preventDefault();
+    if (e.dataTransfer.files[0]) loadFile(e.dataTransfer.files[0]);
+  });
+
+  document.querySelectorAll(".tier-filter").forEach(el => el.addEventListener("change", renderClusters));
+  document.getElementById("sort-select").addEventListener("change", renderClusters);
+  document.getElementById("include-yes").addEventListener("change", updateSelectionBar);
+
+  document.getElementById("select-all").addEventListener("click", () => {
+    document.querySelectorAll('.session:not(.hidden-by-filter) input[data-session-id]').forEach(input => {
+      input.checked = true;
+      selectedIds.add(input.dataset.sessionId);
+    });
+    updateSelectionBar();
+  });
+
+  document.getElementById("select-safe").addEventListener("click", () => {
+    document.querySelectorAll('.session:not(.hidden-by-filter) input[data-session-id]').forEach(input => {
+      const sessionId = input.dataset.sessionId;
+      const sess = (currentReport.clusters.flatMap(c => c.sessions)).find(s => s.session_id === sessionId);
+      if (sess && sess.tier === "safe_to_archive") {
+        input.checked = true;
+        selectedIds.add(sessionId);
+      }
+    });
+    updateSelectionBar();
+  });
+
+  document.getElementById("clear-selection").addEventListener("click", () => {
+    selectedIds.clear();
+    document.querySelectorAll('input[data-session-id]').forEach(input => input.checked = false);
+    updateSelectionBar();
+  });
+
+  document.getElementById("copy-command").addEventListener("click", () => {
+    const output = document.getElementById("command-output");
+    output.select();
+    navigator.clipboard?.writeText(output.value).catch(() => document.execCommand("copy"));
+  });
+</script>
+</body>
+</html>

--- a/skills/user/session-consolidation/SKILL.md
+++ b/skills/user/session-consolidation/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: session-consolidation
+description: >
+  Sweeps local Claude Code session transcripts, clusters related ones,
+  classifies each as active/completed/stale/orphaned/superseded, and
+  proposes a tiered action list. Never archives without explicit approval;
+  archiving is always a reversible move, never a delete. Modeled on git
+  branch hygiene. Use when asked to sweep, clean up, consolidate, or tidy
+  Claude Code sessions, or to find redundant/stale/abandoned sessions.
+  Triggers: "/session-consolidation", "sweep my sessions", "clean up my
+  claude sessions", "session hygiene", "consolidate my sessions",
+  "what sessions am I duplicating".
+---
+
+# Session Consolidation
+
+A thin wrapper around the `session-consolidation` CLI — this skill has no
+logic of its own beyond locating the CLI, running it, and mediating approval.
+See `session-consolidation/README.md` and
+`docs/session-consolidation-design.md` in the repo for the full design.
+
+## Step 1 — Locate the CLI
+
+Try, in order:
+
+1. `$SESSION_CONSOLIDATION_REPO/session-consolidation` if that env var is set.
+2. `~/Documents/dev/adventures-in-ai/session-consolidation` (this repo's
+   standard local checkout path, per its `CLAUDE.md`).
+3. Ask the user where their `adventures-in-ai` checkout lives.
+
+Verify with:
+
+```bash
+test -f <candidate>/session_consolidation/cli.py && echo found
+```
+
+If none resolve, tell the user the CLI isn't installed locally and stop —
+do not attempt to install it yourself without asking.
+
+## Step 2 — Parse the invocation
+
+- `/session-consolidation` or no args → default: `--since 30d`
+- `/session-consolidation [7d|14d|30d|90d|all]` → pass through as `--since`
+- Note if the environment has no `~/.claude/projects/` at all (cloud/ephemeral
+  session) — the CLI's `report` command already handles this gracefully
+  (returns zero sessions, not an error), but say so plainly to the user
+  rather than presenting an empty report as if nothing needed sweeping.
+
+## Step 3 — Run the report
+
+```bash
+cd <cli_dir> && python3 -m session_consolidation.cli report --since <timeframe> --out /tmp/session-consolidation-report.json
+```
+
+The command prints a human-readable tiered summary to stderr — relay it to
+the user directly rather than re-deriving your own summary from the JSON.
+Mention the report JSON path so they can open it in `web/viewer.html` if
+they want the visual tree instead of the text summary.
+
+## Step 4 — Present and seek approval
+
+State the three tiers plainly, matching the CLI's own language:
+
+- **Safe to archive** — stale or superseded sessions, no orphaned work.
+  Can be bulk-approved.
+- **Needs a decision** — orphaned uncommitted work. Walk through these
+  individually; never bulk-approve them.
+- **Keep as-is** — active or completed; no action offered.
+
+Ask explicitly:
+
+> "Archive the N safe-to-archive sessions? (This moves their transcripts to
+> `~/.claude/projects-archive/`, never deletes them.) For the sessions that
+> need a decision, tell me per-session: archive, or leave alone."
+
+Do not archive anything on your own initiative. Silence is not approval.
+
+## Step 5 — Execute only what's approved
+
+```bash
+# bulk, for the safe tier
+python3 -m session_consolidation.cli archive --report /tmp/session-consolidation-report.json --approve-tier safe_to_archive --yes
+
+# per-session, for anything the user approved individually
+python3 -m session_consolidation.cli archive --report /tmp/session-consolidation-report.json --approve <id> [<id> ...] --yes
+```
+
+Relay the per-session archive results (archived / missing) back to the user.
+If any session is reported `missing`, say so — don't silently drop it.
+
+## Notes
+
+- This skill never touches git branches, PRs, or repo content — only local
+  session transcripts under `~/.claude/projects/`.
+- Fast/deep categorization modes and a "merge sessions into one brief"
+  offering are Phase 2, not implemented here — see
+  [issue #42](https://github.com/dhk/adventures-in-ai/issues/42) if the user
+  asks for either.


### PR DESCRIPTION
**TL;DR** — **#41 merged the design doc for session-consolidation on 2026-07-26; the implementation it describes never did.** It sat on a branch for four weeks and looked finished locally only because the repo was left checked out on that branch. This lands the tool itself — 1,252 lines: `core.py` (sweep, parse, cluster, classify, report, archive), `cli.py`, an optional MCP surface, a viewer refined across five commits, and **8 tests, all passing**. Brought across at file level rather than rebased, because the branch predates #33 and replaying it would mean resolving ~16k lines of unrelated deletion conflicts.

---

## The gap

[#41](https://github.com/dhk/adventures-in-ai/pull/41) merged `docs/session-consolidation-design.md` on 2026-07-26 — the design for this tool. **The implementation it describes was never merged.** It has been sitting on `claude/session-consolidation-gnc8x1` for four weeks, and because the repo was left checked out on that branch, it looked locally like it had already shipped.

Surfaced during a branch audit today, alongside 7 stale PRs in this repo.

## What lands

| File | |
|---|---|
| `session_consolidation/core.py` | `sweep`, `parse_session`, `cluster`, `classify`, `build_report`, `archive`. **Standard library only** |
| `session_consolidation/cli.py` | Command-line entry point |
| `session_consolidation/mcp_server.py` | Optional MCP surface — the only reason `requirements.txt` exists (`mcp>=1.0`) |
| `web/viewer.html` | Cluster titles, tier/sort filters, archive command builder, theme-toggle tokens, tabular nums, duration sort, select-all, topic-derivation fallback |
| `tests/test_core.py` | 8 tests |
| `skills/user/session-consolidation/SKILL.md` | Skill definition |

1,252 insertions, 10 files.

## Why file-level rather than a rebase

The source branch predates [#33](https://github.com/dhk/adventures-in-ai/pull/33) (the reading-with-ears extraction, merged today). Replaying its 6 commits onto current main would mean resolving ~16,000 lines of deletion conflicts that have nothing to do with this tool — `session-consolidation/` references neither `reading-with-ears/` nor `bin/rwe-*`. Verified with `git grep` before choosing this route.

The cost is losing commit-by-commit history, chiefly the five incremental viewer refinements. The original branch tip is `ee1bc94f` and is retained locally until this lands.

## Verification

All 8 tests pass. `ensurepip` is broken on the local Python 3.14 build, so they were run through a minimal driver supplying the `tmp_path` fixture rather than via pytest:

```
ok  test_sweep_returns_empty_list_when_projects_dir_missing
ok  test_parse_session_extracts_expected_fields
ok  test_cluster_groups_by_project_and_shared_file
ok  test_classify_marks_older_completed_session_as_superseded
ok  test_classify_orphaned_never_marked_superseded
ok  test_build_report_tier_counts_and_shape
ok  test_archive_moves_file_and_writes_manifest
ok  test_archive_reports_missing_file_without_raising
8 passed, 0 failed
```

This repo has no CI workflow, so nothing runs these automatically — worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
