### PR TITLE
docs(tricorder): reports for buzz, berd, and claude-cookbooks, Sep 2–8

### DIFF
--- a/tricorder/2026-09-02-block__berd.md
+++ b/tricorder/2026-09-02-block__berd.md
@@ -1,0 +1,563 @@
+---
+date: 2026-09-02
+repo: block/berd
+window: 2026-08-12 → 2026-09-02
+pr_count: 159
+contributors: ['NickTitle', 'amlozano1', 'caregullin', 'comp615', 'cynfria', 'damienrj', 'delkc', 'johnmatthewtennant', 'josereyes', 'kalvinnchau', 'kennylauren', 'loganj', 'matt2e', 'morgmart', 'mrohan-sq', 'nathan-thillairajah', 'tirsen', 'tulsi-builder']
+visibility: private
+generated_by: tricorder v1.1.0
+---
+
+# PR Review Analysis — block/berd — 2026-09-02
+
+> Window: 2026-08-12 → 2026-09-02 | 159 PRs | 18 contributors
+
+---
+
+## 1. Patterns Ready to Institutionalize
+
+| Pattern | Category | Current Maturity | Next Step | Standard |
+|---------|----------|-----------------|-----------|----------|
+| Human approval gate before irreversible release actions (branch creation, commit, push, PR) | — | judgment | Codify the approval gate as a named step in a release runbook and add a checklist that must be checked off before the gate proceeds; document which actions are reversible vs irreversible | convention |
+| Experiment flag requirement for high database-query-cost features before broad enablement | — | guidance | Add a PR template section 'Rollout gate: does this feature require an experiment flag? If no, justify.' and a review checklist item verifying the answer for any feature touching polling or background DB queries | convention |
+| Validation rollback on release preparation failure restoring all tracked files | — | guidance | Write integration tests covering each failure mode and assert full file restoration; promote to rule once tests are green in CI | rule |
+| Security boundary via exact HTTPS host validation and shell-free bounded CLI invocation for external service calls | — | rule | Document the pattern as an architectural decision record (ADR) and add a review checklist item for any new external service integration; consider a linter rule banning raw shell execution in Tauri command handlers | deterministic |
+| Changelog drift detection between committed changelog and GitHub release notes on recovery | — | guidance | Add an automated test that simulates drift and asserts the recovery path detects and blocks it; promote to rule once tested | rule |
+| Race condition and concurrent state arbitration review requiring controlled interleaving tests | — | judgment | Write an internal guide documenting the team's concurrency review pattern (what to look for, what test structure is expected) and reference it in the PR template for PRs touching shared mutable state | convention |
+
+---
+
+## 2. Reviewer Focus Fingerprints
+
+### caregullin
+**Style:** advisory | **Signal quality:** low — Only 2 PRs reviewed with bot-mediated fix confirmations dominating the comment thread, making it difficult to distinguish the reviewer's independent judgment from responses to automated suggestions.
+
+**Primary focus areas:**
+- Debounce/timer lifecycle correctness — specifically whether cleanup flushes latest refs and whether unmount-during-debounce windows are handled (often)
+- Bounds and limits justification — ensuring numeric thresholds (character limits, rejection caps) are grounded in upstream pipeline constraints rather than arbitrary (often)
+- Rejection/error counter durability across state transitions — ensuring counters survive readiness edges and are not inadvertently reset by intermediate state changes (sometimes)
+- Precise text-range tracking for widget-owned content — ensuring edits to widget-inserted text (e.g. mentions) rewrite only the owned range and do not corrupt user-authored surrounding text (sometimes)
+
+**Apparent blind spots:**
+- Test coverage and test strategy — No comments across either PR mention unit tests, integration tests, or whether new edge cases (unmount-during-debounce, rejection counter reset) have corresponding test cases added.
+- Naming, readability, and code style — All comments are purely behavioral/correctness-focused; no observations about variable naming, function decomposition, or code clarity appear in either review.
+- Type safety and TypeScript correctness — Despite reviewing TypeScript/React code, no comments address type annotations, inference gaps, or unsafe casts.
+
+### comp615
+**Style:** thorough | **Signal quality:** low — Only 2 PRs reviewed and all visible comments appear to be Amp bot resolution confirmations rather than the reviewer's original critique, making it impossible to reliably distinguish the reviewer's independent concerns from automated responses.
+
+**Primary focus areas:**
+- Concurrency and race condition handling in shared state — ensuring that concurrent renderer instances or app processes cannot corrupt state through unserialized writes or missed arbitration (always)
+- Component lifecycle correctness — ensuring state claims survive remount, unmount, and re-presentation without staleness or premature expiry (always)
+- API/schema versioning and backward compatibility — verifying that endpoint or config schema changes do not silently break already-shipped clients (always)
+- Explicit ownership of sequencing and ordering in event/capability contracts — ensuring the public seam documents who owns ordering rather than relying on implicit renderer-side assumptions (often)
+- Accessibility on dismissal — focus restoration to the previously focused element when a modal/survey is dismissed, with a fallback (often) — *WCAG 2.1 SC 2.4.3 (Focus Order) / common React a11y pattern*
+- Virtual list / offscreen measurement correctness — ensuring virtualized rows that own dynamic content force real measurement and receive height revisions (sometimes)
+- Test coverage explicitly tied to the specific edge case discussed — not just general coverage but targeted regression/interleaving tests for each concern raised (always)
+
+**Apparent blind spots:**
+- Performance characteristics of the feedback/survey code paths (e.g., unnecessary re-renders, memoization) — No comments across either PR touch render performance, memo boundaries, or selector efficiency despite reviewing virtual list and stateful survey components where these are commonly relevant.
+- Error handling and failure-mode UX (network failures, Tauri command errors surfacing to the user) — Rust command and TypeScript event files were reviewed but all comments focus on correctness of the happy path and race conditions; no comments address what happens when backend calls fail or how errors propagate to the UI.
+- Naming conventions, code style, and file/module organization — Zero comments across both PRs reference naming, style lint rules, or module structure, suggesting these are either pre-screened by CI or not a focus for this reviewer.
+- Analytics/telemetry correctness on survey events (sampling bias, duplicate event fire) — The PRs involve sampled session feedback but no comments address whether the sampling logic produces statistically correct rates or whether events could be double-fired across remounts.
+
+### cynfria
+**Style:** thorough | **Signal quality:** medium — Most visible comments are bot-authored response summaries (🤖 prefixed) rather than direct reviewer prose, making it difficult to separate the human reviewer's original observations from automated reply drafts, though the breadth and technical specificity of topics covered is consistent across PRs.
+
+**Primary focus areas:**
+- Atomic file operations and concurrency safety in Rust/Tauri backend (no-replace semantics, backup collision handling, inode retention, hard-link recovery) (often) — *null*
+- Text boundary contracts — grapheme-aware truncation vs. raw code-unit caps, shared segmentation policy, and consistent enforcement across snapshot schema and presentation layer (often) — *Unicode grapheme segmentation (Intl.Segmenter)*
+- Schema permissiveness and import resilience — invalid or oversized fields ignored rather than rejecting the whole agent, round-trip fidelity of valid metadata (often) — *null*
+- Async lifecycle management — operation deadlines, worker timeouts, abort on dialog close, and restoration of UI state after failure (often) — *null*
+- Authored vs. fallback/placeholder content distinction — filtering placeholder values from snapshot export, localizing fallback copy at the presentation layer only (often) — *null*
+- Locale/i18n parity — translations for all changed keys, locale-parity test coverage (sometimes) — *null*
+- Race condition prevention at import/invalidation boundaries — shared invalidation hooks, preventing stale reads from reaching preparation (sometimes) — *null*
+- Regression test coverage for concurrency, timeout, and boundary-condition behaviors (often) — *null*
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, ref() usage, model layering, incremental strategy) — All reviewed PRs are TypeScript/Rust application code; no SQL or dbt model changes appear in any reviewed PR, so there is no evidence this reviewer evaluates dbt conventions at all.
+- Performance and query optimization — No comments touch rendering performance, query plans, or algorithmic complexity despite several UI-heavy PRs.
+- Accessibility (ARIA, keyboard navigation, focus management beyond composer PR) — Only one PR (#128) touches focus restoration and was simply approved with no inline comment; no accessibility concerns raised across any other UI PRs.
+- API contract versioning and backward-compatibility documentation — While schema permissiveness is flagged, there are no comments about formally versioning API responses, deprecation notices, or changelog entries for breaking field removals like good_for/vibes.
+- Security review (input sanitization, privilege escalation, secrets in snapshots) — Despite agent snapshot export/import handling arbitrary user-supplied content and file paths, no security-oriented comments appear in the review history.
+
+### damienrj
+**Style:** thorough | **Signal quality:** low — Only one PR reviewed, and all visible comments are bot-generated resolution acknowledgments rather than the reviewer's original critique, making it impossible to reliably infer the reviewer's own voice, priorities, or blind spots.
+
+**Primary focus areas:**
+- Race conditions and concurrent state management — ensuring generation-guarded transitions prevent stale actors from overwriting newer state (always)
+- Process identity verification and PID revalidation before signaling — preventing kill/stop of wrong process after PID reuse (always)
+- Shutdown ordering and lock discipline — ensuring shutdown holds relevant locks to prevent re-establishment during teardown (always)
+- Portability of shell scripts — replacing GNU-specific flags with POSIX/portable equivalents (sometimes) — *POSIX shell compatibility*
+- Data persistence correctness — ensuring session state (including archived state) is durably stored and correctly rehydrated across restarts (often)
+- Attachment and input sanitization at dispatch boundaries — stripping unsafe local paths/files before remote sends (sometimes)
+- Log file size bounding and resource management in shell daemons (sometimes)
+- Atomic file operations for lock/state files — preventing TOCTOU issues in shell-level mutual exclusion (sometimes)
+- Regression test coverage for every addressed bug or race — explicit mention of tests in each resolution (always)
+
+**Apparent blind spots:**
+- API contract design and backwards compatibility — no comments observed on schema versioning, API surface changes, or breaking changes for callers — All 15 comments focus on implementation correctness (races, persistence, portability); none address interface design or versioning concerns.
+- Performance and scalability — no comments on latency, throughput, or resource usage beyond log file size cap — No comments touch query performance, connection pooling efficiency, or throughput under load.
+- UI/UX and accessibility — no comments on the React component changes beyond functional correctness of experiment toggling — ChatInputToolbar and RemoteHostsSettings changes are addressed only for functional safety, with no mention of user experience, accessibility, or visual design.
+- Error message quality and user-facing error handling — Conflict errors are noted as carrying metadata for the developer, but no comments address the clarity or helpfulness of messages surfaced to end users.
+
+### delkc
+**Style:** advisory | **Signal quality:** low — A single PR with an approval and no recorded comments is insufficient to establish any pattern of focus or neglect.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- All review dimensions — Only one PR reviewed with an approval and no inline comments, providing no signal about what this reviewer prioritizes or overlooks.
+
+### johnmatthewtennant
+**Style:** blocking | **Signal quality:** high — Every comment is a concrete, specific behavioral defect with an identified failure scenario, a described fix, and a cited regression test, yielding highly actionable and consistent signal across all 20 PRs.
+
+**Primary focus areas:**
+- Concurrency correctness: race conditions, stale lifecycle/session/revision checks, and authoritative-owner enforcement in async Rust and TypeScript (always)
+- Idempotency and exactly-once delivery guarantees: deduplication of retried operations, stable delivery IDs, and safe re-entry on repeated calls (always)
+- Bounded async operations: explicit deadlines, timeouts, and watchdogs on every blocking or long-running async path to prevent hangs (always)
+- Atomic/safe file I/O: write-then-rename patterns, crash-safe persistence, and avoiding partial-write corruption (often)
+- Generation/revision monotonicity: using monotonic counters or generation tokens to invalidate stale async completions and prevent out-of-order state mutations (always)
+- Regression test coverage for every identified bug path, including discriminating edge cases (not just happy-path tests) (always)
+- Resource cleanup and leak prevention: process-tree teardown, guard disarming on all exit paths (success, failure, cancel), and avoiding orphaned subprocesses (often)
+- Accessibility correctness: stable accessible names, localized user-facing strings, and avoiding raw diagnostic/error text in UI-facing copy (often) — *WCAG accessible name computation*
+- Security/authorization boundaries: rejecting stale or unauthorized callers before mutating shared native state, especially across windows or renderers (often)
+- API surface minimalism: declining to expand shared component APIs, design-system tokens, or i18n keys for one-off uses that don't justify the maintenance cost (often)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, ref() usage, model materialization strategies, incremental logic) — All 20 PRs reviewed are in a Tauri/Rust/TypeScript desktop application; there is no evidence of any SQL or dbt review activity, so dbt standards are entirely outside scope.
+- Performance profiling and algorithmic complexity — No comments address CPU/memory complexity, hot paths, or profiling; focus is exclusively on correctness, safety, and coverage rather than performance characteristics.
+- Code style, naming conventions, and formatting nitpicks — Zero comments across 20 PRs concern naming, formatting, or stylistic preferences; all feedback is substantive behavioral or safety-correctness feedback.
+- Dependency management and supply-chain risk (new crates, package versions, license review) — No comments address dependency choices, version pinning, or license compatibility despite multiple new Swift/Rust/npm integrations.
+- Documentation and code comments (inline docs, README updates, API documentation) — No comments request or commend documentation improvements; all feedback targets runtime behavior.
+
+### kalvinnchau
+**Style:** thorough | **Signal quality:** high — Comments are consistently specific, reproducible, severity-labeled (P2/P3), and include concrete failure scenarios with reproduction conditions, indicating deep engagement rather than surface-level scanning.
+
+**Primary focus areas:**
+- Concurrency and race condition correctness: shared mutable state accessed from multiple processes, renderers, or async contexts without proper synchronization (mutexes, atomic operations, file locks) (always)
+- Process and resource lifecycle ownership: unbounded resource growth (log files, buffers), orphaned child processes, missing cleanup on cancellation or failure paths (always)
+- Experiment/feature flag enforcement at transport and authorization boundaries, not just UI layer (often)
+- Schema versioning and backward compatibility for serialized/deserialized API contracts (deny_unknown_fields, version identifiers) (often)
+- Sequence/ordering guarantees at cross-process or cross-renderer boundaries (non-atomic sequence allocators, event ordering) (often)
+- Capability and dependency coupling: features incorrectly gated behind unrelated capability requirements (e.g., requiresKgoose coupling) (often)
+- Sampling and probability semantics: correctly naming and documenting hazard rates vs. per-session probabilities, documenting intended statistical behavior (sometimes)
+- Accessibility and focus management: restoring focus after modal/overlay dismissal, Tab order integrity (sometimes) — *WCAG 2.1 SC 2.4.3 Focus Order*
+- Unused exports and dead code that misleads future maintainers or inflates test surface (sometimes)
+- UTF-8 boundary safety in byte-level string operations (drain, split at byte offsets) (sometimes)
+- Virtual/windowed list measurement correctness: survey or dynamic content included in offscreen measurement when it should not be, causing layout corrections on scroll (sometimes)
+- State target / event routing continuity across async or tool-call boundaries in streaming pipelines (sometimes)
+- Error recovery UX: dead-end product states with no actionable recovery path for the user (sometimes)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, ref usage, model layering, incremental strategy) — Repository is described as dbt/SQL analytics but all 37 PRs reviewed involve TypeScript, Rust, and shell code; no SQL or dbt-specific comments appear anywhere in the review history, suggesting the reviewer operates outside the dbt domain entirely.
+- Test coverage requirements: reviewer rarely blocks or comments on missing unit/integration tests for new logic — Across 37 PRs with multiple CHANGES_REQUESTED decisions, no comment requests new tests; tests are mentioned only when describing how the reviewer verified a fix themselves, not as a requirement on the author.
+- CSS correctness beyond functional reproduction: reviewer noted one CSS layout issue (overflow-wrap) but only after reproducing it, and otherwise does not flag CSS or styling concerns proactively — Only one CSS comment across all PRs, and it was limited to a confirmed reproduction; purely visual or design-system concerns are absent.
+- Naming conventions, code style, and readability nits beyond one isolated 'nit' label — Only a single nit comment appears in 37 PRs (unused parameters in PR #131); the reviewer does not engage with naming, formatting, or stylistic consistency as a pattern.
+- Dependency version management and supply-chain security beyond approving the single CVE bump PR — PR #254 (js-yaml CVE bump) received a plain APPROVED with no inline analysis; no other PRs surfaced dependency hygiene concerns despite multiple dependency-touching changes.
+
+### kennylauren
+**Style:** advisory | **Signal quality:** low — Only one PR reviewed with no recorded comments, providing no basis for inferring reviewer priorities or patterns.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- All areas — Only one PR reviewed with an approval and no visible inline comments, making it impossible to identify any consistent focus areas
+
+### loganj
+**Style:** thorough | **Signal quality:** medium — Many reviews are delegated to or co-authored with automated agents (Carl, Princess Donut, Brother Darryl), making it difficult to cleanly attribute specific findings to loganj's own judgment versus the agent ensemble's.
+
+**Primary focus areas:**
+- Security boundaries: URL validation, shell-injection prevention, subprocess invocation safety, and IPC input bounding (always) — *OWASP Input Validation / Command Injection prevention*
+- Race conditions and concurrent write safety — overlapping async operations on shared state, stale-snapshot writes, and unqueued migrations (often)
+- Persisted-state migration correctness — ensuring normalization/validation gates cover all entry paths (not just the happy path) (often)
+- Classifier / boundary completeness — ensuring all variants of a protocol or schema are handled, no cases silently fall through (often)
+- Dead code and unused symbol removal — tracking whether removed symbols have remaining consumers before deletion (sometimes)
+- Truthfulness / no-fabrication rule in UI copy — rendered text must be grounded in actual data, not inferred or hallucinated labels (sometimes)
+- Feature-flag / experiment gating before broad rollout (sometimes)
+
+**Apparent blind spots:**
+- Test coverage gaps — no comments observed requesting additional unit or integration tests for new logic paths — Across 12 PRs with complex async, migration, and classifier logic, no review comment explicitly requested new test cases; one comment noted test removal without requesting replacement coverage
+- Performance and scalability concerns — no comments on query efficiency, rendering cost, or large-dataset behavior — PRs touching transcript scanning, PR list rendering, and session queuing received no performance-oriented feedback
+- Accessibility and i18n beyond a passing mention — Accessibility is listed as a traced area in PR #115 but no specific findings or suggestions appear; no comments on internationalization in any PR
+- API contract and versioning discipline — backward-compatibility of changed method signatures or wire formats — PR #62 migrates a session deletion method and PR #48 replays a lockfile, but no comments address downstream consumers or versioning contracts
+
+### matt2e
+**Style:** advisory | **Signal quality:** low — Only 6 PRs with sparse inline comments (most PRs approved silently), providing insufficient volume to establish reliable patterns.
+
+**Primary focus areas:**
+- Correctness of technical claims in code review — pushes back when a reviewer or author makes incorrect assertions about library/OS behavior (sometimes)
+- Dead code / orphaned state after refactors — flags store properties, hooks, or UI components that lose all consumers after a change (sometimes)
+- Regression of existing filtering/deduplication logic — notices when a guard or filter is removed without a replacement, potentially causing duplicate UI entries (sometimes)
+- Pragmatic acceptance of imperfect-but-acceptable launch-time code — explicitly defers polish on non-critical paths (sometimes)
+
+**Apparent blind spots:**
+- Test coverage — no comments in any PR about missing or inadequate tests for new features or bug fixes — Across 6 PRs including a telemetry pipeline, marketplace slug validation, and doctor/agent-setup fixes, there are zero comments requesting tests or asserting test adequacy.
+- SQL/dbt-specific concerns (grain, ref vs source, model naming, incremental strategy) — not applicable to this repo's domain — This is a Tauri/Rust/TypeScript repository, not a dbt/SQL repo; reviewer comments reflect that domain correctly.
+- Error handling and user-facing error messages — skips over error handling gaps with explicit 'fine for launch' justifications rather than filing follow-ups — The reviewer explicitly dismissed error handling concerns in WelcomeStep.tsx and main.tsx without requesting tracking issues or TODOs.
+- Performance and bundle size — no comments across any PR about render cost, bundle impact, or query efficiency — No mention across any of the 6 PRs despite changes touching React components and a new OpenTelemetry pipeline.
+
+### morgmart
+**Style:** blocking | **Signal quality:** high — The reviewer (an automated system) produces highly specific, reproducible findings with exact code locations, concrete failure scenarios, user-visible effects, and clear P1/P2/P3 severity distinctions across a large, consistent sample of 97 PRs.
+
+**Primary focus areas:**
+- Async operations without bounded timeouts (never-settles / never-completes behavior) (always)
+- Race conditions and TOCTOU (check-then-act) bugs in file system and concurrent state mutations (always)
+- Stale request / generation-counter races in concurrent async flows (last-write-wins bugs) (always)
+- Localization / i18n completeness — hard-coded English strings bypassing the translation system (always)
+- Idempotency and crash-recovery correctness in durable persistence (pending files, atomic rename, delivery deduplication) (often)
+- Security boundary violations — credential leakage, allowlist bypasses, test-only code shipping in production builds (often)
+- User consent and telemetry gating — consent state must be checked continuously, not just at flow start (often)
+- Accessibility — missing ARIA attributes, label-in-name violations, screen-reader omissions for dynamic state (often) — *WCAG 2.5.3 Label in Name; ARIA live regions*
+- Design-system contract compliance — feature code must not define its own colors, spacing, interactive states, or reusable visual treatment (often)
+- Backward-compatible schema / persisted-data migration — new validation must not reject previously valid stored records (often)
+- Test honesty — regression tests must exercise the exact failure mode they claim to cover, not a weaker variant (often)
+- Resource lifecycle — process/thread cleanup, Drop implementations, zombie processes, unbounded thread spawning (often)
+- String encoding correctness — UTF-16 code-unit length vs. grapheme cluster length for user-visible validation limits (sometimes)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain, ref() vs source(), incremental strategies, test coverage of models) — This is a TypeScript/Rust/Tauri desktop application repository; no SQL or dbt files appear in any reviewed PR. The reviewer has no opportunity to demonstrate awareness or blindness to dbt conventions.
+- Performance profiling and algorithmic complexity — Across 97 PRs the reviewer rarely flags O(n) or memory-growth concerns except when they directly cause an unbounded resource condition (e.g., line-buffer growth). Pure throughput or latency trade-offs without a correctness consequence are never mentioned.
+- Code duplication / DRY violations that do not introduce a correctness bug — The reviewer consistently cites design-system contract violations only when they involve reusable interactive or visual treatment; purely structural duplication without a behavioral or consistency consequence does not appear in any finding.
+- Bundle size, tree-shaking, and dependency weight — No PR review mentions import cost, bundle impact, or unnecessary dependency inclusion, even in PRs that add new npm packages or restructure import boundaries.
+- CI/CD pipeline correctness beyond build-feature flag gating — The reviewer notes missing CI wiring for Swift tests (PR #181) but otherwise does not audit workflow files, test parallelism, caching correctness, or flaky-test risk.
+
+### nathan-thillairajah
+**Style:** thorough | **Signal quality:** low — Only one PR was reviewed, and all visible comments are bot-generated resolution summaries rather than original human reviewer comments, making it impossible to reliably characterize the reviewer's independent judgment or focus patterns.
+
+**Primary focus areas:**
+- Security: credential/session handling and storage hygiene — ensuring credentials are not re-read from storage after issuance, stale sessions are deleted before fresh login, and auth state transitions are explicit (always)
+- Security: output sanitization — recursively redacting secret/credential data from JSON responses before they reach CLI output, preserving non-secret fields and response shape, and ensuring object keys are not collapsed or overwritten (always)
+- Security: URL/origin validation — enforcing strict allowlists for approved HTTPS hostnames, rejecting remote IPs, localhost names, userinfo, path, query, and fragment in test/override endpoints (always)
+- Test architecture: no runtime overrides or feature flags in distributable binaries — removing environment-variable URL overrides, Cargo features, embedded test CAs, and DNS overrides from release artifacts (always)
+- Interactive vs. non-interactive mode separation — ensuring JSON and non-TTY callers never trigger implicit browser login, returning structured auth_required instead (always)
+- Credential validation delegation — removing duplicate/local credential length or character alphabet definitions and relying on shared/upstream auth validators (often)
+- Test coverage completeness — restoring and locking built-binary regression tests for all major CLI flows (contract, create, deploy) after each architectural change (always)
+
+**Apparent blind spots:**
+- dbt/SQL-specific concerns (grain declarations, model naming conventions, ref() usage, etc.) — This PR is a Rust CLI authentication refactor with zero dbt or SQL content; no SQL-related feedback was given, but the repository context suggests those concerns could exist elsewhere.
+- Performance and latency considerations (e.g., unnecessary network round-trips, caching of auth tokens) — All comments focus on correctness and security of auth flows; no comments address whether repeated /v1/auth/me calls or five-minute callback deadlines are appropriate from a latency or UX standpoint.
+- Error message UX and localization beyond the specific 401 recovery path — Only one error message (the 401 recovery instruction) is called out; broader UX of error messaging across other failure modes receives no feedback.
+
+### tulsi-builder
+**Style:** advisory | **Signal quality:** low — All 4 PRs were approved with no recorded comments, making it impossible to identify any genuine focus areas or review criteria.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- Code correctness and logic review — All 4 PRs were approved with no recorded comments, suggesting no scrutiny of implementation details
+- SQL/dbt model design standards (grain declaration, ref() usage, model layering) — No evidence of any dbt or SQL-specific feedback across any reviewed PR
+- Test coverage requirements — No comments requesting or validating tests on any PR
+- Documentation and naming conventions — No comments on naming, descriptions, or documentation quality despite PRs touching agent descriptions and UI labels
+- Security and data privacy considerations — PR #82 introduces always-on preamble content affecting all interactions; no scrutiny recorded
+
+---
+
+## 3. Author Growth Profiles
+
+### NickTitle
+**Trajectory:** insufficient-data — Only one PR is available in the review window, which is insufficient to identify patterns or determine trajectory.
+
+**Strengths:**
+
+**Growth areas:**
+
+### amlozano1
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to establish any meaningful trend or growth pattern.
+
+**Strengths:**
+
+**Growth areas:**
+
+### caregullin
+**Trajectory:** insufficient-data — Only two PRs from the same day are available, so no chronological trend can be established beyond noting that the author responds well to review within both PRs.
+
+**Strengths:**
+- Responsive to automated and peer review feedback — fixes are delivered in follow-up commits within the same PR cycle, with clear explanations of what changed and why (consistent)
+- Precise scoping of fixes: changes are targeted to the specific logic cited in review comments rather than broadening scope unnecessarily (consistent)
+- Transparent risk communication — when a finding is acknowledged but not fixed, the author clearly explains the deliberate decision and the existing bounds that justify deferral (consistent)
+
+**Growth areas:**
+- Edge-case resilience in stateful UI interactions — both PRs surfaced P2 findings around unmount/flush timing and retry bounds that were not caught before review, suggesting pre-review self-review of lifecycle and error-path scenarios is inconsistent (consistent)
+  → **Support:** Before opening a PR, walk through a checklist of stateful edge cases: component unmount with pending async work, input truncation without user feedback, and retry/back-off bounds on failure paths. Codify this as a team PR template checklist item.
+- Proactive limit enforcement at input boundaries — the homeLayoutMapper truncation issue (PR #209) reveals a pattern of enforcing constraints downstream in the pipeline rather than at the point of data entry, which can lead to silent data loss (occasional)
+  → **Support:** Adopt a 'validate at the boundary' principle: any input that has a known max length should reject or warn at the UI layer before data reaches the processing pipeline. Add a linting or review step that checks for truncation-only guards without corresponding user-facing validation.
+
+### comp615
+**Trajectory:** stable — Across all three PRs in the same date window, comp615 demonstrates consistent strength in response quality and ownership design but also consistent blind spots in concurrency reasoning and proactive schema safety, with no chronological signal of improvement or regression within this narrow window.
+
+**Strengths:**
+- Thorough and structured inline response to reviewer feedback: each concern is addressed with a specific commit reference, a clear description of the resolution, and coverage of edge cases (e.g., remount, arbitration, focus restoration) (consistent) — *dbt/analytics PR norms: responses should be traceable and actionable; analogous here to commit-level traceability in code review*
+- Designs to clear ownership boundaries: separating transport-neutral capabilities (feedbackSurveys) from KGoose-dependent ones, and making sequencing sink-owned rather than renderer-owned, reflects good separation-of-concerns discipline (consistent) — *dbt modularity principle: sources, models, and exposures should have single, well-scoped owners*
+- Adds regression and remount test coverage when addressing concurrency and state machine bugs, not just fixing the immediate code path (consistent) — *null*
+
+**Growth areas:**
+- Concurrency and multi-process/multi-renderer race conditions are consistently introduced and only resolved after reviewer escalation: sequence allocation races (PR #214), post-await state overwrite between renderer realms (PR #215), and cross-process cooldown-file races (PR #215) all appeared as blind spots (consistent) — *null*
+  → **Support:** Before submitting PRs that touch shared state (IPC, native storage, multi-renderer), author should self-review with a checklist: (1) enumerate all concurrent actors that can access this state, (2) identify every read-modify-write sequence and confirm atomicity, (3) document the chosen consistency contract in a code comment. Pairing with kalvinnchau on a concurrency design review session before implementation on the next multi-renderer feature would accelerate internalization.
+- Schema and API backward compatibility is surfaced by reviewers rather than proactively reasoned about: adding a field to a deny_unknown_fields struct without a version bump (PR #214) was caught externally (consistent) — *dbt versioning: model contracts and schema changes require explicit version bumps when downstream consumers exist; analogous principle applies to API schema evolution*
+  → **Support:** Author should adopt a pre-PR checklist item for any struct or API change: (1) is deny_unknown_fields or an equivalent strict schema in use? (2) are there deployed consumers on older schemas? (3) does this change require a new schema version or a feature-flag gate? A short internal doc on the team's schema versioning contract for the runtime-config endpoint would provide a reusable reference.
+- Accessibility considerations (focus management after programmatic UI changes) are missed at design time and require reviewer prompting: focus returning to document body after survey dismissal (PR #215) was not caught pre-review (occasional) — *WCAG 2.1 SC 2.4.3 Focus Order; standard practice for modal/overlay dismissal is to return focus to the trigger element or a defined fallback*
+  → **Support:** Add an accessibility self-review step to the PR template for any component that programmatically moves focus or unmounts focused elements: (1) where does focus land after dismiss/unmount? (2) is there a logical fallback (trigger element, composer)? Running a keyboard-only walkthrough of new UI before marking PR ready would catch this class of issue before review.
+
+### cynfria
+**Trajectory:** improving — Later PRs (#87, #95, #96, #217) pass review cleanly in one round, and cynfria increasingly self-corrects localization and lifecycle issues within revision cycles, though the underlying patterns of async races and atomicity gaps persist in complex PRs.
+
+**Strengths:**
+- Feature delivery across broad surface area: consistently ships complex UI features (onboarding, navigation, agent cards, import/export flows) that span frontend and backend (consistent)
+- Responsive to reviewer feedback: addresses blocking issues across multiple revision cycles and engages substantively in review threads with comments explaining design decisions (consistent)
+- Localization awareness improving over time: later PRs demonstrate proactive addition of Spanish translations and locale-keyed identity checks after early gaps were flagged (emerging)
+- Clean, focused small-scope PRs when scope is well-defined: PRs #87, #95, #96, #217 pass review in a single round with no blocking issues (consistent)
+
+**Growth areas:**
+- Localization completeness: repeatedly ships new user-visible copy in English only, missing parity in supported locales (Spanish). Flagged in PR #42, #74, #124, #83, #157. (consistent) — *i18n best practice: all user-visible strings must be externalized and translated for every supported locale before merging*
+  → **Support:** Add a pre-commit or CI lint step that diffs locale JSON files and fails if new English keys have no matching Spanish entry. Pair with a one-time walkthrough of the i18n workflow so cynfria can self-audit before pushing.
+- Async race conditions and lifecycle safety: multiple PRs introduce concurrent-read/write races, missing AbortSignal propagation, and stale-ref patterns (PR #42 animation fetch stall, PR #83 gallery ZIP race and StrictMode abort, PR #151 import-path race, PR #124 migration rename race). (consistent) — *React: effects that start async work must cancel in-flight operations on cleanup; generation counters or AbortController must be shared across all code paths that can mutate the same state*
+  → **Support:** Schedule a focused pairing session on async lifecycle patterns in React (AbortController, generation counters, cleanup functions) and Rust (atomic check-then-act alternatives). Provide a team-internal checklist: for every async operation, ask 'what happens if a newer operation starts before this one resolves?' and 'is every code path that can produce a result guarded by the same invalidation signal?'
+- File-system atomicity in Rust migration/replacement code: multiple rounds of PR #124 and #151 introduced check-then-act races on the file system (hash then rename without atomic binding), and recovery paths that could overwrite concurrent edits. (consistent) — *Systems correctness: file identity checks and replacements must be atomic; use O_CREAT|O_EXCL, hard-link-then-rename, or platform-specific no-replace semantics rather than separate existence/hash checks followed by independent rename calls*
+  → **Support:** Provide cynfria with a short internal reference on POSIX and Windows atomic file-replacement patterns (link+rename, MoveFileExW MOVEFILE_REPLACE_EXISTING caveats). When a PR touches bundled-agent migration or any file replace path, require an explicit comment in the PR describing the atomicity strategy and the failure mode if the process is interrupted between each step.
+- Boundary validation completeness: recurring P1/P2 findings around missing or incorrect input validation (grapheme vs code-unit counting, off-by-one after punctuation append, raw-size pre-bound before expensive segmentation, v1 snapshot schema compatibility). Seen in PR #42, #124. (consistent) — *Defensive programming: validate at the trust boundary using the same unit the downstream consumer enforces; validate after all transformations (e.g., punctuation) not before*
+  → **Support:** Introduce a code-review checklist item: 'Does every validation constraint use the same unit as the consumer, applied after all transformations?' Pair on the PR #124 grapheme/code-unit confusion as a concrete case study. Encourage cynfria to write boundary unit tests that include emoji, CJK, and punctuation-appended edge cases.
+- Complex PRs accumulate many blocking issues before approval: PRs #42 (6 rounds), #83 (7 rounds), #124 (9+ rounds) each required many CHANGES_REQUESTED cycles, suggesting scope or design is not fully resolved before implementation begins. (consistent)
+  → **Support:** For high-complexity PRs, require a brief design note (even a PR description section) covering async lifecycle, atomicity, localization, and validation strategy before implementation. Encourage cynfria to open a draft PR early and request an informal design review before investing in full implementation, reducing expensive late-cycle rework.
+
+### damienrj
+**Trajectory:** insufficient-data — Only one PR is available for review, so no chronological improvement signal can be established despite the PR showing both responsiveness to feedback and recurring lifecycle/resource defects across multiple commit cycles.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: consistently addressed P1 and P2 findings across multiple commit cycles within the same PR, with documented resolution comments on each inline finding (emerging)
+- Ambitious feature scope with sound architectural foundations: the SSH/ACP transport design was validated by reviewers as viable, with no request for a fundamental rewrite (emerging)
+- Thorough self-review engagement: author actively responded to automated and human reviewer comments, indicating strong ownership of quality (emerging)
+
+**Growth areas:**
+- Lifecycle and resource ownership correctness in concurrent/async code: multiple P1/P2 findings around stale PID records, tunnel PID not cleared after exit, race between reconnect establishment and shutdown, and generation token not guarding reconnecting state — required 3+ commit cycles to resolve (consistent)
+  → **Support:** Before opening PRs with async state machines, author should conduct a structured concurrency audit checklist: for each shared mutable state variable, document (a) which lock/generation guard owns it, (b) all code paths that read or write it, and (c) the expected invariant at each state transition. Pair review with a senior engineer on any new supervisor or lifecycle FSM before first review cycle.
+- Cross-platform shell scripting safety: portable base64 decoding (GNU vs macOS), unbounded log files, stale-lock wedge scenarios, and orphaned daemon processes on bootstrap timeout were all flagged as P1/P2 — indicating insufficient pre-review testing on non-Linux targets (consistent)
+  → **Support:** Establish a pre-merge checklist for shell scripts targeting multiple OS environments: run shellcheck, test on both GNU/Linux and macOS, explicitly verify each external command's flag compatibility, and define bounded resource usage (log rotation, lock timeouts) before opening for review.
+- Boundary enforcement for experiment feature flags: the remote-session experiment flag was not consistently checked at transport, reconciliation, and multi-window boundaries, requiring multiple rounds of feedback to fully propagate the guard (consistent)
+  → **Support:** When implementing experiment-gated features, author should map all enforcement boundaries (transport layer, UI layer, state rehydration, multi-window sync) upfront in the PR description and confirm each is covered before requesting review. Consider using a shared utility or type that enforces the experiment check at every call site.
+- UTF-8 byte-boundary safety in Rust string manipulation: draining a String at a byte offset derived from len() without verifying character boundaries was flagged as a P3 defect (occasional)
+  → **Support:** Review Rust documentation on String::drain and char_indices; prefer splitting at char boundaries using char_indices or split_at checked with is_char_boundary. Add a linting pass or code review note for any String manipulation using raw byte offsets.
+
+### delkc
+**Trajectory:** insufficient-data — All three PRs span only three days and received approvals with minimal visible review feedback, providing too little signal to distinguish a meaningful improvement or regression trend.
+
+**Strengths:**
+- Consistent reviewer approval with no requested changes across all PRs, suggesting clean, reviewable code submissions (consistent)
+- Clear, descriptive PR titles that communicate intent (fix, feat, refactor scope) following conventional commit conventions (consistent)
+- Rapid, focused delivery — three PRs across three days covering distinct feature areas without apparent scope creep (emerging)
+
+**Growth areas:**
+- No reviewer discussion or inline feedback visible in any PR, making it impossible to assess code quality depth, SQL/dbt logic correctness, or whether reviews are substantive (consistent)
+  → **Support:** Encourage the author to solicit specific feedback on implementation decisions in PR descriptions (e.g., 'I chose X approach over Y because...') to prompt richer review dialogue and surface potential blind spots.
+- PR #139 was reviewed by an automated tool ('🤖 Automated code review'), which may not catch semantic or business-logic issues — reliance on automation without human review depth is a risk (occasional)
+  → **Support:** Establish a team norm that PRs merging significant UI or settings restructuring (like merging About into System settings) require at least one human reviewer providing substantive commentary, not just automated approval.
+- Insufficient evidence of testing strategy, documentation updates, or rollback considerations in any PR (consistent) — *dbt best practices: every model change should include test coverage; general eng best practice: PRs should reference tests added or explain why none are needed*
+  → **Support:** Add a PR template checklist that requires authors to explicitly confirm: tests added/updated, documentation updated, and rollback plan considered before requesting review.
+
+### johnmatthewtennant
+**Trajectory:** stable — Across the full window, the same categories of first-submission defect (unbounded async, localization gaps, design-system bypass, accessibility omissions, ingress trust) appear with consistent frequency from the earliest PRs through the most recent, indicating a stable skill profile that is productive and thorough in iteration but has not yet internalized these classes of concern at the pre-submission stage.
+
+**Strengths:**
+- Rapid iteration and responsiveness to review feedback: consistently addresses blocking P1 findings across multiple push cycles within the same PR, providing detailed fix citations (commit SHAs) for each resolved issue (consistent)
+- Deep ownership of complex async and concurrent systems: designs and ships multi-layered lifecycle management for native voice pipelines (Pocket, Siri, OpenAI, AirPods), correctly modeling serialization, generation-ordering, and cancellation semantics (consistent)
+- Cross-layer feature delivery: consistently delivers features that span Rust/Tauri backend, Swift native bridges, and TypeScript/React frontend in a single coherent PR (consistent)
+- Defensive hardening after initial review: when a lifecycle or race condition is called out, fixes are thorough and include regression test coverage (e.g., PR #150, #160, #184, #234) (consistent)
+- Productive engagement with automated review: treats automated reviewer findings as first-class, providing substantive written rationale when declining a proposed change and a fix commit when accepting (consistent)
+
+**Growth areas:**
+- First-submission lifecycle correctness: P1 blocking issues (unbounded waits, missing deadlines, unsafe concurrent mutations, stale-winner races) are recurrently introduced and caught only in automated review across PR #135, #150, #160, #164, #172, #177, #184, #190, #206, #232, #234. The same classes of defect—unbound async operations, missing serialization, stale-generation misuse—appear in nearly every large PR. (consistent) — *General async correctness: every async operation must have a bounded timeout; every shared mutable resource must be protected by a serialization primitive scoped to the relevant lifecycle revision*
+  → **Support:** Before opening a PR, apply a personal pre-flight checklist that explicitly asks: (1) Does every async await have a timeout or cancellation path? (2) Does every shared mutable state write carry a generation/revision check? (3) Can two concurrent callers both succeed and leave the system in an invalid state? Pair-review one complex PR per sprint with a senior engineer focused exclusively on these three questions before automated review runs.
+- Localization coverage: user-visible strings are repeatedly introduced as English template literals or hardcoded English copy and caught by review in PR #150, #160, #170, #184. The same omission recurs across both Rust/Swift and TypeScript layers. (consistent) — *i18n standard: all user-visible strings must be routed through the project's localization resource system; template-literal construction of UI copy is not permitted*
+  → **Support:** Add a lint rule or pre-commit hook that flags new string literals containing spaces in UI-layer files (src/features/, src/shared/ui/). Additionally, add a localization checklist item to the PR template so it is evaluated before submission, not discovered in review.
+- Design-system compliance for new UI components: feature-local styling (colors, radius, spacing, interaction states) and new interactive primitives are built directly in feature code instead of using or extending shared design-system components, caught in PR #150, #184, #192. Custom dialog layouts, button variants, and card interactions bypass the shared anatomy contract. (consistent) — *Design-system contract: feature code must not define local color, radius, spacing, or interaction-state classes; reusable interactive patterns must live in the shared design-system layer with explorer documentation*
+  → **Support:** Schedule a 30-minute walkthrough of the shared design-system component catalog and dialog/button/card anatomy contracts with the design-system owner before starting any PR that introduces new interactive UI. For PRs touching shared primitives, require design-system owner sign-off as a named reviewer.
+- Accessibility completeness on first submission: aria labels, live-region semantics, and accessible name composition are repeatedly missed on first submission and caught in PR #150, #184, #192, #204. Issues include missing localized close labels, incorrect aria roles, and visible text not reflected in accessible names. (consistent) — *WCAG 2.1 / project accessibility standards: every interactive control must have a programmatic accessible name that matches or includes its visible label; dialog primitives must supply localized close labels*
+  → **Support:** Run axe or a similar accessibility linter as part of the local dev workflow and block CI on new violations. Add an accessibility checklist to the PR template covering: localized close labels on dialogs, aria-label matches visible text, live-region labels updated for dynamic state changes.
+- Ingress validation at trust boundaries: data accepted from the renderer or an external source is passed directly into native operations without re-validation at the Tauri command boundary, caught in PR #205 (Siri voice name) and PR #234 (NUL bytes in monitor output). The pattern of trusting caller-supplied values without re-resolving them against authoritative native state recurs. (consistent) — *Security/correctness principle: every Tauri command accepting externally-supplied identifiers or data must re-validate that data against the authoritative server/native catalog before use, not trust the renderer's copy*
+  → **Support:** Add a security checklist item to the PR template: 'For every new Tauri command, does it re-validate caller-supplied identifiers against the authoritative native/server source before acting?' Include this as a standing agenda item in sprint retrospectives until the pattern stops appearing.
+
+### josereyes
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to identify patterns or trends in the author's work.
+
+**Strengths:**
+
+**Growth areas:**
+
+### kalvinnchau
+**Trajectory:** improving — Early PRs in the window surface CI security flags and multi-blocking release script issues, while later PRs (August 26 onward) receive clean first-pass approvals across increasingly complex feature and fix work, suggesting the author is tightening pre-submission review and edge-case reasoning over time.
+
+**Strengths:**
+- High merge rate with clean first-pass approvals — the majority of PRs across CI fixes, feature work, and chores are approved without blocking feedback, indicating solid pre-submission hygiene (consistent)
+- Responsive iteration when reviewers flag issues — on PRs #27 and #163, blocking feedback was addressed quickly with follow-up commits and confirmed fixed in inline reviewer responses (consistent)
+- Broad technical range across CI/CD pipelines, TypeScript/React frontend, Rust/Tauri native layers, CLI tooling, and release scripting — consistently delivers in each domain (consistent)
+- Release engineering discipline — version synchronization across package manifests, lockfiles, Rust, Tauri, and plugin declarations is consistently validated clean (PRs #25, #32) (consistent)
+
+**Growth areas:**
+- Security hardening in CI workflows — PR #13 triggered two zizmor cache-poisoning alerts on release.yml, indicating runtime artifacts were left vulnerable without pinned or hash-verified action references (occasional) — *GitHub Actions security hardening: use pinned SHA refs for third-party actions and avoid mutable cache keys on untrusted input paths*
+  → **Support:** Review the zizmor findings from PR #13 together and walk through the GitHub Actions hardening guide; add a zizmor or actionlint step to CI so cache-poisoning and unpinned-action patterns are caught automatically before merge
+- Edge-case state management in async/store logic — PR #163 shipped with a stale error field surviving a successful empty refresh, and PR #27 shipped with a local-tag and stale-main-snapshot race condition; both required P1/P2 reviewer intervention (consistent) — *Defensive state reset pattern: on any success branch, explicitly clear all error and staleness fields rather than spreading existing state*
+  → **Support:** During design or code review, prompt a checklist item: 'Does every success path explicitly reset all error, stale, and timestamp fields?' Add lint or type-level helpers (e.g., a Result wrapper) that make carrying stale error state structurally impossible
+- Release script correctness under concurrent remote state — PR #27 needed two blocking fixes (local-only tag filtering and stale main-snapshot during approval window) before it was safe to merge; these are subtle but high-impact gaps in release tooling (occasional) — *Release automation best practice: all baseline references must be validated against remote state at the point of use, not at script start*
+  → **Support:** Pair on a structured review of release.mjs with a focus on 'what can change between step N and step N+1'; add integration tests or dry-run assertions that simulate a remote tag appearing or main advancing mid-script
+
+### kennylauren
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to identify patterns, strengths, or growth areas.
+
+**Strengths:**
+
+**Growth areas:**
+
+### loganj
+**Trajectory:** stable — Across the review window loganj consistently resolves flagged issues when prompted, but the same categories of blocking defects (migration safety, race conditions, contract precision) recur in each PR rather than diminishing over time, suggesting the workflow is reactive rather than preventive.
+
+**Strengths:**
+- Responsive to reviewer feedback — consistently iterates on flagged issues across multiple commits within a PR, with documented fix confirmations (consistent)
+- Documentation discipline — proactively creates and updates specification documents (TELEMETRY.md, LAWS/CHAT.md, docs(laws)) alongside code changes (consistent)
+- Engages multiple review perspectives including automated and human reviewers, and self-audits own PRs when external approval is blocked (consistent)
+
+**Growth areas:**
+- Submitting PRs with blocking P1 defects that automated and human reviewers catch before merge — race conditions, stale state, schema migration gaps appear across PR #17, #64, #65, #97 (consistent)
+  → **Support:** Before opening a PR, run a self-checklist for: (1) concurrent write paths that share mutable state, (2) any removal of persisted/serialized identifiers requiring a migration or normalization shim, (3) bidirectional contract invariants in interface/law definitions. Consider adding a PR description section explicitly calling out these risk categories and how each was tested.
+- Persisted schema compatibility — removing or renaming persisted IDs without providing forward/backward migration, causing hydration failures for existing users (PR #97, PR #64) (consistent)
+  → **Support:** Establish a personal rule: any deletion of a value that appears in a persisted or serialized schema must be accompanied by a normalization/migration step in the same PR. Create a short checklist item: 'Does this value exist in any stored record format?' and pair with a test that loads a v1 fixture containing the old ID and asserts safe hydration.
+- Race conditions in async state management — PRs #17 and #64 both had P1 findings around concurrent reads and writes to shared state without proper locking or sequencing (consistent)
+  → **Support:** For any function that reads state and then writes it back (read-modify-write), explicitly annotate or document what prevents interleaving. Add unit tests that simulate concurrent calls (e.g., two rapid saves) and assert final state is deterministic. Pair with a reviewer ask: 'Can this path be entered twice simultaneously?'
+- PR #65 and #78 were dismissed by reviewers, indicating PRs are sometimes opened before the change is sufficiently complete or aligned with architectural contracts (occasional)
+  → **Support:** Before opening a PR that modifies interface contracts or law documents, do a draft review pass against existing consumers/callers to verify the new wording preserves all invariants (bidirectionality, attempt-scoping, etc.). Consider using a draft PR and requesting a single early-pass review before moving to ready-for-review.
+
+### matt2e
+**Trajectory:** improving — Early PRs (#14, #15, #61, #62) merged cleanly with minimal friction; PR #16 showed the most review churn with repeated blocking findings and some resistance, but PR #179 demonstrated that matt2e now proactively addresses lifecycle/timeout issues (bounded waits implemented before final approval) and PR #254 merged cleanly, suggesting growing awareness of the recurring gaps.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: when blocking issues are raised, matt2e addresses them in follow-up commits within the same PR cycle (e.g., PR #179 timeout fix in d97bde3, PR #16 multiple revision rounds) (consistent)
+- Broad scope of contribution: spans infrastructure (build config, Cargo features), backend (Rust/Tauri commands), frontend (React hooks, UI components), telemetry pipelines, and dependency hygiene — demonstrates full-stack ownership (consistent)
+- Clean, scoped PR structure: PRs are tightly scoped to their stated purpose (fix, feat, chore, refactor) with descriptive conventional-commit titles, making review straightforward (consistent)
+- Security hygiene: proactively bumps vulnerable dependency (js-yaml GHSA-5p4m-2wfm-xmqj) and maintains lockfile consistency (PR #254) (emerging)
+
+**Growth areas:**
+- Cross-platform correctness: blocking P1 issues around platform-specific behavior (Windows rename semantics for consent file, Windows omission of enforced telemetry Cargo feature) surface repeatedly in PR #16, suggesting platform coverage is not part of the pre-submission checklist (consistent)
+  → **Support:** Add a mandatory cross-platform checklist item to the PR template for any Tauri/native command: verify Cargo feature flags are applied symmetrically across all target triples and test or document Windows-specific fs behavior. Pair matt2e with a Windows-owning engineer for at least one review cycle on native code.
+- Consent and lifecycle boundary conditions: multiple P1 blocking findings in PR #16 relate to consent state not being checked at async boundaries (revocation not stopping pending exports, consent choice advancing before save completes), indicating async lifecycle edge cases are consistently missed before submission (consistent)
+  → **Support:** Schedule a focused session on async state-machine design for consent/settings flows: establish a team convention that any async sequence gated on user consent must re-check consent at each await point. Create a short internal doc or checklist item: 'consent is checked at every async boundary, not just at entry.'
+- Accepting automated review findings too quickly as non-issues: in PR #16, matt2e dismissed at least two automated P1 findings inline (Windows rename concern, unknown-cohort onboarding path) with 'I think this is fine for launch' without demonstrating a concrete counter-argument or test, and one of those findings was later re-raised as still-blocking (consistent)
+  → **Support:** Establish a team norm that dismissing a P1 automated finding requires either a repro attempt proving it does not apply, a link to language/OS documentation, or explicit sign-off from a second human reviewer. Matt2e should be coached to treat 'fine for launch' as a documented risk acceptance, not a resolution.
+- Presentation timeout / unbounded async waits: PR #179 required a blocking revision because filesystem operations lacked presentation timeouts, leaving UI in permanent loading states — a pattern also flagged (non-blocking) in PR #16 for unbounded body acceptance in native export (occasional)
+  → **Support:** Introduce a team-level convention (documented in a CONTRIBUTING guide or architecture decision record) that any native/async operation surfaced in the renderer must be wrapped with a bounded timeout and an explicit recovery path. Reference the PRESENTATION_TIMEOUT_MS pattern from PR #179 as the canonical example.
+
+### morgmart
+**Trajectory:** stable — Approval rate and velocity remain consistently high across the window, but the recurring pattern of dismissed reviews (appearing in PRs #68, #94, #153, #156 spread across the full date range) has not reduced over time, indicating a stable ceiling rather than improvement in review discipline.
+
+**Strengths:**
+- High merge rate with clean approvals — the vast majority of PRs are approved with minimal back-and-forth, indicating solid pre-submission quality and reviewer trust (consistent)
+- Broad cross-functional scope — confidently ships across UI (chat, connections, composer), installer/packaging (macOS DMG), agent/skill publishing, and canvas features without being siloed (consistent)
+- Responsive to review feedback — in PR #76 the author engaged substantively in discussion, defended intentional design decisions with clear rationale, and followed up with a targeted fix (46617e56), demonstrating good review collaboration habits (emerging)
+- Clear, descriptive PR titles — titles consistently communicate intent (fix/feat/docs prefix, concise scope), making the changelog easy to read (consistent) — *dbt/Conventional Commits style: type(scope): description*
+
+**Growth areas:**
+- Dismissed reviews without visible resolution — PRs #68, #94, #153, and #156 all have at least one reviewer DISMISSED, suggesting reviews were occasionally bypassed or the author merged without fully resolving outstanding concerns (consistent) — *Standard PR hygiene: all review threads should be resolved or explicitly acknowledged before merge; dismissing a review should require a written justification*
+  → **Support:** Establish a team norm that dismissed reviews require a written comment explaining why the dismissal is appropriate (e.g., reviewer unavailable, concern addressed in follow-up PR). Pair morgmart with a senior reviewer on the next 2–3 PRs that receive blocking feedback to practice resolution workflows before merging.
+- Regression/omission of existing logic during refactors — PR #76 surfaced two non-trivial regressions (duplicate-extension filter removal, orphaned migration banner mount point) that the reviewer had to catch, suggesting pre-submission testing of edge cases in refactored UI components needs strengthening (occasional) — *dbt/analytics engineering best practice: when modifying existing logic, explicitly audit downstream consumers and test boundary conditions*
+  → **Support:** Before submitting refactor PRs, ask morgmart to produce a brief 'what I audited' checklist in the PR description (deleted code paths, existing callers, UI states affected). Add a component-level test or Storybook story for each UI state touched in a refactor to catch regressions automatically.
+- Limited PR descriptions visible — with no description text surfaced across 18 PRs, context for reviewers is likely thin, which may contribute to reviewers needing to ask clarifying questions or missing subtle regressions (consistent) — *dbt PR template best practice: every PR should include motivation, approach summary, and testing evidence*
+  → **Support:** Adopt a lightweight PR template requiring: (1) one-sentence motivation, (2) summary of approach, (3) how it was tested. Have morgmart apply this retroactively to the next 3 PRs as a habit-building exercise, with a senior reviewer providing written feedback on the description quality before approving.
+
+### mrohan-sq
+**Trajectory:** insufficient-data — Only one PR is available, making it impossible to assess directional growth over time.
+
+**Strengths:**
+
+**Growth areas:**
+- CSS table layout specifics: applying overflow-wrap: break-word without accounting for automatic table layout behavior, which fails to constrain intrinsic minimum cell width for long unbroken tokens like URLs or identifiers (occasional) — *CSS Intrinsic & Extrinsic Sizing — automatic table layout algorithm ignores overflow-wrap for minimum width calculation; word-break: break-all or table-layout: fixed is typically required alongside overflow-wrap*
+  → **Support:** Pair review of CSS table fixes with a checklist item to test with worst-case content (long URLs, hash strings) and verify table-layout: fixed is set on the table element when overflow-wrap or word-break is used on cells. Share MDN docs on table-layout: fixed as a reference.
+
+### nathan-thillairajah
+**Trajectory:** improving — PR #38 required seven automated review cycles to resolve persistent security and correctness issues, but PRs #270 and #271 — submitted two weeks later — both received immediate approvals with zero findings, suggesting the author internalized key lessons from the extended review process.
+
+**Strengths:**
+- Responsiveness and iteration on blocking review feedback: consistently addresses each raised blocking finding with targeted code changes across multiple review cycles (consistent)
+- Structured CLI command design: PRs #270 and #271 received clean approvals with no findings, indicating well-constructed authenticated request flows, proper URL encoding, and consistent output formatting (emerging)
+- Incremental feature delivery: separates readiness/debugging commands (PR #270) from inspection commands (PR #271) into focused, reviewable units (emerging)
+
+**Growth areas:**
+- Security boundary design — debug/test code leaking into production builds: PR #38 saw repeated blocking findings (P1) where test features, environment-variable transport overrides, embedded test CAs, and loopback transports were compiled into distributable binaries, requiring multiple full revision cycles to fully isolate (consistent) — *OWASP: Test code and debug instrumentation must not be present in production artifacts; Cargo conventions: cfg(test) or dev-dependencies should gate test-only code*
+  → **Support:** Before opening any PR that introduces test infrastructure touching auth or network transport, author should produce a written summary of how each test-only path is gated from release builds (cfg(test), dev-dependency, or separate binary), and have a senior reviewer sign off on that design doc before implementation begins
+- Credential lifecycle correctness — TOCTOU races, premature persistence, and session reuse on error: PR #38 repeatedly introduced patterns where a credential was verified then re-read from storage (race), a failed session was persisted before validation completed, or a 401 recovery path reused the already-rejected credential (consistent) — *OWASP ASVS V3: Session tokens must be invalidated on failure; secure credential handling requires verifying and using the same in-memory value atomically*
+  → **Support:** Author should study the verify-then-use-in-memory pattern explicitly: pair with the security-focused reviewer (morgmart) for a 30-minute walkthrough of the final approved credential flow in PR #38, then write a short internal design note codifying the rule — 'verify and hold the returned credential; never re-read storage after verification' — to reference in future auth PRs
+- Sanitization and data-loss correctness in output redaction: PR #38 introduced a redact_json_value implementation that collapsed distinct object keys when both contained the session string, silently dropping fields (occasional) — *General software correctness: map-rebuild transformations must preserve key uniqueness and must not silently discard data*
+  → **Support:** Author should add property-based or table-driven tests for any redaction/sanitization utility covering edge cases (duplicate keys after transformation, nested objects, array elements) before submitting PRs that touch output sanitization logic
+- Test coverage preservation across refactors: PR #38 saw multiple review rounds flag that successful end-to-end CLI tests (contract, create, multipart deploy) were deleted and had to be restored, recurring across at least two separate revision cycles (consistent) — *dbt/analytics engineering norms and general CI best practices: refactors must not reduce test coverage on the happy path*
+  → **Support:** Author should adopt a personal pre-PR checklist item: run the full test suite diff (e.g., cargo test -- --list before and after) and explicitly confirm no previously passing test names have been removed; include that confirmation in the PR description
+
+### tirsen
+**Trajectory:** insufficient-data — Only two PRs are available and both received approval with strong security praise, but the sample is too small to establish a directional trend.
+
+**Strengths:**
+- Security-conscious implementation: URL validation, shell-free subprocess invocation, IPC validation, and SQL parameterization are consistently noted as careful and correct (consistent) — *dbt best practices: use parameterized queries to prevent injection; general secure coding: avoid shell=True, validate and canonicalize external URLs*
+- Coherent refactoring alongside feature work: scroll and state-dir refactors in PR #113 were described as coherent, indicating clean separation of concerns (emerging) — *dbt style guide: models should have a single, clear purpose; refactors should not silently change behavior*
+- Bounded, timeout-guarded external process execution: both PRs show deliberate handling of Tauri/gh subprocess boundaries with timeouts and prompt disabling (consistent) — *null*
+
+**Growth areas:**
+- Feature gating / default-on behavior: PR #113 required negotiation about whether the pull request tracker should be default-on, suggesting insufficient upfront alignment on rollout scope before implementation (occasional) — *null*
+  → **Support:** Before implementing net-new user-facing features, document the intended default state and rollout plan in the PR description or a linked spec. Add a checklist item to the PR template: 'Is this feature gated / off by default for existing users?'
+
+### tulsi-builder
+**Trajectory:** insufficient-data — Only four PRs are available in the window, with one complex PR requiring two rounds of review and three simple PRs approved immediately, which is too small a sample to establish a directional trend.
+
+**Strengths:**
+- Responsive to reviewer feedback: addresses blocking issues promptly and completely, as seen in PR #41 where both the race condition and localization gap were resolved in a follow-up commit with regression coverage (emerging)
+- Consistent approval rate across PRs with minimal back-and-forth on non-complex changes (PRs #84, #92, #137 all approved on first review) (consistent)
+
+**Growth areas:**
+- Internationalization (i18n) completeness: new user-facing strings were added only to the English locale catalog, missing the Spanish locale in PR #41, requiring a reviewer catch before it was addressed (occasional) — *dbt/analytics style guides generally require all user-facing string additions to be mirrored across all supported locales before submission*
+  → **Support:** Add a pre-commit or CI lint step that diffs locale JSON files and fails if any supported locale is missing keys present in the base (English) catalog. Additionally, include an i18n completeness checklist item in the PR template so the author self-reviews locale parity before requesting review.
+- Concurrency and race condition awareness: the overlapping-reclaim race in PR #41 (stale queue replay on overlapping window closes) was not caught before submission, suggesting concurrent async flows need more careful pre-review scrutiny (occasional)
+  → **Support:** Encourage the author to add a concurrency section to their self-review checklist for any PR touching async drains, queues, or shared state: explicitly ask 'what happens if two instances of this run simultaneously?' Pair on one session reviewing async patterns and serialization strategies to build intuition.
+
+---
+
+## 4. Team Gap Analysis
+
+### Where the team is strong
+| Area | Evidence | Standard |
+|------|----------|----------|
+| Release automation rigor: human approval gates, atomic version synchronization, idempotent/resumable steps, and fail-closed conflict semantics | Multiple rule/convention-maturity signals covering SemVer floor enforcement, annotated tag semantics, lockstep manifest updates, changelog drift detection, and identity-bound PR resumption — all reviewed by matt2e on kalvinnchau's PRs | The Checklist Manifesto (Gawande) — pause point before irreversible actions; Semantic Versioning |
+| Security-conscious IPC and subprocess handling: URL canonicalization, shell-free CLI invocation, SQL parameterization, and exact HTTPS host validation | loganj explicitly praised the subprocess, IPC-validation, SQL-parameterization, timeout, and URL-boundary work as 'unusually careful'; security boundary enforced at rule maturity via bounded gh invocation and canonical URL reconstruction | OWASP: Command Injection prevention; OWASP: URL validation and canonicalization best practices |
+| Concurrency correctness review: race conditions, serialization boundaries, and arbitration logic scrutinized with controlled interleaving tests required | comp615 consistently raises concurrent renderer races and state corruption across reviewed PRs, requiring explicit test coverage of race scenarios at rule/guidance maturity | — |
+| React effect and timer lifecycle correctness: unmount-during-debounce windows, cleanup flushing latest refs, and rejection counter durability across state transitions | caregullin focuses precisely on cleanup hygiene, debounce edge cases, and counter survival across state transitions across both reviewed PRs | React lifecycle/effect hygiene |
+| Feature rollout gating via experiment flags before broad enablement of high-cost features | loganj explicitly conditioned approval of the PR tracker on experiment-gating to control database query cost at scale; pattern recorded at guidance maturity | — |
+| Business-logic edge case validation through iterative discussion: reviewers raise, investigate, and formally withdraw findings after discussion | loganj raised and then formally withdrew transcript-based project association and stale PR row concerns after discussion — demonstrating structured correctness validation rather than drive-by review | Google's Code Review Developer Guide — thoroughness and iterative dialogue |
+| Test pyramid coverage for new feature surface area including both frontend (Vitest) and backend (Rust) unit tests | loganj noted 49 focused Vitest tests and 3 Rust PR-tracker tests as part of the approval rationale for the PR tracker feature | Testing pyramid |
+| Secrets hygiene: sensitive configuration supplied as repository secrets rather than hardcoded values | Updater public-key configuration managed via repository secret, reviewed by matt2e at convention maturity | OWASP: Sensitive data exposure |
+
+### Gaps and blind spots
+| Area | Gap Type | Missing Standard | Recommendation |
+|------|----------|-----------------|----------------|
+| TypeScript strict-mode and type safety review: no reviewer comments on type annotations, inference gaps, unsafe casts, or strict-mode violations in TypeScript/React code | blind_spot | TypeScript strict mode | Enable strict: true and noUncheckedIndexedAccess in tsconfig and add a CI gate (tsc --noEmit) that fails the build on type errors; add a checklist item for reviewers to confirm no 'any' escapes or unsafe casts are introduced |
+| Test strategy and coverage for edge cases: reviewers like caregullin identify complex behavioral edge cases (unmount-during-debounce, counter reset) but do not verify or require corresponding test cases | knowledge_gap | Testing pyramid | Add a review checklist item: 'For every edge case identified in review, is there a corresponding unit or integration test?' Train reviewers to block merge when a named edge case has no test coverage |
+| Accessibility (WCAG) review for UI components: no evidence of any reviewer ever checking keyboard navigation, ARIA roles, focus management, or color contrast in the React frontend | blind_spot | WCAG 2.1 | Integrate axe-core or eslint-plugin-jsx-a11y into CI to catch obvious violations automatically; add a checklist item for interactive UI PRs requiring a reviewer to verify keyboard operability and ARIA labeling |
+| Performance regression review: the polling interval concern (30s database query cost) was raised but resolved by experiment-gating rather than by bounding or documenting the cost model | knowledge_gap | — | Establish a lightweight performance review checklist for features introducing polling, background timers, or DB queries: require authors to state expected query frequency, row count bounds, and index usage; make this a required section in PR descriptions for backend feature PRs |
+| Naming, readability, and code style feedback: across the reviewed PRs no reviewer comments address function decomposition, variable naming, or code clarity | coverage_gap | Google's Code Review Developer Guide — readability as a review dimension | Configure and enforce clippy (with #![deny(clippy::all)]) for Rust and eslint with agreed rules for TypeScript as CI gates so mechanical style issues are caught before review; free reviewers to focus naming and decomposition comments on non-automatable clarity concerns |
+| Conventional Commits enforcement: no evidence that commit message format is reviewed or enforced, despite the team having a structured release automation pipeline that could benefit from machine-readable commit history | blind_spot | Conventional Commits | Add a commitlint CI check enforcing Conventional Commits format on PR branches; this directly feeds the release changelog automation already present and removes manual changelog curation burden |
+| Validation rollback and release preparation failure handling: rollback of tracked files on failed preparation is at guidance maturity with no evidence of automated test coverage for the rollback path | knowledge_gap | The Checklist Manifesto (Gawande) — irreversible action safety | Add integration tests for the release script's rollback path that simulate each failure mode (network error, validation failure, conflict) and assert that all tracked files are restored to pre-release state; gate release tooling PRs on these tests passing |
+
+### Review culture
+The team demonstrates strong depth in its core domains — release automation correctness, security boundary enforcement, and concurrency safety — with reviewers who engage iteratively and are willing to formally withdraw findings after discussion, which is a healthy sign of intellectual honesty. However, review coverage is uneven: mechanical quality dimensions like TypeScript type safety and accessibility are entirely absent from the record, suggesting reviewers concentrate on behavioral correctness and leave structural/compliance concerns to chance. The release automation and security work is approaching institutional solidity, but several high-value patterns remain at guidance or judgment maturity where a small investment in runbooks, checklists, and CI gates could make them reliably reproducible across the whole team rather than dependent on specific reviewers.
+
+---
+
+## Methodology & Caveats
+
+- **Window:** 2026-08-12 → 2026-09-02 | **PRs analyzed:** 159 | **PRs skipped (no reviews):** 0
+- **Repo context:** SQLFluff config found | PR template found | dbt_project.yml found
+- **What this analysis cannot see:** verbal review culture (Slack), reviewer availability constraints, domain ownership, or PRs merged without review.
+
+---
+
+## Appendix: Reference Standards
+
+- **dbt Labs style guide**: https://docs.getdbt.com/best-practices/how-we-style/0-how-we-style-our-dbt-projects
+- **dbt-project-evaluator**: https://github.com/dbt-labs/dbt-project-evaluator
+- **SQLFluff rule catalog**: https://docs.sqlfluff.com/en/stable/rules.html
+- **Kimball dimensional modeling**: https://www.kimballgroup.com/data-warehouse-business-intelligence-resources/kimball-techniques/dimensional-modeling-techniques/
+- **Google Engineering Practices — code review**: https://google.github.io/eng-practices/review/
+- **Smart Bear — peer review best practices**: https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/

--- a/tricorder/2026-09-02-block__buzz.md
+++ b/tricorder/2026-09-02-block__buzz.md
@@ -1,0 +1,744 @@
+---
+date: 2026-09-02
+repo: block/buzz
+window: 2026-08-17 → 2026-09-01
+pr_count: 187
+contributors: ['Maxwellimus', 'TheSentinel454', 'baxen', 'bradseiler', 'brow', 'jedwards27', 'jmecom', 'kalvinnchau', 'klopez4212', 'kruegermj', 'loganj', 'mahanti', 'matt2e', 'morgmart', 'ngthuydiem', 'philazar', 'ravarora2', 'salman1993', 'tellaho', 'thomaspblock', 'tlongwell-block', 'tulsi-builder', 'wesbillman', 'wpfleger96']
+visibility: private
+generated_by: tricorder v1.1.0
+---
+
+# PR Review Analysis — block/buzz — 2026-09-02
+
+> Window: 2026-08-17 → 2026-09-01 | 187 PRs | 24 contributors
+
+---
+
+## 1. Patterns Ready to Institutionalize
+
+| Pattern | Category | Current Maturity | Next Step | Standard |
+|---------|----------|-----------------|-----------|----------|
+| Append-only audit logging required for any mutation of security-critical or privileged state | — | rule | Document as an Architecture Decision Record (ADR); add to PR checklist: 'any insert/update/delete on a trust or permission table must have a corresponding append-only audit table write in the same transaction'; add integration test asserting audit row exists after each mutation type | deterministic |
+| Input canonicalization before security-critical lookups (case normalization, encoding normalization) | — | rule | Write a team convention document enumerating all external input types that require canonicalization (hex pubkeys, email, usernames) and the canonical form required; add unit test requirement for canonicalization edge cases in any auth or lookup code path | rule |
+| Fail-closed authentication configuration: unrecognized auth modes must abort startup | — | rule | Add startup integration test asserting that unrecognized AUTH_MODE value causes non-zero exit; document fail-closed requirement in service configuration ADR; add to PR checklist for auth configuration changes | deterministic |
+| Frontend type definitions must be kept in sync with backend API schema for all new or modified fields | — | guidance | Adopt OpenAPI or protobuf as the authoritative schema contract; generate TypeScript types from schema at build time; enforce generated types are committed and up-to-date via CI diff check | deterministic |
+| CI pipeline timeout values must be set to realistic expected durations, not defaults | — | judgment | Define a team convention document specifying maximum timeout values by job category (unit test: 5m, integration: 15m, e2e: 30m); add a linting step or PR checklist item for any workflow change that raises a timeout above category maximum | convention |
+| Policy document cross-reference during review of enforcement and notification code paths | — | judgment | Convert VISION_MODERATION.md and similar policy documents into machine-readable checklists linked from PR template; require reviewer to confirm each enforcement action type has corresponding notification task before approval | convention |
+| Replay protection uniqueness guarantees for cryptographic signing operations | — | rule | Add unit/integration tests asserting distinct event IDs for concurrent same-endpoint requests; document nonce requirement in authentication module README; add to PR checklist for any NIP-98 or similar signing code path | deterministic |
+| Observability metrics for operationally significant new code paths (enforcement actions, migrations, auth events) | — | judgment | Define a metric naming convention document; add to PR template a required field: 'Metrics added: <metric_name> or N/A with justification'; conduct team review session to identify existing gaps in metric coverage | convention |
+
+---
+
+## 2. Reviewer Focus Fingerprints
+
+### TheSentinel454
+**Style:** advisory | **Signal quality:** medium — Most substantive comments are on a Rust/infra repo rather than a SQL/dbt repo, limiting applicability to analytics review patterns, but the reviewer's consistent focus areas are clearly inferrable from their questioning style and the bot-response thread structure.
+
+**Primary focus areas:**
+- Correctness and completeness of documentation — ensuring docs match actual implementation details (e.g., tag formats, operating contracts, migration caveats) (often)
+- Avoiding duplication — questioning repeated code, functions, or test logic without consolidation (often) — *DRY principle*
+- CI/CD pipeline correctness — timeout values, test isolation, job deduplication, and discovery script triggering (often)
+- Removing noise from PRs — plans, design docs, and low-value tests should not be included (sometimes)
+- Understanding the rationale behind code changes — demanding explanation for changed values, renamed tests, or unexpected fixture modifications (often)
+- Architectural concerns and technical debt — flagging problematic patterns (e.g., migrations on boot) for future work even if not blocking the current PR (sometimes)
+- Observability and metrics for operationally significant code paths (e.g., migration duration tracking) (sometimes)
+
+**Apparent blind spots:**
+- SQL-level correctness (query plans, index usage, join cardinality, grain declarations) — No comments across four PRs touch SQL semantics, query structure, or data modeling concerns — the reviewer is focused on Rust/infrastructure, not SQL analytics patterns.
+- Security review of credentials and secrets handling in CI workflows — The staging dev relay image workflow introduces image publishing and CI secrets; reviewer approved without visible comment on secret scoping, OIDC usage, or least-privilege for the workflow token.
+- Test coverage gaps — absence of tests for new code paths — The reviewer actively removes what they consider low-value tests but does not comment on missing coverage for new configurable timeout logic or new workflow paths.
+
+### baxen
+**Style:** blocking | **Signal quality:** high — The reviewer consistently identifies precise, reproducible contract violations with specific type-level fixes, independently verifies findings at named commits, and distinguishes P1 from P2 severity — producing a high-density signal across both PRs.
+
+**Primary focus areas:**
+- Wire contract invariants encoded in types vs. only documented in comments — ensuring that invariants like request/response correlation, action matching, and outcome validation are enforced structurally by the type system rather than left to caller discipline (always) — *Parse, don't validate (type-driven design principle)*
+- Serialization idempotence and byte-stability across retry attempts — preventing re-serialization of typed structs from introducing byte drift between retries when the contract requires identical bytes (always)
+- Strict deserialization rejecting unknown/extra fields and explicit nulls — using deny_unknown_fields and explicit null rejection to prevent protocol extension fields or malformed host responses from silently passing validation (always)
+- Identifier canonicalization before equality comparisons — ensuring UUIDs, public keys, and other identifiers are normalized to a canonical form before storage and correlation to prevent false mismatches (often)
+- Pagination cursor design — rejecting timestamp-based cursors in favor of opaque server-issued tokens to avoid infinite loops when multiple events share a timestamp boundary (sometimes)
+- Error type semantics and side-effect fate — ensuring error variants accurately reflect whether a request was dispatched and whether the outcome is known, so callers can make correct retry decisions (often)
+- Exhaustive match enforcement on closed enumerations — replacing wildcards on error code enums with exhaustive matches so new variants force an explicit decision at every branch point (sometimes)
+- Deployment environment impact analysis for security-critical changes — tracing every non-dev launch path to confirm a removed fallback or changed requirement does not break production deployments (sometimes)
+- Test scanner/lint robustness — rejecting superficial string-scan tests that can be bypassed by type aliases, wrapper types, or generic containers in favor of structural invariants (sometimes)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, model materialization, ref hygiene, source freshness) — Neither PR touches dbt or SQL; all reviewed code is Rust. There is no evidence of engagement with analytics engineering standards in either review.
+- Performance and latency implications of validation overhead on the hot path — Every comment pushes toward more validation at execution time (validate_for mandatory, exhaustive checks, strict deserialization) with no balancing discussion of throughput or latency impact.
+- API ergonomics and developer experience for external consumers of the SDK — Reviews focus heavily on correctness invariants and type constraints; there are no comments about whether the resulting API surface is easy to use correctly by downstream SDK consumers.
+- Breaking change management and versioning — Multiple review cycles remove public types (BrokerResult Deserialize, CredentialRejected, validate method), but no comment addresses semver impact or migration guidance for existing callers.
+
+### brow
+**Style:** advisory | **Signal quality:** medium — Comments are technically detailed and consistently grounded in empirical measurement (mutation probes, live rig traces), but almost all are explicitly labeled non-blocking, limiting signal on what the reviewer would actually block on.
+
+**Primary focus areas:**
+- Test coverage adequacy and mutation testing — specifically identifying branches that are untested because no existing fixture exercises them, verified by actually mutating the code and confirming the suite stays green (often) — *mutation testing / test adequacy*
+- Edge-case behavioral correctness in retry/backoff and timer logic — tracing through degenerate inputs (e.g., retry delay of 0ms) to identify where fallback paths silently degrade to unintended behavior (sometimes)
+- User-visible state correctness and race conditions in real-time/live session features — measuring actual observable effects (e.g., a client rendering a Huddle as ended while the call is still active) (sometimes)
+- Lifecycle and chunk/scope correctness in event replay and buffered delivery scenarios — identifying cases where stale or retired chunks can incorrectly pass or block event filters (sometimes)
+- CI build path coverage — ensuring CI exercises the real production linker/build path rather than a synthetic workaround that could miss the failure mode seen in RC (sometimes)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, model design, ref vs source hygiene, incrementality strategy) — All reviewed PRs are mobile/Flutter/Dart. No SQL or dbt models appear anywhere in the review history, so no signal exists for these dimensions.
+- Code style, naming conventions, and readability — Across 8 PRs and numerous inline comments, no comment addresses naming, formatting, or readability concerns — all comments are behavioral or structural.
+- Security and authorization review — The reviewer explicitly frames the 48103 issue as 'not only an authorization question' and focuses on the user-visible measurement rather than the auth control itself, suggesting auth is underweighted relative to behavioral correctness.
+- Performance and scalability of data models or queries — The one performance PR (#6996) received behavioral/test-coverage comments, not performance measurement or profiling analysis.
+
+### jedwards27
+**Style:** blocking | **Signal quality:** high — The reviewer consistently identifies exact file/line defects with reproducible failure scenarios, distinguishes P1/P2 severity, tracks prior blockers across multiple round-trips, and records precise commit SHAs for every verdict, producing highly actionable and specific signal.
+
+**Primary focus areas:**
+- Async lifecycle correctness: detached/unawaited async operations that can escape their owning scope (tenant, relay session, identity) and write stale state after context switches, community changes, or teardown (always)
+- Regression test causality: tests must exercise the exact production wiring that fixed the defect, not a test-local stub or parallel callable that can be deleted without failing the suite (always)
+- Relay subscription filter limits and fan-out: subscriptions that exceed the relay's per-REQ cap (128 explicit IDs), N+1 relay queries per list card, and unbatched relay reads (often) — *NIP-01 REQ filter limits*
+- Authorization boundary fail-closed behavior: indeterminate or error results from relay/cache lookups must not be collapsed into permissive ordinary-channel or DM context (always)
+- Keyboard and focus accessibility: Tab order, Shift+Tab reverse traversal, focus restoration after modal/overlay close, and aria-hidden on covered but mounted content (often) — *WCAG 2.1 SC 2.1.1, SC 2.4.3*
+- WCAG AA contrast requirements on interactive and text elements, especially in multiple themes (often) — *WCAG 2.1 SC 1.4.3 (AA, 4.5:1 normal text, 3:1 large/UI)*
+- Exact-head CI gate enforcement: reviewer withholds or revokes approval when required CI is red or still running on the reviewed commit (always)
+- Native device / physical artifact evidence as a release gate for mobile and native-audio features (often)
+- Concurrent mutation ownership: refresh/load races where a later-settling in-flight result can overwrite a more recent live or user-authored update (always)
+- Atomic multi-step persistence: operations presented to the user as one commit must not be split into independently recoverable sub-writes (often)
+- Relay protocol correctness: NIP-01/NIP-45 response correlation (CLOSED vs NOTICE for REQ vs COUNT), rejection framing, and backoff/retry after rate-limited or refused frames (often) — *NIP-01, NIP-45*
+- CI policy and script coverage: always-on enforcement scripts must exercise the production consumption path and not admit compiling bypasses through untested code routes (often)
+
+**Apparent blind spots:**
+- SQL query performance and index coverage — Across 86 PRs touching relay/database layers, no comment addresses missing indexes, sequential scans, or query plan regressions; only high-level relay filter limits are mentioned.
+- API versioning and backward-compatibility contracts for relay schema migrations — Reviews focus on correctness of the migration execution path but do not raise versioned wire-format compatibility or rolling-deploy compatibility windows beyond the immediate fix.
+- Memory/resource bounds for long-running processes (relay, mobile background tasks) — No comment across the reviewed PRs raises unbounded cache growth, memory pressure, or OOM risk even in PRs adding large in-memory channel/message caches.
+- Internationalization and RTL layout — Many UI/layout PRs are reviewed in detail (contrast, wrapping, chip labels) with no mention of RTL text direction, locale-sensitive formatting, or i18n string coverage.
+- Rate-limit amplification from end-user actions (e.g., rapid UI interactions triggering relay writes) — Relay subscription fan-out is caught, but write-side amplification from user gestures is not raised in any PR even where reaction, mention, and send flows are changed.
+
+### jmecom
+**Style:** advisory | **Signal quality:** medium — Most substantive comments come from an automated Codex bot rather than the reviewer directly, making it difficult to fully attribute focus areas to jmecom's own judgment versus the bot's heuristics; the human approvals on CI PRs add little signal.
+
+**Primary focus areas:**
+- Security vulnerabilities in authentication and authorization paths, including bypass conditions and shadow-row creation via non-canonicalized inputs (often) — *OWASP: Input Validation, NIP-98 auth spec*
+- Integer overflow and panic-inducing casts in user-controlled numeric inputs (u64→i64, chrono::Duration range) (sometimes) — *Rust reference: as-cast wrapping behavior; chrono::Duration panics on out-of-range seconds*
+- Audit trail and durable record-keeping for privileged mutations (append-only history for roster/role changes) (sometimes) — *Security audit logging best practices; principle of non-repudiation*
+- Validation normalization gaps — data normalized at creation/output but not re-validated on intake, allowing inconsistent state to persist through the pipeline (sometimes)
+- Type invariant enforcement — accepting structurally valid formats that are semantically invalid (e.g., hex strings that are not valid secp256k1 points) (sometimes) — *Parse, don't validate (type-driven design principle)*
+
+**Apparent blind spots:**
+- SQL query correctness, index usage, and query performance in DB layer changes — The relay_operators.rs DB layer was reviewed only from a security/audit angle; no comments addressed query structure, missing indexes, or N+1 patterns.
+- dbt/SQL model grain, naming conventions, and lineage documentation — No comments across any PR touch model-level concerns such as grain declarations, ref() vs source() usage, or documentation — consistent with a Rust/backend-focused reviewer operating outside a dbt codebase.
+- Test coverage requirements for new code paths — Despite flagging several exploitable edge cases (overflow, bypass, normalization gap), reviewer never requested accompanying unit or integration tests to prevent regression.
+- CI/infra change review depth — The three CI-related PRs (#6962, #7042, #7179) received quick approvals with minimal or no inline scrutiny beyond confirming the stated fix, suggesting infra/workflow changes receive lighter treatment.
+
+### kalvinnchau
+**Style:** thorough | **Signal quality:** low — Only one PR generated substantive inline feedback and one generated a detailed dismissal summary; the remaining four reviews are bare approvals with no comments, making it difficult to infer consistent patterns with confidence.
+
+**Primary focus areas:**
+- Security contract correctness: authentication flows, token lifecycle, bearer validation, fail-closed config semantics (often) — *NIP-98 HTTP Auth, general zero-trust / fail-closed design principles*
+- State machine / lifecycle correctness in schema migrations: ensuring that denied/success/revoked branches cannot accept events from sibling lifecycle paths (sometimes) — *null*
+- Deployment dependency ordering and rollout sequencing between services (sometimes) — *null*
+- API capability filtering and backward-compatibility gating for catalog/model discovery (sometimes) — *null*
+
+**Apparent blind spots:**
+- SQL model grain declarations, ref/source hygiene, and incremental strategy correctness — No comments across any PR touch dbt model design patterns, grain documentation, or incremental model configuration despite the repo being described as a dbt/SQL analytics repository.
+- Test coverage requirements — unit, integration, or schema contract tests — None of the six reviews mention missing or insufficient tests; even the CHANGES_REQUESTED review focuses purely on logic correctness, not on test coverage of the identified edge case.
+- Code style, naming conventions, and documentation quality — No comments address naming, readability, or inline documentation across any of the reviewed PRs, including the complex schema migration PR.
+- Performance and query efficiency (indexes, partition pruning, scan costs) — The schema migration PR (6994) adds significant SQL schema with no performance-related feedback from the reviewer.
+
+### klopez4212
+**Style:** thorough | **Signal quality:** high — Comments are highly specific, consistently cite the exact commit that fixes each issue, describe the precise failure mode, and include the regression test added — providing strong evidence of both what was caught and what was required to resolve it.
+
+**Primary focus areas:**
+- Security boundary and scope isolation: ensuring operations validate their originating relay, identity, session, and community context before mutating state, and fail closed when context changes mid-flight (always) — *NIP-98 auth, general relay-scoped state management*
+- Race condition and concurrency correctness: preventing stale async completions from affecting newer state, serializing overlapping mutations, and invalidating in-flight futures on cancellation or context change (always)
+- Regression test coverage: requiring explicit widget/unit/integration tests for every bug fix, including edge cases like delayed callbacks, community switches mid-operation, and stale scope completions (always)
+- Fail-closed semantics for identity/agent classification: keeping UI features hidden until all identity resolution sources (directory, verified owner, bot-role, kind:0, kind:10100) are confirmed non-agent (often) — *NIP-10100, NIP-39002*
+- Resource lifecycle management: ensuring streams, camera controllers, audio contexts, object URLs, and native platform views are released on cancellation, background, or disposal without leaking (often)
+- Accessibility and semantics correctness: ensuring interactive controls expose correct accessible names, button/selected/enabled states, semantic actions, and do not duplicate or leak stale labels (often) — *WCAG contrast, Flutter Semantics*
+- Rate limiting and quota enforcement ordering: ensuring validation and bounded-field checks run before rate-limit token consumption (sometimes)
+- Public API documentation: requiring doc comments on all exported constructors, fields, and constants (often)
+- Replay ordering and event validation: enforcing deterministic ordering of same-timestamp lifecycle events and accepting lifecycle events only from authorized signers (sometimes) — *NIP-98, Nostr event model*
+
+**Apparent blind spots:**
+- Performance profiling and rendering cost (e.g., unnecessary rebuilds, expensive widget subtree rebuilds, or N+1 provider subscriptions) — Across 15 PRs with extensive Flutter/React code, no comments address widget rebuild frequency, selector granularity beyond one instance in PR #6611, or rendering benchmarks. The one selector comment (huddleSessionProvider.select) was raised as a correctness issue, not a performance one.
+- Data schema migration safety and backwards compatibility for persisted local state — PR #5864 touched migration code but comments focused on correctness of the migration logic itself; there are no comments about rollback safety, migration versioning discipline, or handling of partially migrated stores in production.
+- Bundle size, dependency weight, and dead code elimination — No comments across any PR address import hygiene, tree-shaking, or the impact of new dependencies on bundle size, despite multiple large feature additions to both desktop (Tauri/TS) and mobile (Flutter).
+- Error message UX and user-facing copy quality — The one user-facing string comment (relay_membership_required mapping) was raised as a security concern (leaking machine tokens) rather than UX clarity. No comments elsewhere address error message tone, localization, or copy consistency.
+
+### loganj
+**Style:** blocking | **Signal quality:** low — All three PRs are reviewed by an AI agent (Larry) operating through the human's account, so the comments reflect automated analysis rather than authentic human reviewer judgment, making it impossible to characterise the human reviewer's actual focus areas.
+
+**Primary focus areas:**
+- Commit/tree SHA pinning and explicit head verification before rendering a verdict (always)
+- End-to-end causal contract validation: ensuring that a single artifact (e.g., a name, slug, or config value) flows correctly through every stage of a pipeline (CI → codegen → build system → runtime) with no silent truncation or substitution (often)
+- Silent discard / silent failure detection — flagging paths where inputs are accepted by a gate but then quietly dropped rather than surfaced as errors (often)
+- Scope-bounded approval: explicitly naming the agreed behavioral slice and refusing to approve beyond it (always)
+- Incremental re-review after fixes — re-reading each revision rather than trusting the author's fix summary (always)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declaration, ref() vs source(), model layering, incremental strategy, schema tests) — All three reviewed PRs are CLI/desktop/Rust/TypeScript features; no SQL or dbt modelling artefacts appear in any comment, so it is impossible to tell whether the reviewer would catch dbt-layer issues.
+- Style, documentation, and non-correctness feedback (naming conventions, inline comments, changelog entries) — Every comment targets runtime correctness or contract integrity; no advisory or stylistic feedback appears across any of the three PRs.
+- Performance and scalability considerations — No comment in any PR addresses query cost, index usage, payload size, or algorithmic complexity; focus is exclusively on correctness of control flow.
+
+### matt2e
+**Style:** thorough | **Signal quality:** low — Only 2 PRs reviewed with a small number of comments, making it difficult to distinguish consistent patterns from coincidental observations.
+
+**Primary focus areas:**
+- Byte vs. character boundary bugs in string truncation and validation logic (sometimes) — *null*
+- React memoization invalidation caused by unstable object/JSX references created inline (sometimes) — *React.memo / useMemo referential stability*
+- Guard/gating condition correctness — logic gates on proxy state rather than the actual target state, leading to silent misbehavior (sometimes) — *null*
+- Keyboard modifier key handling correctness in input event logic (sometimes) — *null*
+
+**Apparent blind spots:**
+- SQL/dbt model concerns (grain, incremental strategy, ref vs source usage, etc.) — Neither PR touches SQL or dbt artifacts and no comments address data modeling conventions; the reviewer appears scoped entirely to application/frontend code
+- API contract and schema validation (types, required fields, backward compatibility) — No comments across either PR address API shape, versioning, or serialization correctness despite PRs involving agent/channel feature additions that likely have API surfaces
+- Error handling and user-visible error states — The multibyte name bug noted would cause a silent creation error, but no broader pattern of checking error propagation paths or user-facing error messages appears in any comment
+- Test coverage adequacy — Comments mention test scenarios only incidentally when describing a fix already applied; reviewer does not proactively flag missing test cases for new behavior
+
+### philazar
+**Style:** advisory | **Signal quality:** low — Only one PR has substantive feedback; the other three are effectively rubber-stamp approvals, providing insufficient data to identify consistent review patterns.
+
+**Primary focus areas:**
+- High-level architectural and structural sense-checking of benchmark evaluation layers (sometimes)
+- KPI/metric aggregation design — flagging imbalanced weighting in composite scores (sometimes)
+- Provenance of test fixtures and generated data — flagging AI-generated or randomly generated content in test assets (sometimes)
+
+**Apparent blind spots:**
+- Detailed code-level review (logic, edge cases, SQL grain, naming conventions) — Three of four reviews are 'lgtm' with no inline substantive comments; no evidence of line-by-line scrutiny of logic or implementation details
+- Test coverage and assertion quality in benchmark tasks — No comments across any PR addressing whether benchmark tasks are adequately covered or assertions are meaningful
+- Performance and correctness of the scripted event delivery fix — PR #6487 approved with 'lgtm' and deference to agent reviewer, suggesting no independent deep analysis
+
+### ravarora2
+**Style:** advisory | **Signal quality:** low — A single PR with an approval and no visible commentary provides virtually no signal about the reviewer's habits or focus areas.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- Any and all review dimensions — Only one PR reviewed with an approval and no recorded comments, making it impossible to identify consistent focus areas or blind spots.
+
+### salman1993
+**Style:** advisory | **Signal quality:** low — Only 3 PRs reviewed with very sparse comments (mostly one substantive note per PR), making it difficult to identify consistent patterns with confidence.
+
+**Primary focus areas:**
+- Test determinism and flakiness in E2E tests — specifically identifying self-healing timers or race conditions that can produce false positives on buggy code (sometimes) — *null*
+- Realism and meaningfulness of test fixtures and benchmark data (e.g., whether slugs or identifiers are plausible real-world values) (sometimes) — *null*
+- Correctness of edge-case logic in retrieval/context-window trimming (e.g., ensuring truncation hints, thread root inclusion, and deduplication of already-delivered events are all handled correctly together) (sometimes) — *null*
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declaration, model structure, ref() usage, incremental strategy, etc.) — None of the three PRs reviewed touch SQL or dbt models, and no comments reflect awareness of dbt standards; the reviewer appears focused on application/TypeScript/Python code rather than analytics engineering concerns.
+- Code style, naming conventions, and documentation — No comments across any PR address naming, inline comments, or documentation quality; feedback is purely behavioral/correctness-oriented.
+- Performance and scalability considerations — No comments raise concerns about query performance, data volume handling, or algorithmic complexity across the reviewed PRs.
+
+### tellaho
+**Style:** advisory | **Signal quality:** low — Only one PR reviewed and all five comments are AI-generated resolution summaries rather than original reviewer observations, making it impossible to reliably infer the human reviewer's actual focus areas or blind spots.
+
+**Primary focus areas:**
+- State transition correctness for enabled/disabled workflow flags — ensuring create, duplicate, and edit operations preserve explicit boolean states rather than falling through to backend defaults (sometimes)
+- Form mutation side-effects — editing one predicate/field must not silently broaden or alter unrelated workflow conditions (e.g., merging legacy trigger fields before presenting structured conditions) (sometimes)
+- Cron expression parsing robustness — normalizing across multiple field-count variants (5-, 6-, 7-field) to correctly classify schedule frequency (sometimes)
+- Input normalization and case-sensitivity — lowercasing hex identifiers (author IDs, event IDs) before serialization to prevent subtle equality mismatches from pasted uppercase values (sometimes)
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, model naming conventions, ref() usage, incremental strategies) — This is a TypeScript/React frontend PR with no SQL or dbt artifacts; no evidence exists of engagement with dbt standards across any reviewed PR
+- Performance and bundle size considerations for UI components — All five comments focus exclusively on behavioral correctness; no comments address rendering performance, re-render boundaries, or bundle impact
+- Accessibility and UX copy quality — Despite the PR being about UI clarification and workflow dialogs, no comments address ARIA attributes, keyboard navigation, or warning message wording
+- Test coverage completeness and test design — Comments reference regression coverage as a resolved fact but do not appear to have independently scrutinized test structure, edge case selection, or test naming
+
+### thomaspblock
+**Style:** blocking | **Signal quality:** medium — Only two PRs reviewed, but both contain detailed, structured security analysis with explicit P1 labels and follow-up re-reviews that confirm fixes, providing clear signal on security/authority focus despite the small sample size.
+
+**Primary focus areas:**
+- Authority and routing integrity: ensuring only the correct, authorized channel/project/signer can trigger routing, create repositories, or claim project-home membership (always) — *null*
+- Privilege escalation via implicit side-effects: implicit repository creation or membership grants that confer unintended authority to foreign principals (always) — *null*
+- Adversarial/bypass scenarios: tracing code paths that a malicious or misconfigured actor could exploit to bypass checks (same-id repo reuse, slug squatting) (always) — *null*
+- Correctness of memoization dependency arrays in React components (useMemo/useCallback exhaustive-deps) (sometimes) — *react-hooks/exhaustive-deps ESLint rule*
+- Encoding safety: UTF-8 string truncation at character boundaries rather than byte boundaries (sometimes) — *null*
+- CI noise triage: distinguishing pre-existing failures unrelated to the diff from regressions introduced by the PR (sometimes) — *null*
+
+**Apparent blind spots:**
+- SQL/dbt-specific concerns (grain declarations, ref() usage, model naming conventions, incremental strategies) — Neither PR touches SQL or dbt; reviewer's feedback is entirely Rust/TypeScript/security-oriented with no dbt commentary, so no signal exists here.
+- Performance and algorithmic complexity of non-security code paths — No comments address latency, query cost, or algorithmic efficiency in any of the reviewed code changes.
+- Test coverage for non-adversarial (happy-path) scenarios — Reviewer acknowledges a CJK regression test but never requests broader unit or integration test coverage for normal user flows.
+- Code style, readability, and naming conventions — All comments are functional/security-focused; no remarks on naming, formatting, or documentation in either PR.
+
+### tlongwell-block
+**Style:** advisory | **Signal quality:** low — A single approved PR with no recorded comments provides no basis for inferring consistent review patterns or focus areas.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- All focus areas are indeterminate — Only one PR reviewed with an approval and no visible inline comments, providing no signal about what the reviewer consistently prioritizes or ignores
+
+### wesbillman
+**Style:** blocking | **Signal quality:** high — Reviews are highly specific, cite exact file paths and line numbers, track findings across multiple PR iterations, and consistently distinguish P1 blockers from P2 advisories with clear rationale — producing reliable signal about what the reviewer genuinely prioritizes.
+
+**Primary focus areas:**
+- Security boundary enforcement: authentication, authorization, and fail-closed behavior (always) — *NIP-98, NIP-OA, NIP-FI (project-specific Nostr protocols)*
+- Cross-device and cross-session lifecycle correctness: state not retained, synced, or tombstoned properly across devices (always) — *Nostr addressable event replacement semantics (kind:5 tombstones, 30175/30176/30177/30178)*
+- Async state machine correctness: terminal states, failure propagation, and error-vs-empty disambiguation (always)
+- Privacy leaks from eager/automatic network fetches of publisher-controlled or attacker-controlled content (often)
+- Race conditions and atomicity in concurrent credential/token management and single-flight coalescing (often)
+- History/live-subscription handoff correctness: gaps, ordering races, and stale data swamping live data (often)
+- Deployment/migration safety: new code running before required schema migrations, rollout fences, and startup repair guards (often)
+- Process/resource bounding: unbounded spawns, missing timeouts, and process-tree teardown (often)
+- UI state contract correctness: accessible names matching visible labels, Escape/focus trap handling, stale UI not reflecting backend truth (often) — *ARIA authoring practices (aria-label, aria-modal)*
+- Workspace/community boundary isolation: operations must not cross workspace or community context (sometimes)
+- Deterministic test coverage: tests must not pass due to timing windows or retry loops masking the defect (often)
+
+**Apparent blind spots:**
+- SQL query performance, index usage, and query plan analysis — Across 69 PRs touching a database layer (migrations, schema, relay DB adapters) there are zero comments about missing indexes, N+1 queries, or query plans. Schema FK and constraint correctness is flagged, but query efficiency is never mentioned.
+- API versioning and backward-compatibility of serialized formats — Protocol evolution (e.g., NIP event kinds, ACP prompt fields) is reviewed for correctness at the current version, but no comments address clients on older versions receiving new fields or servers receiving legacy payloads after a deploy.
+- Observability: logging, metrics, tracing, and alerting coverage for new failure paths — Many blocking failure paths are identified (token rejection, tombstone races, push gateway errors) but no review comment asks for structured logs, metrics counters, or alerting on those paths.
+- Test coverage of happy-path integration scenarios (as opposed to failure/edge paths) — Reviews consistently demand regression tests for newly found failure modes but rarely ask whether the positive/sunny-day integration scenario is covered end-to-end.
+- CSS/visual design consistency and design-system token adherence — UI reviews focus on ARIA, keyboard interaction, and state correctness; no comments address color tokens, spacing scales, or design-system compliance across 10+ UI-heavy PRs.
+
+### wpfleger96
+**Style:** thorough | **Signal quality:** high — Reviews are consistently pinned to exact commit SHAs, use multiple independent lanes (source + live E2E), cite specific file paths and line numbers, distinguish blocking from advisory findings, and track resolution across rounds — producing highly actionable, verifiable signal.
+
+**Primary focus areas:**
+- Security boundary correctness: authentication, authorization, and trust-boundary enforcement (NIP-98, NIP-42, NIP-OA, membership checks, replay guards) (always) — *NIP-98 (HTTP Auth), NIP-42 (AUTH), NIP-11 (Relay Info Document)*
+- Regression test coverage for every behavioral invariant changed or fixed, including mutation sensitivity of new tests (always)
+- Exact-head verification: reviews are always pinned to a specific commit SHA and re-verified after each round of changes (always)
+- Lifecycle and cancellation correctness in async/concurrent UI flows (effect cleanup, in-flight teardown, queue ownership) (often)
+- Cross-implementation parity: when logic exists in both Rust and TypeScript interpreters, both must be updated consistently (often)
+- Database migration correctness and ordering: migration numbering, idempotency, fresh-bootstrap parity with live schema, and advisory lock interactions (often)
+- Privacy and correlation risk from identifiers shared across tenants, communities, or third-party services (often)
+- Resource management: connection pool reuse, client instantiation, and operator-configurable rate/timeout limits (often)
+- UI label/display correctness: raw machine identifiers must not surface to end users; humanized labels must survive closed/selected states of pickers (often)
+- Pure-move / refactor verification: mechanically confirming no production logic is lost or altered during extractions (often)
+- Conventional Commits compliance for PR titles (required for squash-merge repos) (sometimes) — *Conventional Commits specification; dbt/repo CONTRIBUTING.md squash-merge policy*
+- Benchmark/grader correctness: reward functions must reject semantically negated or malformed answers, not just check token presence (sometimes)
+
+**Apparent blind spots:**
+- SQL query performance and index usage — Across all reviewed PRs touching database code, no comments address query plans, missing indexes, or N+1 patterns; focus is exclusively on correctness, migration ordering, and lock semantics.
+- Accessibility (a11y) of UI components — Multiple desktop UI PRs reviewed (lightbox, emoji picker, GIF composer, quick reactions) with no a11y comments on ARIA roles, keyboard navigation, or focus management.
+- Bundle size and tree-shaking impact of new frontend dependencies — New frontend features (GIF search, Pi preset, emoji picker) are reviewed for behavioral correctness but no comments address import cost or lazy-loading.
+- Internationalization (i18n) / localization of user-facing strings — UI copy changes (notification titles, tooltip labels, preset descriptions) are reviewed for correctness but never flagged for i18n wrapping or string extraction.
+- Error observability / structured logging for new code paths — New API endpoints and async flows are reviewed for correctness and resource use, but no comments request structured log fields, error code tagging, or span attribution for new failure modes.
+
+---
+
+## 3. Author Growth Profiles
+
+### Maxwellimus
+**Trajectory:** improving — The earlier PRs in the window received clean approvals with no blocking findings, the one CHANGES_REQUESTED (PR #6460) was resolved quickly, and the description-accuracy note from the reviewer is a minor process gap rather than a recurring technical deficiency, suggesting the author is building both technical and process maturity over the review window.
+
+**Strengths:**
+- Performance-focused problem decomposition: consistently breaks perf work into small, targeted PRs (roster off channel-switch path, Projects fan-out, prefetch on hover, render-cheap Projects surface), each with a clear scope (consistent) — *dbt/analytics engineering best practice: single-responsibility changesets that are easy to review and revert*
+- Rapid iteration and responsiveness to review feedback: in PR #6460 both P1 findings were resolved in a follow-up commit before the reviewer's second pass, demonstrating tight feedback loops (consistent) — *null*
+- Clean-up discipline: PR #6517 removes a dead constant with no consumers, showing proactive hygiene alongside feature/perf work (emerging) — *null*
+
+**Growth areas:**
+- PR description accuracy and completeness: in PR #6460 the description contained an obsolete 'Contribution graph' optimization bullet after the related code was removed, requiring a reviewer correction comment (occasional) — *Standard PR authorship practice: PR descriptions should reflect the actual changeset at merge time, not the original intent*
+  → **Support:** Before requesting final review, do a self-review pass comparing the PR description bullet-by-bullet against the final diff; add a checklist item 'Description reflects current diff (no stale bullets)' to your PR template
+- Pre-flight correctness checks on component lifecycle and side-effect guards: PR #6460 had two P1 findings (incremental card counters active outside grid layout) that should have been caught before review, suggesting component lifecycle edge cases are sometimes missed during self-review (occasional) — *null*
+  → **Support:** For perf PRs involving conditional rendering or mount/unmount counters, add an explicit local test step: render the component in each layout variant (overview vs. grid) and assert counters/effects are dormant in the non-target variant before pushing for review
+
+### TheSentinel454
+**Trajectory:** improving — Earlier PRs (e.g., #6229, #6730) required three or more CHANGES_REQUESTED rounds with significant back-and-forth, while later PRs (#6819, #6782, #6987) received single-pass or no-blocking-findings approvals, indicating the author is internalizing reviewer expectations over time.
+
+**Strengths:**
+- Large-scale refactoring with semantic preservation — repeatedly extracts and splits database modules (replaceable events, community, channel membership, domain stores) while maintaining byte-identical behavior verified by mechanical diffing (consistent) — *dbt/SQL best practice: pure refactors should produce no behavioral change; author demonstrates this rigorously across PRs #6660, #6668, #6782, #6987*
+- Responsive iteration on reviewer feedback — addresses multi-round CHANGES_REQUESTED cycles (e.g., PR #6229, #6730) and produces detailed inline replies explaining each fix (consistent)
+- Database observability and operational hardening — adds instrumented advisory-lock sites, transaction timers, configurable session timeouts, and vacuum tuning with correct understanding of PostgreSQL semantics (consistent) — *PostgreSQL best practice: lock_timeout, idle_in_transaction_session_timeout, and vacuum_truncate are used correctly across PRs #6700, #6898, #6229*
+- Test infrastructure improvement — introduces canonical fixtures, isolated CI lanes, and per-test database isolation for PostgreSQL integration tests (consistent) — *Testing best practice: test isolation per PR #6819, #6730*
+
+**Growth areas:**
+- Conventional Commits PR title compliance — PR #6777 was flagged for a non-conforming title despite CONTRIBUTING.md requiring Conventional Commits format for all squash-merged PRs (occasional) — *Conventional Commits specification; repo CONTRIBUTING.md requirement cited in PR #6777 review*
+  → **Support:** Add a CI lint step (e.g., commitlint or a GitHub Action checking PR titles against the Conventional Commits regex) so non-conforming titles are caught automatically before review; also add a checklist item to the PR template reminding authors of the format.
+- Incomplete migration/schema hygiene — PR #6229 required multiple CHANGES_REQUESTED rounds because the migration exemption path, env-var scoping to only one binary, and comment accuracy about lock_timeout actor were all missed initially; PR #6730 had a migration-routing blocker identified late (consistent) — *Database migration best practice: migrations must be idempotent, correctly scoped, and exempt from session-level timeouts that apply to normal queries*
+  → **Support:** Create a migration authoring checklist in buzz-db/CONTRIBUTING.md covering: (1) verify advisory-lock paths are timeout-exempt, (2) confirm env-var parsing is present in all writer binaries, (3) validate idempotent post-apply reconciliation. Pair author with a senior reviewer specifically for migration PRs until two consecutive migrations pass without CHANGES_REQUESTED.
+- Including low-value or scope-creeping test code — PR #6777 had a test flagged inline as 'low value, remove it'; PR #6730 bundled unrelated test name changes and repeated utility functions across multiple crates (consistent) — *Testing best practice: tests should be targeted and each PR should have a single coherent scope*
+  → **Support:** During PR self-review, author should audit each new or modified test for: (a) whether it tests a distinct behavior not covered elsewhere, and (b) whether it belongs in this PR's scope. Consider adding a PR description section requiring the author to justify each new test file added.
+- Post-merge defects introduced in complex PRs — PR #6229 had a confirmed audit-loss defect and cross-tenant liveness risk discovered in post-merge review; suggests insufficient pre-merge end-to-end coverage for PRs touching multiple pools/binaries (occasional) — *Integration testing best practice: changes affecting multiple connection pools or binaries require cross-binary E2E validation before merge*
+  → **Support:** For PRs touching shared connection pool configuration or multi-binary behavior, require a documented E2E test matrix in the PR description listing each affected binary and the pool behavior verified. Work with the team to expand the isolated relay + Postgres CI lane to cover all writer binaries automatically.
+- Asking clarifying questions in PR comments rather than resolving ambiguities before opening the PR — PR #6730 shows many sequential author comment rounds responding to 'why did X change?' questions that could have been pre-empted with a thorough PR description (consistent)
+  → **Support:** Adopt a PR description template that requires the author to explain: (1) every file changed outside the primary scope and why, (2) any test fixture or value changes and their root cause, and (3) any dependency on other PRs. Review the description against the diff before marking ready for review.
+
+### baxen
+**Trajectory:** insufficient-data — Only one PR is present in the window and baxen appears primarily as a reviewer rather than author, providing no chronological author signal to assess trajectory.
+
+**Strengths:**
+- Thorough, adversarial code review with precise contract reasoning — identifies wire-level invariant gaps, type-system enforcement failures, and serialization edge cases that would otherwise become silent bugs (consistent)
+- Prioritized, structured feedback delivery — comments are tagged by severity (P1/P2), anchor to specific code locations, and distinguish contract blockers from minor follow-ups (consistent)
+- Closes review loops with verified reproduction steps — each fix is confirmed against a named commit with a probe test or reproduction scenario before accepting the resolution (consistent)
+- Willingness to concede and self-correct when reviewee provides evidence — explicitly acknowledges when own rationale was factually wrong (e.g., local signature verification, scanner bypass cases) (consistent)
+- Drives iterative hardening beyond the original ask — accepts fixes that generalize past the literal comment, recognizes when a narrower fix would be insufficient, and pushes for structural solutions (e.g., removing Deserialize from BrokerResult entirely) (consistent)
+
+**Growth areas:**
+- Insufficient data to identify persistent gaps — only one PR is available for review, making it impossible to distinguish consistent patterns from one-off occurrences (occasional)
+  → **Support:** Expand the review window to at least 3–5 PRs authored by baxen (not PRs where baxen is reviewer) before drawing growth-area conclusions. The current sample captures baxen acting as a rigorous reviewer, not as an author under review.
+
+### bradseiler
+**Trajectory:** insufficient-data — Only three PRs are available across a four-day window, offering too narrow a chronological span to determine whether documentation and specification quality is improving, stable, or regressing.
+
+**Strengths:**
+- Delivering focused, purposeful PRs that address specific infrastructure concerns (IRSA credentials, staging workflows, versioned bucket deletions) with clear scope (consistent)
+- Responsive to reviewer and automated feedback — documentation gaps flagged in PR #6709 were addressed in subsequent commits (acbd5b9, 15f496c) (emerging)
+
+**Growth areas:**
+- Documentation completeness at initial submission — PR #6709 required multiple inline corrections to align examples with the actual tag format and to clarify the operational contract of staging artifacts before reviewers approved (occasional)
+  → **Support:** Before opening PRs that introduce new workflows or tooling, draft the documentation first and verify every example matches the implementation exactly. A personal checklist item — 'do all doc examples reflect the actual output format?' — would catch tag-format mismatches and missing operational-contract language before review.
+- Explicit operating-contract documentation for staging/ephemeral artifacts — the initial PR #6709 lacked clear language that staging images are not release-qualified and must not feed production or canonical promotion pipelines (occasional)
+  → **Support:** Adopt a team-standard 'staging artifact disclaimer' section in any workflow documentation that produces non-release images. Work with the team to create a reusable documentation template for staging lanes that includes scope, restrictions, and promotion eligibility by default.
+
+### brow
+**Trajectory:** stable — Across all five PRs brow ships ambitious, high-risk features and responds well to feedback, but the same categories of async lifecycle, tenant-boundary, and recovery-path defects appear as blockers in the earliest and most recent PRs alike, indicating the growth areas are not yet improving between cycles.
+
+**Strengths:**
+- Delivering complex, high-risk mobile features end-to-end (channel discovery, push notifications, invite flows) across multiple platform layers including Dart, Swift, iOS build tooling, and Helm charts (consistent)
+- Responsiveness to reviewer feedback — repeatedly iterating to address blockers across multiple review rounds until approval is granted (consistent)
+- Engaging constructively with inline automated review comments, acknowledging findings and explaining resolutions (e.g., PR #7187 inline responses) (consistent)
+- Tackling infrastructure and DevOps concerns alongside feature work (CI linker flags, Helm deployment charts, gateway schema) (emerging)
+
+**Growth areas:**
+- Async state lifecycle correctness — specifically fencing async operations (directory loads, unread sync, membership refreshes) against tenant/identity/community changes so stale or leaked state cannot persist across context switches (consistent)
+  → **Support:** Before opening a PR that introduces detached async work, require brow to complete a self-review checklist covering: (1) what cancels this operation if the active community or identity changes, (2) where generation/scope tokens are checked after every await point, and (3) how a partially-completed async chain is cleaned up. Pair on at least one session where a senior engineer walks through an existing cancel-safe pattern in the codebase.
+- Durable error and recovery path design — initial submissions consistently lack retry/recovery for failures mid-flow (starter channel setup failure, push enrollment failure, failed revocation on sign-out), requiring reviewer-driven blockers to surface them (consistent)
+  → **Support:** Introduce a pre-PR design step for any flow touching persisted state: brow should explicitly document the failure modes for each network/async step and the recovery path (retry, rollback, or durable queue). A short design doc or PR description section titled 'Failure handling' should be required before review begins on features of this risk level.
+- Tenant and identity boundary safety — state (subscriptions, unread counts, APNs tokens, invite recovery objects) is frequently constructed once and not rebuilt when the active relay, identity, or community changes, leading to P1/P2 tenant-boundary leak findings across multiple PRs (consistent)
+  → **Support:** Schedule a focused pairing session on the codebase's relay/identity lifecycle model. Brow should be able to articulate which providers are scoped to a relay session versus the app lifetime, and write a small internal guide or code comment block documenting this. Reviewers should reference this guide when returning boundary-leak findings.
+- Incremental database/schema migration discipline — changing a desired-state schema snapshot without providing the corresponding incremental migration script (PR #7158) (occasional)
+  → **Support:** Add a linting step or PR template reminder that flags any change to the schema snapshot file without a corresponding migration file. In the interim, brow should be pointed to existing migration examples in the repo and asked to apply the same pattern consistently.
+
+### jedwards27
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to identify patterns, strengths, or growth areas with any confidence.
+
+**Strengths:**
+
+**Growth areas:**
+
+### jmecom
+**Trajectory:** improving — Later PRs (#6913, #7004) received clean first-pass approvals with no blocking findings, suggesting the lessons from multi-round reviews in #6838 and #6816 are being internalized over the window.
+
+**Strengths:**
+- Security-first design thinking: consistently architects trust boundaries carefully, e.g. re-resolving authorization through GitHub, pinning exact head SHAs, separating trusted/untrusted code paths, and enforcing cryptographic time bounds (consistent) — *dbt/analytics engineering best practice: model ownership and access control must be enforced at the boundary, not assumed from context*
+- Iterative responsiveness to reviewer feedback: in PR #6838 and #6816, jmecom addressed multiple rounds of CHANGES_REQUESTED and produced complete fixes that satisfied reviewers on re-review (consistent)
+- Scope discipline: PRs are narrowly scoped to a single concern (cooldown enforcement, relay key removal, access policy, security review gating), making them tractable to review (consistent) — *dbt best practice: models/PRs should encapsulate a single logical change*
+
+**Growth areas:**
+- Incomplete coverage of all production call sites before submitting: in PR #6838, multiple rounds of CHANGES_REQUESTED were needed because the initial fix only handled one reuse path, missing `useMentionSendFlow.ts`, `useQuickBotDrop.ts`, and template application paths that omit `respondTo` (consistent) — *Analytics engineering standard: a fix must be applied at every upstream caller, not just the most visible one; analogous to ensuring a dbt macro change propagates to all referencing models*
+  → **Support:** Before submitting security or correctness fixes, produce a grep/call-graph audit of every code path that reaches the affected function and include it as a checklist in the PR description; pair with a senior engineer on the first two such PRs to build the habit of exhaustive call-site enumeration
+- Freshness/staleness contract gaps in stateful review systems: PR #6816 initially used only `head.sha` to determine review currency, omitting `baseSha`, which broke the correctness guarantee for range-based reviews (consistent) — *Data freshness standard: a record's validity must be scoped to the full key (source + target), not just one dimension — analogous to dbt snapshot `unique_key` covering the full natural key*
+  → **Support:** When building any cache or staleness check, require a written invariant in the PR description that names every field in the composite key and explains why each is necessary; add a reviewer checklist item specifically asking 'does the freshness check bind all dimensions of the range?'
+- First-pass completeness before review: across PR #6838 and #6816, correctness blockers were caught only in review rather than pre-empted, suggesting pre-submission self-review against a structured security/correctness checklist is not yet habitual (consistent) — *dbt best practice: run `dbt test` and review model DAG completeness before opening a PR; equivalent principle applies to security PRs*
+  → **Support:** Adopt a written pre-submission checklist for security PRs covering: (1) all call sites enumerated, (2) composite keys fully bound in any staleness check, (3) at least one negative test case authored; make this checklist a PR template section so reviewers can verify it was completed
+
+### kalvinnchau
+**Trajectory:** improving — Later PRs (#7213) show a false positive review retraction due to stale build artifacts rather than a code defect, suggesting the author's implementation quality is increasing while reviewer tooling noise is the remaining source of friction.
+
+**Strengths:**
+- Feature delivery and scope management: PRs are well-scoped with clear intent (lightbox controls, image navigation, Databricks catalog discovery, model name humanization, capability additions), and each lands its core goal without scope creep. (consistent)
+- Responsiveness to review feedback: Blocking and important issues raised by reviewers are resolved in follow-up commits within the same PR cycle across all 5 PRs, demonstrating reliable iteration speed. (consistent)
+- Manifest-driven routing discipline: After initial corrections in PR #6918, subsequent PRs (#7135, #7213) show internalization of the single-manifest-owner pattern for model routing and capability projection. (emerging)
+
+**Growth areas:**
+- Pre-submission correctness verification — UI/display state edge cases: Multiple PRs (#7135, #7213) had blocking issues where persisted/closed UI state rendered raw values instead of humanized labels, indicating the author's local testing does not consistently cover closed/persisted component states. (consistent)
+  → **Support:** Add a personal checklist item before PR submission to explicitly test selected/closed/persisted UI states (not just open picker states). For model label changes specifically, verify the trigger element renders the humanized string after selecting and closing the picker. Consider pairing with a focused Playwright test template that covers this scenario.
+- Cross-interpreter parity for business logic: PR #6918 introduced an FQN special-case only in the Rust consumer, missing the TypeScript interpreter, requiring an IMPORTANT correction. This suggests logic split across language boundaries is not being audited symmetrically during development. (occasional)
+  → **Support:** When implementing capability or routing logic that exists in both Rust (crates/buzz-agent) and TypeScript (desktop/src/features/agents), create a shared checklist or grep pattern to confirm every conditional is mirrored in both interpreters before pushing. A code-search step (e.g., searching for the analogous function name in the other language) should be part of the self-review ritual.
+- Filtering completeness at data ingestion boundaries: PR #6918 admitted UC model services on FQN shape alone without screening `supported_api_types`, even though the API returned the necessary metadata. This is a recurring pattern of fetching sufficient data but not applying all required filters at the boundary. (occasional)
+  → **Support:** When writing catalog or discovery logic that fetches external metadata, explicitly document in a comment which fields are used for admission decisions and verify each filtering criterion against the API contract. Consider adding a unit test asserting that services with non-empty capability lists must satisfy the capability predicate to prevent regressions.
+- Floating-point accumulation in incremental numeric operations: PR #6710 had a minor but persistent issue where repeated step additions caused floating-point drift, missing displayed endpoints. This reflects a pattern of not stress-testing incremental numeric logic at boundary values. (occasional)
+  → **Support:** For any UI control that applies repeated arithmetic steps (zoom, slider, etc.), add a boundary test that applies N steps from min to max and asserts the endpoint equals the expected value. Consider rounding or clamping after each step, or computing target values as discrete multiples of the step constant rather than accumulating.
+
+### klopez4212
+**Trajectory:** improving — Later PRs (#6944, #7182, #6926) achieve approval with fewer review cycles and no P0/P1 blockers compared to earlier large PRs (#6056, #6583), suggesting klopez4212 is internalizing reviewer patterns around lifecycle correctness and documentation even though the gap categories persist across the window.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: consistently addresses blocking findings across multiple review cycles within the same PR, providing precise commit references for each fix (consistent)
+- Breadth of feature delivery across complex cross-platform domains: mobile Flutter/Dart, iOS native Swift, Android Kotlin, Rust relay, and desktop React/TypeScript, often in a single PR (consistent)
+- Active engagement in code review dialogue: leaves substantive inline comments reproducing bugs, explaining design rationale, and confirming fixes with test evidence (consistent)
+- Regression test authorship: fixes are consistently accompanied by focused widget, integration, or E2E test coverage proving the corrected contract (consistent)
+
+**Growth areas:**
+- First-submission correctness for concurrency and lifecycle edge cases: across PRs #6056, #6583, #6676, #6680, and #6978, reviewers consistently find P1/P2 race conditions, resource leaks, and teardown gaps that require multiple review-fix cycles before approval (consistent) — *General software engineering: concurrent state machines must be fully specified before submission; async code should be audited for every await point's cancellation and error path*
+  → **Support:** Before opening a PR that involves async lifecycle (camera teardown, community switch, relay reconnect, media upload), author a written state-machine diagram or checklist covering: (1) every concurrent entry point, (2) disposal ordering, (3) fail-closed vs fail-open on each error path. Share this with a teammate for a lightweight async-focused pre-review before formal review begins.
+- Public API documentation completeness at submission time: reviewers repeatedly raise P1 findings in PRs #6583, #6680, and #6488 for missing doc comments on newly exported constructors, constants, and callback types, requiring additional fix commits (consistent) — *Dart/Flutter effective Dart: all public APIs must have doc comments; dbt analogy: all public models and macros require descriptions in schema.yml*
+  → **Support:** Add a personal pre-push checklist item: run `dart doc --dry-run` or grep for `^  [A-Z]` (public symbols) without a preceding `///` and resolve all gaps before pushing. Consider adding a CI lint rule enforcing doc comments on public symbols in the mobile package.
+- File size discipline: test files repeatedly exceed the repository's stated line-count ceiling (1,000 lines), requiring post-fix splits in PRs #6583 and #6680 (consistent) — *Repository TESTING.md line-count ceiling (referenced by reviewers); analogous to dbt style guides limiting model complexity*
+  → **Support:** Configure a pre-commit or CI check that fails when any single test file exceeds 1,000 lines. When a test file approaches 800 lines during authoring, proactively split into part files before the PR is opened.
+- Authorization and identity fail-closed completeness at submission: PRs #6056, #6312, and #6676 each received blocking findings for roster/identity sources that fail-open (showing Huddle controls, accepting lifecycle events, or enabling features before async identity resolution settles) (consistent) — *Security principle of least privilege: authorization checks must default to deny when resolution is pending or errored*
+  → **Support:** Establish a team checklist for any feature gated on async identity: (1) what is the initial state before resolution — must be hidden/disabled, (2) what happens on resolution error — must stay hidden/disabled, (3) what happens on reconnect — must re-resolve. Review this checklist with a peer before submitting PRs that introduce new authorization-dependent UI gates.
+- Relay protocol and cross-client compatibility gaps at submission: PRs #6056 and #6558 show that mobile/desktop protocol version mismatches and relay-side expect/panic paths reach review before being caught, requiring multiple blocking rounds (consistent)
+  → **Support:** For any PR touching the relay audio protocol, add a cross-client compatibility matrix to the PR description listing: protocol version sent by each client, relay version required, and which legacy client versions remain compatible. Pair with a relay-side reviewer before opening the PR to catch panic/unwrap paths in production teardown code.
+
+### kruegermj
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to identify trends or trajectory.
+
+**Strengths:**
+- Targeted, coherent fixes: the stacking context isolation was implemented correctly, scoping z-index layers without side effects noted by the reviewer (emerging)
+
+**Growth areas:**
+
+### loganj
+**Trajectory:** insufficient-data — Only one PR is available for review, so no chronological trend can be established.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: blocking issues raised by automated and human reviewers were addressed across multiple fix rounds with clear commit citations and explanations of what changed (emerging)
+- Transparent communication during review cycles: each response clearly links to the new head commit and summarizes the specific fixes made, aiding reviewer re-verification (emerging)
+
+**Growth areas:**
+- Pre-submission completeness: two separate P1/blocking findings were identified by the first reviewer pass (packaging-contract failures, name-length boundary bug), suggesting the change was submitted before sufficient self-review or automated local validation (occasional)
+  → **Support:** Establish a personal pre-submission checklist that mirrors the known CI contract checks (e.g., boundary-value tests for accepted name lengths, packaging smoke tests). Run these locally before opening the PR to reduce required fix rounds.
+- Multiple iterative fix commits required post-review (at least three head commits pushed in response to reviewer findings), indicating the root cause of each issue may not be fully analyzed before pushing a fix (occasional)
+  → **Support:** When addressing a blocking finding, pause to audit adjacent code paths for the same class of defect before pushing. A short root-cause note in the PR comment alongside each fix commit would also help reviewers trust completeness of the repair.
+
+### mahanti
+**Trajectory:** insufficient-data — Only two PRs are available and both share the same date, making chronological improvement or regression impossible to assess.
+
+**Strengths:**
+- Responsiveness to reviewer feedback: addresses blocking findings across multiple review rounds and iterates to resolution (consistent)
+- Tackles complex, cross-platform feature work (agent avatar rendering, protected-build experiment gating) with meaningful scope (consistent)
+
+**Growth areas:**
+- Boundary correctness on first submission: both PRs required multiple REQUEST CHANGES cycles for compile-time/runtime or artifact boundary defects before reaching approval (consistent)
+  → **Support:** Before opening a PR that introduces a capability or build boundary, author should produce a written boundary contract (what is included/excluded in each artifact, what the fail-closed vs fail-open behavior is) and have it reviewed in a design comment or RFC before coding begins. Reviewers should prompt for this artifact on any PR touching packaging or feature-gating seams.
+- Fail-open vs fail-closed logic: reviewers flagged a fail-open resolver defect in PR #6902, indicating default behavior under missing/unknown conditions was not locked down (consistent)
+  → **Support:** Adopt a checklist item for every feature-flag or experiment PR: explicitly enumerate the OSS/internal split behavior and document the default state when the flag or build capability is absent. Pair with a senior engineer who can review the failure-mode logic before the first push.
+- Artifact and module graph hygiene: OSS module graph leaking internal metadata required multiple revision cycles across PR #6902 (consistent)
+  → **Support:** Run an OSS build smoke-test locally (or in CI) as a required pre-PR step for any protected-build change. Document which modules must not appear in the OSS graph and add a CI lint or import-boundary check to catch regressions automatically.
+
+### matt2e
+**Trajectory:** improving — Early PRs in the window received clean or near-clean reviews; the more complex feature PRs (#6684, #6860, #6862) showed multi-round iteration, but the author consistently resolved blockers and later PRs show tighter initial implementations with reviewers finding fewer actionable defects per round.
+
+**Strengths:**
+- Narrow, well-scoped fixes: each PR targets a single, clearly described behavioral problem (e.g., scrolling stabilization, pulsing agents, draft space after mention pick), making intent easy to trace during review. (consistent)
+- Responsive iteration on reviewer feedback: across PRs where changes were requested (e.g., #6684, #6862), the author consistently pushed corrective commits and resolved blockers without extended back-and-forth on intent. (consistent)
+- Meaningful test coverage for edge cases: reviewers explicitly called out well-constructed guard-rail tests (e.g., 'does not complete a partial name', 'leaves an exact prefix open for a longer name', isPlainSpace modifier rejection) across multiple PRs. (consistent)
+- Clean commit hygiene within a PR: automated reviewers consistently note narrowly scoped deltas between heads (e.g., 'changed head delta only reverses displayed segments'), suggesting disciplined incremental commits. (emerging)
+
+**Growth areas:**
+- Keyboard accessibility coverage: PR #6860 required 6+ rounds of changes-requested specifically because the initial implementation and multiple subsequent heads each dropped or missed keyboard access to mention Options controls (Shift+Tab path). This recurred across at least 6 distinct head reviews before resolution. (consistent) — *WCAG 2.1 SC 2.1.1 Keyboard; SC 2.1.2 No Keyboard Trap — interactive overlays must be fully operable without a mouse*
+  → **Support:** Before submitting any PR that introduces or modifies an interactive overlay (mention menus, autocomplete, popovers), author should run a keyboard-only walkthrough checklist: Tab into overlay, Tab through all controls, Shift+Tab back to trigger, Escape dismissal. Add this as a PR description checkbox. Pair with a front-end accessibility specialist for one design review session focused on focus-ownership patterns for composer-anchored overlays.
+- Mixed-selection edge case handling: PR #6684 (hyperlink on paste) required multiple rounds because mixed markable/unmarkable selections were only partially handled — the fallback replacement path was bypassed. The fix required explicit guard logic that was not anticipated in the initial implementation. (consistent)
+  → **Support:** When implementing selection-aware transformations, author should explicitly enumerate selection composition cases in a decision table (all-markable, all-unmarkable, mixed) before coding, and write failing tests for the mixed case first. Consider adding a PR template prompt: 'What are the boundary compositions of the selection this change operates on?'
+- Force-push discipline during active review: PR #6860 shows a pattern where a previously approved fix was dropped in a subsequent force-push, causing the reviewer to re-flag the same keyboard-accessibility regression. This signals that rebasing or amending during review is inadvertently reverting accepted work. (occasional)
+  → **Support:** When a reviewer approves an intermediate head, treat that approved diff as locked. Use a tracking comment or branch note to record which commits are approved. Before any force-push during active review, diff the new head against the last approved head and verify no approved logic is removed. Alternatively, prefer fixup commits over rewrites during the review window.
+
+### morgmart
+**Trajectory:** improving — Earlier PRs (#6359, #6529) required multiple review rounds to resolve ordering and cross-surface issues, while later PRs (#6665, #6892) received first- or second-pass approval with no actionable findings, suggesting morgmart is internalizing reviewer feedback over time.
+
+**Strengths:**
+- Responsive to reviewer feedback — consistently iterates and resolves change requests within the same PR cycle, as seen in PR #6359 (validation ordering fixed after P2 finding) and PR #6529 (multiple CHANGES_REQUESTED rounds resolved to approval) (consistent)
+- Narrow, well-scoped changesets — PRs consistently fix a single contract or behavior boundary (e.g., feed category normalization in #6665, rem scaling in #6514, quick reactions in #6892) without sprawl (consistent)
+- Placing fixes at the authoritative owner — reviewers repeatedly note that logic is correctly placed at the contract boundary (Rust producer in #6665, link parser in #6359), indicating good architectural instinct (consistent)
+
+**Growth areas:**
+- Pre-submission validation ordering and edge-case coverage — PR #6359 required a post-review fix for local validation ordering before relay fetch, and PR #6529 required multiple change-request rounds addressing interaction correctness across keyboard, touch, and narrow layouts; suggests pre-review self-review checklists are not catching these systematically (consistent)
+  → **Support:** Adopt a personal pre-submission checklist that explicitly walks through: (1) input validation sequencing (parse before fetch), (2) all layout/interaction surface variants affected by shared components, and (3) contract boundary correctness. Pair with a brief async walk-through with a senior engineer before opening PRs that touch shared UI rails or cross-layer contracts.
+- First-pass completeness on user-visible shared components — PR #6529 (message action rail) accumulated three consecutive CHANGES_REQUESTED verdicts covering shared toolbar behavior, reactions, and multi-layout correctness; indicates that when touching cross-cutting UI components, the initial scope assessment misses downstream consumers (consistent)
+  → **Support:** Before opening PRs that modify shared message-action or toolbar components, explicitly enumerate all consumers (channel, thread, inbox, keyboard, touch, narrow) in the PR description and confirm each is tested or intentionally unaffected. Consider tagging a domain owner for a quick scope sanity-check before the first review request.
+
+### ngthuydiem
+**Trajectory:** insufficient-data — Only one PR is available for review, making it impossible to assess directional trends.
+
+**Strengths:**
+- Targeted, well-scoped test fixes that directly address root cause (replacing wordlist-unsafe separators in test data) (emerging)
+
+**Growth areas:**
+
+### philazar
+**Trajectory:** insufficient-data — Only one PR is available for review, making it impossible to identify a directional trend across time.
+
+**Strengths:**
+- Responsive to reviewer feedback — addressed lockfile cleanup, seeded values, distractor memories, and prompt guard concerns across multiple review rounds (emerging)
+- Iterative fixture quality improvement — proactively improved test fixtures (five-memory isolation, less-guessable seeded values) when prompted (emerging)
+
+**Growth areas:**
+- Grader/verifier correctness — the score_evidence() function accepted semantically negated or malformed answers (e.g., 'Do not use net_gpv') as correct due to naive token presence matching, requiring multiple change-request cycles before resolution (occasional)
+  → **Support:** Before submitting evaluation or grading code, explicitly enumerate and test adversarial inputs (negations, wrong-context mentions, malformed prose) against the acceptance logic. Pair-review grading functions with a senior engineer as a checklist step prior to first review submission.
+- Test realism — an auto-generated, non-meaningful slug (e.g., containing '7f2a') was included in fixture data without vetting, requiring a reviewer to flag it (occasional)
+  → **Support:** Establish a personal pre-PR checklist item to audit all fixture/seed data for realism and intentionality before opening a review. Any auto-generated values should be replaced or explicitly justified in the PR description.
+
+### ravarora2
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to establish any meaningful trend or pattern in code quality or review feedback.
+
+**Strengths:**
+
+**Growth areas:**
+
+### salman1993
+**Trajectory:** stable — Across the window, salman1993 consistently ships meaningful features and responds well to feedback, but the same categories of gaps — test determinism, UI copy completeness, and resource lifecycle bounding — recur in later PRs at roughly the same rate as earlier ones, indicating no clear upward trend yet.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: consistently addresses blockers across review rounds and documents resolutions in comments (consistent)
+- Cross-cutting refactors with clear behavioral intent: PRs like prompt section clarification and context deduplication show deliberate scoping and well-reasoned change boundaries (consistent)
+- Benchmark and test infrastructure contributions: expands coverage across scripted-event delivery, evaluation layers, and E2E determinism (consistent)
+- Feature gating and rollout discipline: new features (thread-scoped sessions, Pi preset) are consistently placed behind experiment flags and default-off gates (consistent)
+
+**Growth areas:**
+- Test determinism: E2E tests rely on timing assumptions (e.g., 4s delay inside 5s auto-retry window) rather than explicit gates, requiring multiple review rounds to correct (consistent) — *dbt/testing best practice: tests must be deterministic and not rely on wall-clock timing or retry windows as correctness mechanisms*
+  → **Support:** Before submitting any E2E or integration test, explicitly verify that all assertions are gated on observable state changes (network interception, explicit deferred flags) rather than time-based self-healing; add a checklist item to PR template for test determinism review
+- Omitting copy/catalog completeness for UI features: new presets or UI entries are added without corresponding display copy, causing degraded user-visible states caught only in review (consistent)
+  → **Support:** Establish a personal checklist: any new catalog entry, preset, or UI-registered feature must be accompanied by a corresponding copy/string resource in the same PR; reviewers have flagged this pattern in at least two separate PRs
+- Resource lifecycle bounding for newly introduced cardinality: adding session-per-thread behavior without LRU/TTL bounds, leaving unbounded growth as a known pre-existing gap that the PR widens (consistent)
+  → **Support:** When a PR increases the cardinality of any pooled or cached resource (sessions, connections, entries), include or explicitly track a bounded-lifecycle companion issue before the PR ships; pair with wpfleger96 on a lifecycle hardening template for resource pool PRs
+- Scope removal without regression coverage: removing workspace anchor logic without replacing its regression tests required a review cycle to catch the behavioral gap (occasional) — *dbt best practice: deleting model logic or test coverage must be accompanied by either a documented justification or a behavioral replacement test*
+  → **Support:** For any PR that deletes existing test cases, require an explicit comment in the PR description explaining why each removed test is no longer needed or what replacement covers its behavior; consider a PR template section for 'tests removed and why'
+
+### tellaho
+**Trajectory:** stable — Across the full 18-PR window tellaho consistently ships ambitious features and resolves reviewer blockers, but the same categories of defect — stateful edge cases, weak test oracles, and executor contract mismatches — recur in the most recent PRs at roughly the same rate as early ones, indicating the author is not yet internalizing feedback into pre-submission habits.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: consistently addresses blocking findings across multiple review cycles and ships corrected code within the same PR (consistent)
+- Feature breadth and ambition: tackles high-risk, cross-cutting surface areas (workflow editors, composer state, navigation guards, persistent addressing) that require understanding of multiple subsystems simultaneously (consistent)
+- Quick turnaround on narrow bug fixes: smaller scoped PRs (e.g., #6531 caret fix, #6837 mention preference) achieve clean first-pass or single-round approval with no blocking findings (consistent)
+
+**Growth areas:**
+- Edge-case correctness in stateful composer and draft logic: repeated P1/P2 blockers across PRs #6252, #6793, #6956, #7144 for issues such as duplicate-mention stripping, module-global clear tombstones, stale ownership metadata, and draft data loss indicate insufficient pre-submission reasoning about state machine boundaries and race conditions (consistent) — *dbt/analytics engineering principle of 'test the boundary, not the happy path'; analogously, UI state machines should be modeled and their invariants explicitly tested before shipping*
+  → **Support:** Before opening PRs that touch composer send lifecycle, draft persistence, or recipient tagging, author should write an explicit state-transition table covering all entry/exit paths (send, clear, restore, rename, delete) and pair with a reviewer for a design review session prior to implementation. Introduce unit tests for each state transition, not just integration-level E2E smoke tests.
+- Test oracle quality and determinism: across PRs #6581, #6606, #6712, #6897, reviewers repeatedly flagged that regression tests were nondeterministic, internally inconsistent with new defaults, or did not exercise the specific failure path the PR intended to prevent (consistent) — *TESTING.md (referenced by reviewers); general principle that a regression test must fail on the pre-fix code and pass only on the fix*
+  → **Support:** Author should adopt a red-green discipline: write the failing test first, confirm it fails on the pre-fix branch, then apply the fix. For WebKit/platform-specific regressions, add a code comment explaining why native observation is not available and what proxy assertion is used instead. A pairing session on test oracle design with jedwards27 or wesbillman would accelerate this.
+- Runtime-executor contract awareness: PRs #6248 and #6470 both shipped UI that taught or produced trigger-condition syntax the backend executor could not evaluate (wrong function names, missing parentheses for Boolean precedence, unsupported cron arities), requiring P1 changes-requested rounds (consistent)
+  → **Support:** Before building any UI that generates or displays backend-evaluated expressions, author should read the executor source (normalize_cron, Pubkey serialization, Boolean lowering) and add a mapping table or shared constant file that both UI and tests reference. A checklist item 'verified against executor contract' should be added to the PR template for workflow-related changes.
+- N+1 and fanout query patterns in data-fetching layers: PR #6712 initially introduced per-card relay queries in the workflow grid, requiring a blocking round to batch and deduplicate before approval (occasional) — *Analytics engineering principle of pushing aggregation/deduplication upstream; equivalent in UI: resolve at list boundary, not at item render*
+  → **Support:** When adding any data-fetching hook inside a list-rendered component, author should audit whether the hook issues a network command and, if so, lift resolution to the list parent with explicit deduplication. A code-review checklist item for 'no per-item network commands' on list PRs would catch this before submission.
+- Accessibility and aria contract consistency: PR #6252 had multiple rounds of changes-requested for mismatched aria-label vs visible label on resolved PR chips, indicating that accessibility contracts are not part of the author's default review checklist (occasional) — *WCAG 2.1 SC 4.1.2: Name, Role, Value — accessible name must match or include the visible label*
+  → **Support:** Add an axe-core or similar accessibility linting step to the local dev workflow. For any component that renders a chip, badge, or link with a computed label, author should explicitly verify that aria-label, aria-labelledby, or visible text are in sync before pushing. Include an accessibility checklist item in the PR template.
+
+### thomaspblock
+**Trajectory:** improving — Later PRs (#6980, #7137) converge to approval in fewer change-request rounds and with lower-severity findings than the complex multi-week iterations seen in #6590 and #6429, suggesting thomaspblock is internalizing reviewer expectations on security/authority correctness and accessibility lifecycle even though first-pass gaps remain.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: across all PRs, thomaspblock consistently produces incremental fix commits after each change-request round, converging to approval rather than abandoning or stalling (consistent)
+- Breadth of ownership across the stack: PRs span TypeScript/React UI (desktop), Rust CLI/backend (buzz-cli), accessibility/keyboard lifecycle, and startup hydration, demonstrating comfort moving across layers (consistent)
+- Self-review and security analysis capability: in PR #6590 thomaspblock authored multiple structured Cassandra security reviews, identified P1 authority/routing issues independently, and tracked fix status across commits (emerging)
+- Scoped, well-labeled commits: PR titles consistently follow conventional-commit format (fix, feat, perf, polish) with clear scope tags (desktop, projects) (consistent)
+
+**Growth areas:**
+- First-pass completeness on async/state-identity correctness: every PR involving asynchronous data (refetch identity in #6429, ACP cache expiry in #6590, startup hydration in #6939, subscription-settlement in #7013) required multiple change-request rounds before the identity/ownership invariant was correctly enforced end-to-end (consistent)
+  → **Support:** Before opening a PR that touches async data flows, require a written design note (even a PR description section) that explicitly enumerates: (1) every state that can be observed between fetch initiation and settlement, (2) which identity is authoritative at each state, and (3) what the failure-closed behavior is. Pair with a senior reviewer on the first async PR per sprint to calibrate the bar.
+- Accessibility and keyboard lifecycle gaps in layered UI: PR #6901 required three change-request rounds specifically because the initially shipped solution left a visually covered thread keyboard- and AX-tree interactive, then stranded focus on body after dismissal — foundational a11y lifecycle issues (consistent) — *WCAG 2.1 SC 2.1.1 (Keyboard), SC 2.4.3 (Focus Order), SC 4.1.2 (Name, Role, Value)*
+  → **Support:** Add an accessibility checklist to the PR template for any UI PR involving layered/overlay components: inert/aria-hidden on covered content, focus trap while overlay is open, focus restoration target on close. Run axe-core or Playwright accessibility snapshot assertions as a required CI step for desktop UI PRs.
+- Test coverage wiring: reviewers repeatedly flagged that regression tests did not exercise production code paths — test assertions targeted the wrong surface (#6980 empty-state text not scoped), retry tests didn't invoke production wiring (#7013), and CI tests could not detect a production wiring break (#6429) (consistent)
+  → **Support:** Enforce a test-review checklist item: for every bug fix, the reviewer must confirm the test fails on the pre-fix code and passes on the fix. Consider adding a PR template section 'How does the test prove the bug is fixed?' thomaspblock should practice writing this justification before requesting review.
+- Multibyte/Unicode boundary handling: PR #6590 surfaced a recurring pattern where byte-length guards and character-boundary truncation were mismatched (byte measurement vs. char truncation on UTF-8 project names), requiring explicit CJK regression tests before the fix was accepted (occasional)
+  → **Support:** When writing any string-length validation in Rust or TypeScript, apply a standard checklist: measure in bytes when the downstream limit is in bytes, truncate at character boundaries, and include at least one multibyte (e.g., CJK or emoji) unit test. Add this to the team's Rust code review checklist.
+- Memoization correctness in React: PR #6590 had a recurring issue where JSX elements were constructed fresh each render and passed as props into memoized children, defeating memo boundaries — a pattern that appeared across multiple components before being caught (occasional)
+  → **Support:** During desktop PR self-review, thomaspblock should audit every prop passed to a memoized component (React.memo, useMemo) and confirm it is either primitive, a stable reference, or explicitly memoized. Consider adding an ESLint rule or custom lint check for unstable JSX prop references into memoized trees.
+
+### tlongwell-block
+**Trajectory:** improving — Across the three PRs in chronological order, the author moved from a spec-level review dismissal with unresolved normative gaps, through a multi-round performance PR that ultimately reached approval by closing all but one then all blockers, to a targeted fix PR that received immediate positive confirmation of approach from the reviewer — suggesting increasing precision and scope calibration over the window.
+
+**Strengths:**
+- Systematic problem decomposition and root cause tracing. In both the NIP-FI spec PR and the FTS exclusion fix, the author demonstrates thorough analysis of the failure surface before proposing a solution — tracing the 30179 gap across migration 0008, 0014, and schema.sql, and decomposing NIP-FI into distinct profile lifecycles. (consistent)
+- Responsive iteration under review pressure. In PR #6572, the author resolved three of four blockers across two review rounds and ultimately achieved approval, showing willingness to re-engage with reviewer feedback rather than arguing or stalling. (consistent)
+- Correct pattern reuse for schema migrations. Reviewer on PR #6822 confirmed that copying the pg_get_expr shape from migration 0014 was the right approach because it preserves existing per-database policy rather than flattening it. (emerging)
+
+**Growth areas:**
+- Normative contract completeness in specification work — particularly pinning encoding-level details when byte-exact invariants are required. PR #5946 reviewer flagged that logical JWT claim sets do not determine protected-header/payload JSON octets, leaving signed and transport bytes unpinned, making the byte-exact exit test non-satisfiable as written. (occasional) — *RFC 7515 §7.2 (JWS JSON Serialization): signing is over the exact encoded bytes of the JWS Protected Header and JWS Payload, not over the decoded logical structure.*
+  → **Support:** Before publishing normative specs with byte-exact or signature-exact test vectors, require a checklist step: enumerate every layer (serialization format, header encoding, payload encoding, signing input) and confirm each is pinned. Pair with a reviewer who has shipped interoperable JWS/JWT implementations to review the encoding sections specifically before the broader normative review.
+- Startup/lifecycle sequencing — specifically ensuring cache hydration and subscription events are ordered so that post-subscribe refreshes do not race with or get swallowed by slow hydration. PR #6572 required two rounds of changes-requested before the startup ordering race was closed. (consistent)
+  → **Support:** Adopt an explicit startup state machine (e.g., COLD → HYDRATING → HYDRATED → SUBSCRIBED) with documented invariants for when post-subscription side effects are permitted to fire. Add a lightweight integration test that simulates slow hydration and asserts that post-subscribe refreshes still execute. Review the team's existing patterns for provider sequencing before writing new CommunityQueryProvider-style wrappers.
+- Rendering-blocking on async initialization — PR #6572 first-round blocker was that CommunityQueryProvider rendered no children until cache hydration completed, hiding the entire app behind that async step. (occasional)
+  → **Support:** Establish a team convention: providers may gate on async work only if they render a skeleton/loading state, never a null/empty tree. Document this as a code review checklist item and add a lint rule or component test that fails if a provider renders null children for more than a configurable timeout in test environments.
+
+### tulsi-builder
+**Trajectory:** improving — Later PRs (#6900, #7126) reach APPROVE in fewer review rounds than earlier ones (#6702, #6716), and the author is beginning to preemptively address some Unicode and state-clearing concerns, suggesting iterative learning across the window.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: consistently addresses P2 defects within the same PR review cycle rather than deferring or reopening new PRs (consistent)
+- Feature scope breadth: PRs span full-stack concerns (renderer, Tauri/SQLite persistence, relay/catalog, accessibility tokens) showing systemic understanding of the codebase (consistent)
+- Correctness on core logic after revision: reviewers consistently reach APPROVE once flagged defects are addressed, indicating the author understands root cause and implements fixes accurately (consistent)
+
+**Growth areas:**
+- Accessibility compliance (WCAG AA color contrast): mention highlight and badge color tokens have failed AA contrast requirements across at least three PRs (#6716, #6702, #6900), indicating a pattern of introducing theme-coupled colors without verifying contrast ratios upfront (consistent) — *WCAG 2.1 SC 1.4.3 (Contrast Minimum, AA)*
+  → **Support:** Add a pre-commit or CI lint step (e.g., axe-core, Storybook a11y addon, or a custom contrast token validator) that fails if any new or modified color token pair falls below 4.5:1 for normal text or 3:1 for large text. Pair the author with the design system owner for a focused session on the repository's semantic foreground token conventions before the next UI-touching PR.
+- Unicode edge-case handling in text processing: PRs #6946 and #6702 both required changes-requested rounds to address Unicode line separators (NEL U+0085, LS U+2028) and Unicode-normalized span over-highlighting — a recurring blind spot when manipulating user-supplied text (consistent)
+  → **Support:** Create a shared test-fixture file of Unicode edge strings (CRLF, CR-only, NEL, LS, multi-codepoint emoji, NFD vs NFC normalized text) and require its use in any PR that parses or renders user text. The author should review the Unicode standard's line-breaking algorithm (UAX #14) and the project's existing normalization utilities before beginning text-processing work.
+- Navigation lifecycle state clearing: PR #6702 required multiple CHANGES_REQUESTED rounds because highlight/state clearing was implemented caller-locally rather than at the correct ownership boundary, a design-level issue distinct from the surface bug (occasional)
+  → **Support:** Before implementing any stateful navigation feature, require the author to write a short design note (even a PR comment) identifying the ownership boundary for state teardown. A senior reviewer should sign off on the design note before code is written to avoid multiple correction cycles mid-PR.
+- Catalog/relay data pipeline completeness: PR #7126 required a changes-requested round because the community catalog path dropped a newly added field before it reached the UI — a missing propagation step that suggests the author does not systematically trace data flow end-to-end before marking a PR ready (occasional)
+  → **Support:** Introduce a self-review checklist item: for every new or modified data field, explicitly verify and document each layer it must cross (DB schema → relay → renderer → UI). A brief data-flow diagram in the PR description would surface gaps before automated review.
+
+### wesbillman
+**Trajectory:** stable — Across the 19-PR window wesbillman consistently delivers technically ambitious fixes and reaches approval on all PRs, but the same gap categories — missing mutation-sensitive tests, incomplete contract propagation, async teardown races — recur from the earliest PRs through the most recent ones without a clear reduction in the number of review rounds required.
+
+**Strengths:**
+- Cross-domain technical breadth: wesbillman authors PRs spanning relay protocol (NIP-OA, frame rejection), mobile Flutter, desktop Tauri/Rust, CI policy, and ACP authorization — demonstrating confident ownership across the full stack (consistent)
+- Responsive iteration on reviewer feedback: across high-complexity PRs (e.g., #6953, #6961, #6402), wesbillman consistently delivers multiple corrective commits rather than abandoning or stalling, ultimately reaching approval on all reviewed PRs (consistent)
+- Effective use of automated review tooling: wesbillman operates delegated reviewer agents (Carl) to provide blocking self-review commentary on own PRs, catching real defects (e.g., #6338 NIP-OA gate regression, #6533 authorization boundary) before human reviewers escalate (consistent)
+- Security and authorization boundary awareness: multiple PRs (#6338, #6533, #6953) show wesbillman correctly identifying and fixing fail-closed ownership/authz requirements at relay and identity boundaries without prompting after initial flag (emerging)
+
+**Growth areas:**
+- Regression test coverage accompanying behavior changes: reviewers repeatedly flag that new production wiring is not mutation-sensitive in the test suite. In #6953 jedwards27 requests tests that fail when startup-refresh is deleted; in #6996 brow notes two new guards are unfalsifiable; in #6485 multiple rounds of changes_requested center on ceiling tests that pass despite enforcement gaps. This is the single most persistent gap across the window. (consistent) — *dbt/analytics engineering norm: every model/logic change ships with tests that would have caught the regression being fixed*
+  → **Support:** Before opening any PR that changes a behavioral contract, wesbillman should write at minimum one mutation-sensitive test (i.e., verify the test fails when the production logic is deleted or inverted), document the mutation tried, and include that evidence in the PR description. A PR template checklist item — 'I have verified at least one test fails when this logic is removed' — would institutionalize this habit.
+- Incomplete policy/contract propagation on the first submission: CI policy PRs (#6485, #6618) and protocol PRs (#6961) consistently require 4–7 review rounds because the initial implementation enforces the rule in one location while leaving sibling locations (other workflows, other request types, other caller sites) unenforced. Reviewers independently converge on 'the contract is incomplete' across both PRs. (consistent)
+  → **Support:** Adopt a pre-submission checklist step: for every enforcement point introduced, grep/search the entire codebase for analogous patterns and confirm each is covered or explicitly excluded. For CI policy PRs, run the contract script against a temporarily widened glob before filing to confirm no workflow escapes. Include the coverage evidence in the PR description.
+- Lifecycle and teardown correctness in async/concurrent contexts: PRs #6427 (notification activation queue outliving the owning effect), #6415 (reconnect repair race), and #6961 (publish gate window without session fence) each required multiple rounds to close teardown/cancellation races. Reviewers note the isCancelled guard running at enqueue time only, AbortController signals not propagated into nested async calls, and generation checks missing at execution time. (consistent)
+  → **Support:** When introducing any async queue, timer, or subscription, wesbillman should apply a standard three-question checklist before filing: (1) Is the resource cancelled/aborted at the point of teardown, not just at enqueue? (2) Is the session/generation still valid immediately before the effectful operation executes? (3) Is the cancellation signal threaded through every awaited call in the chain? A short design note in the PR description answering these three questions would accelerate reviewer confidence.
+- Rolling-deploy and migration ordering hazards: #6251 required multiple rounds because startup repair could execute before the migration fence was in place (BUZZ_AUTO_MIGRATE opt-in gap), and #7203 had a branch that could destroy last-copy keyring data. These are related: wesbillman tends to implement the happy path correctly but misses the ordering guarantee needed for mixed-version or partial-state environments. (consistent)
+  → **Support:** For any PR touching migrations, startup sequencing, or persistent state recovery, add an explicit section to the PR description titled 'Ordering and rollback safety' that enumerates: (a) what state the system may be in when this code first runs, (b) which branches execute under each state, and (c) what happens if the migration/guard has not yet run. Pair with a reviewer who has shipped a prior migration to validate the analysis before the PR is filed.
+
+### wpfleger96
+**Trajectory:** stable — Across the full chronological window the author ships work of increasing technical ambition (NIP-FI auth runtime, team catalog backend, single-flight OAuth) but the same recurring gap categories — fail-open security boundaries, async error propagation, data lifecycle ordering, and privacy leaks — appear in both early and late PRs without a measurable reduction in initial-submission defect density.
+
+**Strengths:**
+- Broad cross-layer ownership: wpfleger96 consistently authors PRs that span backend (Rust crates), frontend (TypeScript/React), CI pipelines, and database migrations, demonstrating comfort operating across the full stack without siloing. (consistent)
+- Responsiveness to review cycles: across complex PRs (e.g., #5112, #3995, #5545, #6330), the author iterates through multiple CHANGES_REQUESTED rounds and lands approved states, indicating persistence and willingness to address blockers rather than abandoning work. (consistent)
+- Schema and migration authorship: PRs #5719, #6994, and related work show the author is capable of designing non-trivial DB schemas (observer-frame retention, NIP-FI identity, authorization foundation) that eventually pass review. (consistent)
+- CI and tooling hygiene: PRs #6962, #7042, #7179, #6423 demonstrate proactive maintenance of CI pipelines, dependency pinning, and shell-timeout budgets, reflecting operational awareness. (emerging)
+
+**Growth areas:**
+- Security boundary completeness on first submission: across PRs #6776 (NIP-FI verifier — unbounded JWKS lookup, algorithm/key-type mismatch), #5712 (fail-open malformed wire message), #3777 (attachment bytes navigated as typed blob, replay guard collision), and #3995 (unverified relay events affecting paging/content), the author repeatedly misses attacker-controlled input paths, fail-open defaults, or missing validation layers before the first review round. (consistent) — *OWASP Input Validation, CWE-20 (Improper Input Validation), CWE-284 (Improper Access Control)*
+  → **Support:** Before each PR submission, complete a structured threat-model checklist: (1) enumerate every externally-supplied or publisher-controlled value that flows into storage, rendering, or auth decisions; (2) confirm each has a reject-on-invalid default (fail-closed); (3) verify algorithm/key-type binding and size bounds for any crypto primitive. Schedule a 30-minute security design sync with a senior engineer for any PR touching auth, relay ingress, or external content rendering.
+- State lifecycle and error propagation in async/reactive code: PRs #6330 (forced-discovery failures invisible to Settings/onboarding hook), #6447 (thread query timeout not surfaced, false-empty shown), and #5545 (rejected-token identity not included in single-flight coalescing, stale bad-token cache entry left live) each required multiple CHANGES_REQUESTED rounds specifically because error or terminal states were not propagated to the correct observer or evicted from the correct cache slot. (consistent) — *React Query best practices (observer key scoping, error state surfacing); single-flight/coalescing cache invalidation patterns*
+  → **Support:** Adopt a pre-PR self-review step for any async state change: draw the full state machine (pending → success | error | stale) and confirm each state is observable by every consumer that gates UX or subsequent logic. For Rust single-flight / cache patterns, write a unit test that injects a rejection and asserts the cache entry is evicted before adding new callers. Pair with a senior engineer on the first implementation of each new async coordination pattern.
+- Data lifecycle correctness (tombstone ordering, deletion recovery, adoption integrity): PR #5112 required eight CHANGES_REQUESTED rounds with recurring P1 findings around future-dated tombstones being rejected, deleted catalogs being resurrected by delayed shares, built-in reuse conflicts, and cross-device sync heads not being enqueued. These are distinct lifecycle edge cases but reflect a pattern of incomplete event-ordering reasoning. (consistent) — *Event-sourced system design: causality, lamport timestamps, tombstone ordering invariants*
+  → **Support:** For any event-sourced or append-only data model, produce an explicit sequence diagram covering: (a) concurrent write races, (b) delayed/out-of-order delivery, (c) deletion followed by re-publication, and (d) cross-device sync gaps. Have a senior engineer review this diagram before writing code. Add integration tests that inject out-of-order and delayed events to assert correct terminal state.
+- Privacy leak prevention when projecting publisher-controlled data: PR #3995 required five consecutive CHANGES_REQUESTED rounds on the same finding — catalog member avatar URLs supplied by untrusted publishers being fetched on browse, leaking IP/identity to third-party servers. The fix was deferred multiple iterations despite the explicit blocker being restated identically each round. (consistent) — *Privacy-by-design: data minimization; SSRF/tracking pixel prevention for untrusted URL projection*
+  → **Support:** Treat any publisher-supplied URL as untrusted and never eagerly fetch it without explicit user action. Add a linting/code-review checklist item: 'Does this change render or prefetch a URL whose origin is not controlled by the operator?' Pair with a security-focused engineer on any PR that renders community/catalog content from external sources.
+- Contract completeness before first submission (missing edge cases requiring multiple full review cycles): PRs #5112 (12 review rounds), #5545 (8 rounds), #3995 (8 rounds), #6330 (7 rounds), and #6776 (5 rounds) each required a high number of CHANGES_REQUESTED iterations, suggesting systematic gaps in pre-submission coverage rather than isolated misses. (consistent)
+  → **Support:** Institute a mandatory pre-PR self-review against a written acceptance checklist covering: security boundaries, error propagation, data lifecycle edge cases, privacy of external data, and cross-device/cross-process contracts. For P0/P1 feature work, schedule a design review before implementation begins. Track the number of CHANGES_REQUESTED rounds per PR as a personal quality metric and target reducing average rounds by 30% over the next quarter.
+
+---
+
+## 4. Team Gap Analysis
+
+### Where the team is strong
+| Area | Evidence | Standard |
+|------|----------|----------|
+| Security-critical business logic review: integer overflow, cast safety, and panic prevention | jmecom caught u64→i64 cast wrapping and chrono::Duration panic risk in timeout computation, resulting in validated checked arithmetic with boundary unit tests | Rust safety: checked_add_signed, Duration::try_seconds over infallible variants for untrusted input |
+| Append-only audit trail enforcement for security-critical mutations | jmecom required append-only audit history before merging roster mutation code; reviewer identified that upsert/delete destroyed durable records for grant/revoke operations controlling root-of-trust | Kimball: slowly changing dimensions / audit history for security-critical tables; non-destructive audit logging for privileged operations |
+| Input canonicalization before security-critical lookups | jmecom identified pubkey_hex case normalization gap that allowed shadow DB rows to bypass config-immutability 409 checks; fix enforced single canonical lowercase form across all code paths | — |
+| Replay-guard and cryptographic uniqueness review | wesbillman identified deterministic Nostr event ID collision for same-URL/same-second requests under NIP-98 replay protection, requiring fresh nonce tag per signing attempt | NIP-98: uniqueness requirement for kind 27235 event IDs in replay protection |
+| Policy compliance verification against documented moderation contracts | wesbillman cross-referenced VISION_MODERATION.md to identify missing affected-user notification tasks for enforcement actions, preventing silent enforcement without required notice | VISION_MODERATION.md: affected-user notice required for enforcement actions |
+| Fail-secure configuration design for authentication systems | kalvinnchau validated that unrecognized auth modes abort startup rather than defaulting to permissive behavior, and confirmed constant-time bearer validation and CSP coherence | Security principle: fail-closed configuration for authentication systems |
+| Frontend/backend type contract synchronization | wesbillman caught admin-web/src/types.ts omitting status field added to backend API, and identified localStorage-derived UI state that diverged from authoritative backend lifecycle fields | — |
+| CI/CD pipeline correctness including timeout values, test isolation, and job deduplication | TheSentinel454 consistently flagged unreasonable timeout values, failing checks, and redundant test execution across CI job definitions | — |
+| DRY principle enforcement and code duplication identification | TheSentinel454 repeatedly questioned repeated functions and test logic without consolidation across multiple PRs | DRY principle |
+| Documentation accuracy relative to implementation | TheSentinel454 caught doc examples showing old SHA-only image reference formats and missing operating contract clarity for staging artifacts | — |
+
+### Gaps and blind spots
+| Area | Gap Type | Missing Standard | Recommendation |
+|------|----------|-----------------|----------------|
+| SQL query plan and index usage review — no reviewer comments on EXPLAIN output, missing indexes, or sequential scans on large tables | coverage_gap | dbt Labs style guide: performance section; dbt-project-evaluator: missing primary key tests, exposure freshness; SQLFluff: query structure linting | Add CI gate requiring EXPLAIN ANALYZE output in PR description for any migration adding a new query path on tables >100k rows; add SQLFluff rule enforcement in CI; create checklist item for index coverage on foreign keys |
+| Join cardinality and grain declaration — no comments verifying that joins do not fan out rows or that model grain is explicitly documented | blind_spot | Kimball: fact table grain declaration; dbt Labs style guide: model grain must be declared in model description; dbt-project-evaluator: fct_ models must have a grain property | Mandate grain declaration in all model-level descriptions as a dbt-project-evaluator custom check; add review checklist item requiring reviewer to confirm join cardinality is intentional and tested |
+| Primary key and uniqueness test coverage — no reviewer comments verifying dbt unique/not_null tests on new models or tables | blind_spot | dbt-project-evaluator: missing_primary_key_tests check; dbt Labs style guide: every model must have unique and not_null tests on its primary key | Enable dbt-project-evaluator missing_primary_key_tests check in CI as a hard failure; add to PR template a checkbox: 'unique + not_null tests added for all new model PKs' |
+| Model materialization strategy review — no comments questioning whether new models use appropriate materializations (table vs. incremental vs. view) for their expected data volume | coverage_gap | dbt Labs style guide: materialization guidance by layer (staging=view, intermediate=ephemeral/view, marts=table/incremental); dbt-project-evaluator: materialization checks | Add materialization rationale as a required PR description field for any new dbt model; create a team convention document mapping layer to expected materialization and enforce via dbt-project-evaluator custom rule |
+| Incremental model predicate and is_incremental() filter correctness — no comments verifying that incremental models correctly filter on the incremental column | coverage_gap | dbt Labs style guide: incremental models must include is_incremental() filter on a reliable updated_at or surrogate; dbt-project-evaluator: incremental_strategy checks | Add CI check using dbt-project-evaluator incremental model rules; require reviewer sign-off on is_incremental() predicate logic in PR checklist for any model using incremental materialization |
+| Source freshness and data latency SLA review — no comments verifying that source freshness tests are defined and that SLAs are appropriate for downstream use | blind_spot | dbt Labs style guide: sources must define loaded_at_field and freshness thresholds; dbt-project-evaluator: missing_source_freshness_tests | Enable dbt-project-evaluator missing_source_freshness_tests; run dbt source freshness in CI on a schedule; add to PR template a checkbox for any new source: 'freshness thresholds defined and appropriate for downstream SLA' |
+| CI secrets scoping and OIDC least-privilege for workflow tokens — no visible reviewer comments on secret scoping in CI workflows | blind_spot | GitHub Actions security hardening: OIDC preferred over long-lived secrets; least-privilege workflow permissions; secret scoping to minimum required jobs | Add a security-focused CI/CD review checklist item covering: OIDC vs static secret usage, workflow token permission scoping (permissions: key), and secret exposure surface for any PR touching .github/workflows |
+| XSS and content-sniffing prevention for attacker-controlled MIME/blob URLs — identified once by wesbillman but not yet institutionalized as a recurring check pattern | knowledge_gap | OWASP: Content-Type sniffing; CSP: sandbox attribute for blob URLs; X-Content-Type-Options: nosniff | Add to frontend PR checklist: any fetch of user-supplied attachment or media must sanitize MIME before blob URL creation, set nosniff headers, and avoid target=_blank without rel=noopener on untrusted content; conduct one-time team training session on blob URL XSS vectors |
+| Lease fencing and distributed lock correctness — identified as judgment-level by wesbillman but no systematic review pattern exists | knowledge_gap | — | Elevate lease fencing to a team convention: any record_action_failure or similar post-release state mutation must validate caller lease token is still held; document this as an architecture decision record (ADR) and add to review checklist for distributed workflow code |
+| Tombstone and event payload completeness — fields dropped between persistence and emission layers | knowledge_gap | — | Add integration test coverage asserting that emitted event payloads contain all fields present in persisted payloads; add reviewer checklist item: for any event emission PR, verify emitted struct maps all authoritative fields from persistence layer |
+| SQLFluff rule enforcement — no evidence of SQLFluff linting results referenced in any review comment | blind_spot | SQLFluff: L010 keywords uppercase, L014 identifiers lowercase, L031 no table alias in from clause, L034 select wildcards last | Integrate SQLFluff into CI as a required check with a shared .sqlfluff config committed to the repo; configure at minimum L010, L014, L019, L031, L034; block merge on lint failures |
+| Ref vs. source usage discipline — no comments verifying that models reference upstream dbt models via ref() rather than raw schema.table syntax | blind_spot | dbt Labs style guide: always use ref() for model dependencies and source() for raw sources, never raw schema.table; dbt-project-evaluator: direct_join_to_source check | Enable dbt-project-evaluator direct_join_to_source and source_fanout checks in CI; add to PR template: 'All upstream references use ref() or source() — no raw schema.table references' |
+| Observability coverage for new enforcement and moderation code paths — metrics and alerting gaps not systematically reviewed | knowledge_gap | — | TheSentinel454's pattern of requesting observability metrics should be formalized: add to PR checklist a requirement that any new enforcement/moderation action code path includes a counter or histogram metric and a runbook entry; conduct team discussion to agree on metric naming conventions |
+
+### Review culture
+The team demonstrates strong depth in security-critical review when subject-matter experts (jmecom, wesbillman, kalvinnchau) are assigned — catching subtle overflow, canonicalization, replay, and audit trail gaps that would be missed by generalist review. However, review coverage is heavily dependent on individual reviewer assignment rather than systematized checklists or CI gates, creating significant variance: SQL/data modeling dimensions (grain, index coverage, materialization strategy, ref() discipline) have no visible coverage across 187 PRs, suggesting the team either lacks SQL analytics reviewers or has no mechanism to trigger them. TheSentinel454's observability and DRY patterns and wesbillman's policy-compliance cross-referencing are healthy emergent practices that are not yet captured in shared conventions, meaning their value is lost when those reviewers are not assigned — the highest priority institutional investment is converting the team's strongest judgment-level patterns into PR template checkboxes, ADRs, and CI gates before reviewer knowledge walks out the door.
+
+---
+
+## Methodology & Caveats
+
+- **Window:** 2026-08-17 → 2026-09-01 | **PRs analyzed:** 187 | **PRs skipped (no reviews):** 0
+- **Repo context:** SQLFluff config found | PR template found | dbt_project.yml found
+- **What this analysis cannot see:** verbal review culture (Slack), reviewer availability constraints, domain ownership, or PRs merged without review.
+
+---
+
+## Appendix: Reference Standards
+
+- **dbt Labs style guide**: https://docs.getdbt.com/best-practices/how-we-style/0-how-we-style-our-dbt-projects
+- **dbt-project-evaluator**: https://github.com/dbt-labs/dbt-project-evaluator
+- **SQLFluff rule catalog**: https://docs.sqlfluff.com/en/stable/rules.html
+- **Kimball dimensional modeling**: https://www.kimballgroup.com/data-warehouse-business-intelligence-resources/kimball-techniques/dimensional-modeling-techniques/
+- **Google Engineering Practices — code review**: https://google.github.io/eng-practices/review/
+- **Smart Bear — peer review best practices**: https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/

--- a/tricorder/2026-09-03-block__berd.md
+++ b/tricorder/2026-09-03-block__berd.md
@@ -1,0 +1,626 @@
+---
+date: 2026-09-03
+repo: block/berd
+window: 2026-08-12 → 2026-09-02
+pr_count: 159
+contributors: ['NickTitle', 'amlozano1', 'caregullin', 'comp615', 'cynfria', 'damienrj', 'delkc', 'johnmatthewtennant', 'josereyes', 'kalvinnchau', 'kennylauren', 'loganj', 'matt2e', 'morgmart', 'mrohan-sq', 'nathan-thillairajah', 'tirsen', 'tulsi-builder']
+visibility: private
+generated_by: tricorder v1.1.0
+lens: product-engineering-desktop
+---
+
+# PR Review Analysis — block/berd — 2026-09-03
+
+> Window: 2026-08-12 → 2026-09-02 | 159 PRs | 18 contributors
+
+---
+
+## 1. Patterns Ready to Institutionalize
+
+| Pattern | Category | Current Maturity | Next Step | Standard |
+|---------|----------|-----------------|-----------|----------|
+| Updater public-key sourced from repository secret; annotated tag bound to verified merge commit | — | rule | Codify the full signing + tagging ceremony as a documented runbook and add a CI job that validates the public key is present in tauri.conf.json before any release workflow proceeds, making the check deterministic rather than reviewer-enforced. | deterministic |
+| Experiment gate required before broad-audience feature rollout | — | guidance | Add an explicit field to the PR template ('Is this feature experiment-gated? If not, justify.') and define a written policy for what blast-radius threshold requires gating. This moves the practice from individual reviewer memory to a tracked convention. | convention |
+| IPC boundary: exact host/path validation before invoking native subprocesses | — | judgment | Extract the validation pattern into a shared Rust utility (e.g., a typed GithubPrUrl newtype that enforces the invariant at construction), add a property-based test suite for traversal and canonicalization bypass inputs, and document the pattern in CONTRIBUTING.md so all new IPC commands follow it by convention. | rule |
+| Unit test density expectation for new features (Vitest + Rust unit tests) | — | guidance | Define a minimum coverage target or a per-PR checklist requirement ('New state machines must have unit tests; new UI components must have Vitest tests') and enforce via a coverage gate in CI for the Rust crate and a Vitest coverage threshold for the frontend. | rule |
+
+---
+
+## 2. Reviewer Focus Fingerprints
+
+### caregullin
+**Style:** advisory | **Signal quality:** medium — The reviewer identifies real and subtle correctness issues (debounce race, range tracking, rejection bounding) with good specificity, but the sample is only two PRs and entirely omits security, testing, IPC, and type-safety concerns.
+
+**Primary focus areas:**
+- Debounce/timer lifecycle: unsaved state on unmount before debounce flush completes (sometimes)
+- Input validation bounds: magic numeric constants should be documented with their invariants (sometimes)
+- Mention/range tracking correctness: widget-owned text ranges must be tracked and rewritten precisely rather than naively replaced (sometimes)
+- Rejection/retry bounding: unbounded retry loops or rejection counts in message queues must be capped (sometimes)
+
+**Apparent blind spots:**
+- IPC boundary validation and command signatures — Both PRs touch frontend hooks and UI widgets that interact with the backend, but no comments address serialization, input validation at the IPC layer, or command permission scoping.
+- Security and capability scoping — No comments in either PR address capability permissions, CSP, or trust-boundary concerns despite changes to features that persist and send prompt data.
+- Testing (unit and E2E coverage) — No comments request or critique test coverage for the debounce lifecycle fix, the range-rewrite logic, or the rejection-bounding logic — all of which are non-trivial behavioral changes.
+- React hook hygiene (effect dependencies, cleanup) — The debounce comment is about runtime correctness of cleanup, not about effect dependency arrays or Rules of Hooks compliance; no explicit React hygiene framing is applied.
+- TypeScript strictness — No comments on type safety, non-null assertions, or unsafe narrowing across either PR.
+
+### comp615
+**Style:** thorough | **Signal quality:** high — Comments are precise, cite specific code paths and failure modes, demand concrete test coverage for each identified risk, and distinguish between in-process serialization guarantees and cross-process race conditions — all domain-relevant and non-trivially actionable.
+
+**Primary focus areas:**
+- Race conditions and concurrent state ownership across renderer and native processes — specifically who owns sequencing, when a claim transitions state, and whether two simultaneous app instances or remounts can corrupt shared state (always)
+- IPC/transport contract versioning and backward compatibility — whether schema changes break already-shipped strict clients that have no negotiation signal (always) — *https://v2.tauri.app/security/*
+- Capability scoping — separating new transport-neutral capabilities from existing ones rather than reusing or over-broadening existing capabilities (often) — *https://v2.tauri.app/security/capabilities/*
+- Public event/state contract shape — ensuring that sequencing, ordering, and ownership responsibilities are explicitly encoded at the API boundary rather than left implicit in renderer-side logic (often)
+- Component lifecycle and state persistence across remounts — whether a claim or active survey survives or is incorrectly re-presentable after a new mount (often) — *https://react.dev/reference/rules*
+- Focus management and keyboard accessibility on dismissal — restoring focus to the previously focused element or falling back to a known safe target (often) — *https://www.w3.org/TR/WCAG22/*
+- Virtual list measurement correctness — whether offscreen rows that own active UI state receive accurate height measurement and appearance-driven revisions (sometimes)
+- Test coverage of specific concurrency and lifecycle scenarios — demanding dedicated tests for interleaving, remount, and measurement regression rather than accepting untested boundary claims (always)
+
+**Apparent blind spots:**
+- Unsafe Rust and FFI safety — no comments on unsafe blocks, raw pointer usage, or FFI boundaries in src-tauri despite reviewing Rust command files — Both PRs touch Rust command files (runtime_config.rs, feedback_survey.rs) but all comments are about contract versioning and concurrency semantics, never about unsafe usage or soundness.
+- Dependency hygiene — no comments on new npm or Cargo dependencies, license compatibility, or supply-chain risk — New feature code across two PRs likely introduces new imports, but no review comment addresses dependency additions or their justification.
+- Telemetry payload disclosure — no comments on what data the feedback survey events carry, opt-in/out behavior, or consistency with published telemetry policy — The PRs explicitly add sampled session feedback and response feedback UI, which are telemetry-adjacent features, yet no comment references payload content, user consent, or TELEMETRY.md alignment.
+- CSP and webview security — no comments on Content Security Policy implications of new UI features or protocol handlers — New webview UI components are added in both PRs but no review comment touches CSP or webview configuration.
+- TypeScript strictness — no comments on type safety, any-casts, non-null assertions, or floating promises in the TypeScript/React files reviewed — Multiple .ts and .tsx files are reviewed but all comments focus on behavioral correctness and state machine design, never on type-level safety.
+
+### cynfria
+**Style:** conversational | **Signal quality:** medium — Comments are substantive and technically specific about file-atomicity and snapshot-schema correctness, but they are almost entirely bot-authored response confirmations rather than independent reviewer analysis, and critical desktop-app domain areas (IPC validation, capability scoping, React hygiene, type safety) are consistently absent.
+
+**Primary focus areas:**
+- Correctness of concurrent file operations in Rust — specifically atomic claim/replace semantics, no-replace hard linking, backup directory collision, and interruption recovery during bundled agent migration (often)
+- Data contract consistency across the IPC/serialization boundary — ensuring snapshot schema, API response shapes, and UI import/export paths agree on field presence, validation rules, and fallback values (often)
+- Snapshot schema validation correctness — grapheme vs. code-unit counting, raw safety caps before segmentation, and what values are accepted vs. silently dropped vs. rejected (often)
+- Shared utility correctness and consistency — enforcing that truncation, counting, and fallback helpers share a single implementation across call sites (sometimes)
+- Async lifecycle safety in UI — deadlines for async workers, abort/cancellation on dialog close, and preventing stale async results from affecting UI state (sometimes)
+- Regression test coverage accompanying behavior fixes — adding tests that specifically guard the fixed edge case (sometimes)
+- Deliberate product scoping decisions — explicitly declining changes that conflict with product direction (e.g., retiring deprecated fields rather than preserving them as opaque metadata) (sometimes)
+
+**Apparent blind spots:**
+- IPC command input validation — never discusses whether Tauri commands validate or sanitize arguments received from the webview before acting on them — Multiple PRs touch src-tauri Rust services (bundled_agents.rs) and the API layer, but all comments focus on file-operation atomicity or snapshot schema; no comment ever asks whether command parameters are validated at the trust boundary per Tauri security guidance.
+- Capability and permission scoping — never raises whether commands or file-system access are appropriately scoped to the correct windows/webviews — No comment across 12 PRs mentions capabilities, allow-list entries, or permission scopes despite reviewing Tauri core Rust code, which is the primary place these should be audited.
+- React hook correctness (dependency arrays, effect cleanup, render purity) — Several PRs touch React components (AgentShareDialog.tsx, AgentImportDialog.tsx, SessionListCapability.tsx) but no comment addresses hook dependency arrays, missing cleanup, or effect ordering; PR #128 (focus return) was approved without any hook-level remarks.
+- TypeScript type strictness — any casts, non-null assertions, unsafe narrowing — Multiple TypeScript files are reviewed across many PRs with no comment ever addressing type safety, which suggests this is not on the reviewer's checklist.
+- Accessibility — keyboard access, focus management, ARIA semantics in dialog and picker components — PR #128 is explicitly about focus return to composer, and multiple dialog components (AgentShareDialog, AgentImportDialog) are reviewed, yet no comment addresses ARIA roles, focus trapping, or WCAG compliance.
+- Dependency additions and license hygiene — No PR comment across the full history mentions new npm or Cargo dependencies, their licenses, or supply-chain risk, even in PRs that add new file-handling or i18n functionality.
+
+### damienrj
+**Style:** thorough | **Signal quality:** high — Every comment targets a distinct, concrete defect class (TOCTOU races, script portability, trust-boundary leaks, shutdown ordering) with specific fix descriptions and required regression tests, showing deep understanding of the feature's failure modes rather than surface-level style feedback.
+
+**Primary focus areas:**
+- Race conditions and generation/ownership guards across async state transitions in the Rust backend — specifically ensuring that stale async operations cannot overwrite newer state (e.g., tunnel establishment must check generation before publishing Ready, supervisors must verify PID+generation before signaling) (always)
+- Shell script correctness and portability — catching GNU-specific flags that break on macOS/BSD (e.g., base64 --decode vs -d), bounding file sizes in log rotation, and hardening PID-based process identity checks against stale lock records (always)
+- IPC/trust-boundary safety for attachments crossing the remote session boundary — local file paths and directories must not be forwarded to remote hosts; only byte-backed content with local paths stripped is permissible (always) — *https://v2.tauri.app/security/*
+- Shutdown correctness — ensuring that establish/reconnect cannot race with shutdown by holding the appropriate lock across the stop-daemon sequence (often)
+- Feature-flag/experiment lifecycle management — ensuring that disabling an experiment tears down all in-memory state, backend routes, and remote connections while preserving persisted data (often)
+- Persistence and rehydration correctness — session records must restore archived state correctly (archivedAt preserved), and remote host metadata must be inferred and persisted so state survives restarts (often)
+- Regression test coverage for each bug fixed — every concurrency fix, portability fix, and boundary condition is accompanied by a targeted regression test (always)
+- Process-identity verification for daemon takeover — conflict errors must carry inspectable PID/version/binary metadata and an opaque process-identity token; takeover must target exactly that generation (sometimes)
+
+**Apparent blind spots:**
+- Capability and permission scoping for the new SSH/remote commands in tauri.conf.json or capabilities files — All comments focus on runtime logic correctness and script portability; no comment addresses whether the new IPC commands are properly scoped to the windows that need them or whether over-broad permissions were granted.
+- Content Security Policy impact of the remote session feature (e.g., whether connecting to a remote host URL requires CSP relaxation) — No comment in the review touches CSP headers or webview configuration changes that the remote backend connection might necessitate.
+- TypeScript type safety and non-null assertions in the frontend files touched (acpApi.ts, acpConnection.ts, ChatInputToolbar.tsx) — Comments on these files address only behavioral correctness (attachment sanitization, generation tracking); no remark is made about type narrowing, floating promises, or unsafe casts.
+- React hook discipline and effect cleanup in the new UI components (AppShell.tsx, RemoteHostsSettings.tsx, ChatInputToolbar.tsx) — Reconciliation logic in hooks is discussed only at the behavioral level; no comment addresses effect dependency arrays, cleanup callbacks, or hook ordering.
+- Dependency additions (any new cargo or npm packages introduced by the SSH feature) — With only one PR reviewed there is no comment on crate or package additions, license compatibility, or supply-chain risk.
+
+### delkc
+**Style:** advisory | **Signal quality:** low — Only one approved PR with no recorded inline comments provides insufficient evidence to characterize meaningful review patterns or consistent focus areas.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- IPC boundary validation — Only one PR reviewed; no comments on command signatures, serialization, or input validation despite the domain requiring it.
+- React hygiene (hook ordering, effect cleanup, state immutability) — The PR touches UI remount/state persistence behavior — a classic React lifecycle concern — yet no review comments were left addressing hook dependencies, effect cleanup, or state management correctness.
+- E2E coverage — A UI behavioral fix (surveys remaining visible after remount) was approved with no apparent inquiry into whether a Playwright regression test was added to cover the scenario.
+- Capability and permission scoping — No comments observed on capability/permission concerns across the single reviewed PR.
+
+### johnmatthewtennant
+**Style:** thorough | **Signal quality:** high — Every comment is tied to a specific, reproducible failure mode and is followed by a precise fix description plus a named regression test, demonstrating deep domain understanding and consistent enforcement of concrete correctness invariants.
+
+**Primary focus areas:**
+- Race conditions and concurrent state mutation: stale lifecycle requests mutating replacement sessions, concurrent callers settling shared mutable state, generation/revision counters not enforced before writes (always)
+- Lifecycle ordering and teardown correctness: terminal state must be captured before stopping, cleanup guards must be unconditional, duplicate cleanup must be idempotent, shutdown must be serialized with startup (always)
+- Bounded async operations: every wait must have a deadline; unbounded waits, retries, and polling loops are consistently flagged and required to have timeouts or watchdogs (always)
+- IPC command authorization: commands must validate exact caller identity (window label, session ID, lifecycle revision, renderer epoch) before mutating shared native state (always) — *https://v2.tauri.app/security/*
+- Child process and OS resource cleanup: spawned processes must be reaped on every error path, process-tree termination must be unconditional, and detached children must not be orphaned (often)
+- Deduplication and idempotency of message/event delivery: duplicate sends across retries, queued drain, and transcript replay must be detected and suppressed atomically (often)
+- Stale-result invalidation in async UI hooks: useEffect-style hooks must gate their settled results on a generation/mount token so superseded responses cannot overwrite newer state (often) — *https://react.dev/reference/rules*
+- Accessibility: ARIA semantics, accessible names, live-region announcements, focus treatment, and reduced-motion coverage for interactive UI components (often) — *https://www.w3.org/TR/WCAG22/*
+- Input sanitization at native/IPC ingress: untrusted data (NUL bytes, stale voice IDs, unbounded output lines) must be sanitized before being passed to OS APIs or spawned processes (often) — *https://v2.tauri.app/security/*
+- Atomic file writes: persisted state must be written to a temp file and renamed, never written in place, to survive crashes mid-write (sometimes)
+- Test regression coverage: every fix must be accompanied by a focused regression test that demonstrates the exact failure mode (always)
+- Scoped API surface: rejecting proposed changes that would broaden shared component contracts, add new shared state, or introduce new API variants without proportionate reuse justification (often)
+
+**Apparent blind spots:**
+- Capability and permission scoping in tauri.conf.json or capability files — Reviewer extensively reviews IPC command authorization logic in Rust but never comments on which windows are granted which Tauri capabilities, whether command scopes are too broad, or whether new commands are registered under appropriately restrictive capability files.
+- Content Security Policy (CSP) and webview configuration — No comments across 20 PRs touch CSP headers, webview allow-list configuration, or remote URL loading policy, despite active work in both the Tauri core and the React frontend.
+- Dependency hygiene (Cargo.toml and package.json additions) — Multiple PRs introduce new crates (berd-monitor, AirPods bridge, OpenAI audio) and npm dependencies, but no review comments address license compatibility, supply-chain risk, cargo-deny policy, or whether a dependency is justified versus a smaller in-tree implementation.
+- E2E / Playwright test coverage for UI changes — Many PRs ship significant UI changes (VoiceSettings layout, VoiceBuddyApp controls, ChatInputToolbar) with only unit/Vitest coverage. Reviewer never asks whether Playwright E2E tests cover the new user-visible flows.
+- Release and packaging safety (code signing, updater configuration, sidecar staging) — PRs bundle native sidecars (berd-monitor, Swift bridges) and introduce new binary targets but the reviewer never comments on target-triple naming conventions, sidecar staging in tauri.conf.json, code-signing requirements, or updater safety.
+
+### kalvinnchau
+**Style:** thorough | **Signal quality:** high — Comments are consistently specific, cite reproducible conditions with concrete scenarios (exact byte counts, probability calculations, concurrent-instance traces), and distinguish blocking P2 defects from non-blocking P3 notes, making them immediately actionable.
+
+**Primary focus areas:**
+- Race conditions and atomicity violations across concurrent renderer realms, process instances, or async awaits — especially where shared state is read before an await and written after, allowing two actors to both observe the same pre-mutation snapshot (always)
+- Resource lifecycle and process ownership in long-running or detached native processes — unbounded log growth, orphaned child processes after timeout, lock recovery that can wedge or destroy newer generations (always)
+- State machine / session lifecycle correctness — early returns that discard valid subsequent state, stale state surviving restart or navigation, once-per-session contracts violated by reload or window handoff (often)
+- IPC/API schema versioning and backward-compatibility — adding fields to versioned structs without bumping schema versions, `deny_unknown_fields` causing older clients to reject new responses entirely (often) — *https://v2.tauri.app/security/*
+- Unsafe Rust / correctness at byte-level string operations — draining or slicing strings at byte offsets that may not be UTF-8 character boundaries, causing panics in detached tasks (sometimes) — *https://doc.rust-lang.org/nomicon/*
+- Accessibility — focus management after programmatic dismissal of dialogs/surveys, restoring a stable prior focus target rather than dropping to document body (sometimes) — *https://www.w3.org/TR/WCAG22/*
+- Dead code and unused exports — production exports that have no live caller, compatibility accessors kept after refactors, unused function parameters (sometimes)
+- Virtual/measured list layout correctness — items not included in offscreen measurement paths causing height corrections when the user scrolls to them (sometimes)
+- Sampling / probability semantics — correctly naming and documenting whether a rate is a per-opportunity hazard rate or a session-level probability, and whether the implementation matches the stated contract (sometimes)
+- Release script correctness — baseline tag selection, race between approval and main advancing, cumulative note generation (sometimes)
+
+**Apparent blind spots:**
+- Capability and permission scoping in tauri.conf.json / capabilities files — kalvinnchau comments extensively on IPC schema and transport-layer correctness but never comments on which windows are granted which Tauri capabilities, scope tightening, or whether new commands are over-permissioned — even in PRs that add new Tauri commands (e.g., PR #214, #215, #252).
+- Content Security Policy and webview security configuration — No comments on CSP headers, protocol handlers, or remote URL loading appear across 37 PRs, including PRs that add new remote-host connectivity (PR #252).
+- React hook correctness — effect dependency arrays, cleanup, stale closures — Several PRs touch React components (PR #214, #215, #252 RemoteHostsSettings) but kalvinnchau's inline comments focus on business-logic state bugs and accessibility, never on missing effect cleanup, stale closure captures, or missing dependencies in useEffect/useCallback.
+- TypeScript type strictness — `any` casts, non-null assertions, floating promises — No comments on TypeScript type safety appear despite multiple TypeScript files being reviewed; findings stay at semantic/behavioral level rather than type-system level.
+- E2E test coverage for UI changes — Multiple UI-facing PRs (PR #214 response feedback, PR #215 session survey, PR #248 table styling) are approved or have only behavioral comments; no comment ever requests or references Playwright test coverage for the new UI paths.
+- Dependency hygiene and license review — PR #254 (js-yaml bump) is approved with no comment, and no other PR receives scrutiny of transitive dependency additions, cargo-deny policy, or license compatibility — despite both Cargo and npm ecosystems being active.
+
+### kennylauren
+**Style:** advisory | **Signal quality:** low — Only one approved PR with no recorded inline comments is insufficient to establish any meaningful pattern or distinguish genuine focus areas from blind spots.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- IPC boundary validation — Only one PR reviewed and it was a layout/UI change; no evidence of attention to command signatures, input validation, or error shapes at the Rust/webview boundary.
+- Capability and permission scoping — No comments observed on capability definitions or permission scoping across the single PR reviewed.
+- E2E coverage — A UI layout change was approved with no apparent comment on whether Playwright tests cover the updated layout.
+- Accessibility — A Home layout refinement is exactly the kind of change where WCAG concerns (focus management, ARIA semantics, contrast) should surface, but no such comments were recorded.
+- TypeScript strictness — No type-safety observations noted despite reviewing a React/TypeScript UI PR.
+
+### loganj
+**Style:** thorough | **Signal quality:** high — Comments identify specific race conditions, uncovered code paths, and concrete state-transition bugs with exact commit references and file locations, demonstrating deep functional understanding rather than surface-level style feedback.
+
+**Primary focus areas:**
+- Correctness of state transitions and race conditions in async session/message flows (often)
+- Persisted state migration correctness — ensuring normalization/graduation logic covers all entry paths (often)
+- IPC boundary safety — shell-free invocation, URL validation, input bounds, subprocess argument construction (often) — *https://v2.tauri.app/security/*
+- Classifier/mapper completeness — covering the full set of tool call variants at the production boundary (often)
+- Dead code and unused export hygiene (sometimes)
+- Feature flag / experiment gating before shipping to all users (sometimes)
+
+**Apparent blind spots:**
+- Capability and permission scoping in tauri.conf.json / capabilities files — Reviews touch Tauri IPC boundaries and security, but no comments mention capability files, permission scoping, or which windows/webviews can invoke which commands.
+- Accessibility (keyboard navigation, ARIA, focus management) — PR #115 review summary mentions accessibility was traced, but no inline comments or findings on WCAG concerns appear in any PR across the dataset.
+- E2E test coverage for UI changes — Multiple PRs introduce new UI features (PR tracker, PR display, voice, speech status) with no reviewer comments requesting or questioning Playwright/E2E coverage.
+- Dependency additions and license hygiene — PR #48 involves npm lockfile replay and ACP bridges — a natural hook for dependency/license review — yet no comments on that topic appear.
+- TypeScript strictness (non-null assertions, unsafe casts, floating promises) — Multiple TypeScript files are reviewed but no comments address type safety, non-null assertions, or unhandled promise rejections.
+- CSP and webview security configuration — No comments across all 12 PRs address Content Security Policy, protocol handlers, or webview configuration despite the repo being a Tauri desktop app.
+
+### matt2e
+**Style:** advisory | **Signal quality:** medium — When matt2e does comment the observations are precise and domain-relevant (deduplication invariants, std API semantics), but comment volume is very low across 6 PRs and entire critical domain areas (IPC, capabilities, telemetry privacy, E2E) receive no attention.
+
+**Primary focus areas:**
+- Correctness of removed UI logic: verifying that deleted code paths still have a replacement consumer, and that invariants (like deduplication filters) are preserved after refactors (often)
+- Rust standard-library correctness: verifying that platform-specific behavior of std APIs matches how the code uses them (e.g., fs::rename semantics on Windows) (sometimes)
+- Pragmatic acceptance of minor error-handling gaps at launch: willing to let non-critical initialization failures fall back to defaults rather than blocking approval (sometimes)
+
+**Apparent blind spots:**
+- IPC boundary validation: reviewer touches telemetry commands in src-tauri but makes no comments about input validation, serialization correctness, or trust-boundary enforcement on Tauri commands — The only inline comment on src-tauri/src/commands/telemetry.rs is a std::fs::rename correctness note; no review of command signatures, capability scoping, or data crossing the IPC boundary appears in any PR
+- Capability and permission scoping: no comments in any PR about which windows/webviews may invoke which commands or whether capability files are appropriately scoped — PRs include Tauri backend changes (PR #16, #33, #45) with no reviewer commentary on capabilities or permissions
+- Telemetry privacy: PR #16 explicitly adds the OpenTelemetry pipeline and core Berd events, but reviewer leaves no comments about payload content, opt-in/out behavior, or consistency with telemetry policy — Only three inline comments on PR #16, none addressing telemetry data content, user disclosure, or opt-out mechanics
+- E2E test coverage: no comments across any PR requesting or evaluating Playwright tests for UI changes, including the substantial ConnectionsSettings refactor in PR #76 — PR #76 reorganizes the connections UI with no e2e coverage discussion; PR #153 (canvas feature) is dismissed with no test commentary
+- TypeScript strictness and React hook hygiene: no comments about type safety, non-null assertions, or hook dependency arrays despite reviewing several React component files — ConnectionsSettings.tsx and WelcomeStep.tsx reviewed without any mention of type correctness or Rules of Hooks compliance
+- Release and updater safety: PR #10 adds a guarded release workflow and is approved with no inline commentary, suggesting no scrutiny of signing, notarization, or updater configuration — Approved with no comments on a release workflow PR
+
+### morgmart
+**Style:** blocking | **Signal quality:** high — The reviewer consistently identifies specific, reproducible correctness and security defects with precise code-level descriptions of the failure scenario and its user effect, rarely raises stylistic noise, and tracks issues across many revision cycles until they are genuinely fixed.
+
+**Primary focus areas:**
+- Race conditions and atomicity violations in file system operations — TOCTOU gaps between existence checks and renames, non-atomic read-modify-write cycles, and missing crash-recovery paths for multi-step file mutations (always)
+- Unbounded async operations — IPC calls, network requests, font loads, worker messages, and native shutdowns that can hang forever with no timeout, deadline, or abort path (always)
+- IPC command authorization — Tauri commands that accept neither session/revision identity nor caller-window binding, allowing stale or cross-lifecycle requests to mutate live state (always) — *https://v2.tauri.app/security/*
+- Concurrent state serialization — last-write-wins races on shared stores, mutable atomics, and promise chains that can be resolved out of order by overlapping async operations (always)
+- Telemetry consent correctness — consent checked only at initiation rather than throughout async pipelines, fail-unsafe cohort detection that routes unknown installs into onboarding, and UI state that advances before consent is persisted (often) — *https://github.com/block/berd*
+- Localization completeness — user-facing copy added only to the English catalog, hard-coded English strings in UI paths that support Spanish, and accessible names constructed from untranslatable template literals (often)
+- Accessibility — missing ARIA live-region updates for dynamic state, label-in-name violations, progress bars without aria-valuenow, and dialogs with hard-coded English accessible names (often) — *https://www.w3.org/TR/WCAG22/*
+- React effect and lifecycle correctness — StrictMode double-invoke hazards, effects that close over stale snapshots, missing cleanup of blob URLs and abort signals, and component-local state that should be process-global or vice versa (often) — *https://react.dev/reference/rules*
+- Unsafe Rust and FFI soundness — passing pointers derived from shared Rust references to CoreAudio property APIs that can mutate through those pointers, and Objective-C bridge callback correctness (often) — *https://doc.rust-lang.org/nomicon/*
+- Idempotency and delivery deduplication — message delivery IDs lost across code paths, duplicate-check windows that race asynchronous commit, and monitor output that can be re-delivered after a crash because the durable record is removed after the send (often)
+- Security boundary in CLI credential handling — credential read/verify and credential use done in separate storage reads allowing substitution, test transport overrides that ship in release builds, and credential redaction gaps (often)
+- Persisted schema backward compatibility — new hard validation limits applied to existing version-1 records, removed catalog IDs that remain valid in persisted onboarding state, and missing migration for records that predate a new field (often)
+- Process and thread resource management — spawned child processes not reaped on timeout, Drop implementations that send termination signals multiple times, unbounded thread spawning in Siri callbacks, and infallible thread::spawn that can panic inside async tasks (often)
+- Test honesty — tests that verify source text rather than rendered output, regression tests weakened to no longer exercise the stale-response scenario they were written for, and missing CI wiring for new Swift test targets (often)
+- Design-system boundary enforcement — feature code placing color, spacing, or interactive-state classes directly on shared primitives instead of going through semantic variants or wrappers (often)
+- Release script correctness — local-only tags used as git baselines, operator approval windows during which the branch can advance, and release notes generated from stale snapshots (sometimes)
+- macOS capability and permission declarations — using OS frameworks (Speech Recognition, AVAudioEngine) without the corresponding Info.plist usage description or runtime authorization request (sometimes) — *https://v2.tauri.app/security/capabilities/*
+
+**Apparent blind spots:**
+- Cargo and npm dependency hygiene — no comments across any PR about new crate additions, license compatibility, cargo-deny policy, or supply-chain risk from new dependencies — Multiple PRs add new Rust crates and npm packages; the reviewer never comments on dependency justification, license, or cargo-deny policy compliance
+- Content Security Policy and webview configuration — no comments about CSP headers, remote URL loading, or protocol handler configuration despite the project having a Tauri webview boundary — No CSP-related comments appear across 97 PRs even though the project is a Tauri desktop app where CSP misconfiguration is a primary attack surface
+- Tauri capability scoping — no comments about which windows or webviews are allowed to invoke which commands beyond generic lifecycle/session-ID binding concerns — Reviewer flags missing session/revision binding on IPC commands but never references the Tauri capability file or per-window permission grants
+- Performance — no comments about bundle size, render cost, unnecessary re-renders, or memory allocations despite reviewing React and Rust code extensively — The reviewer consistently finds race conditions and correctness bugs but never raises performance or cost-of-render concerns even in hot paths like the transcript renderer and voice pipeline
+- Code signing and notarization pipeline correctness — no review comments on macOS notarization, Windows code signing, or release packaging integrity despite reviewing release scripts — PR #27 (release scripts) and PR #25 (release version bump) are reviewed without any mention of signing, notarization, or updater signature verification
+
+### nathan-thillairajah
+**Style:** thorough | **Signal quality:** high — Every comment maps precisely to a concrete behavioral or security defect with a specific remediation, and the reviewer tracks each item through multiple revision cycles with named commits.
+
+**Primary focus areas:**
+- IPC/CLI boundary input validation: origins, credentials, and request parameters must be validated at first ingress before use (always) — *https://v2.tauri.app/security/*
+- Secret/credential redaction in output: session tokens and credentials must be sanitized recursively before reaching CLI output, including object keys (always)
+- Credential storage lifecycle and recovery: stored sessions must be invalidated before fresh login, not reused after failure (always)
+- Test isolation: test infrastructure (transports, overrides, test CAs, env vars) must not bleed into distributable binaries (always)
+- Non-interactive vs interactive mode separation: JSON/non-TTY callers must never trigger browser flows (often)
+- Credential provenance: use the exact credential verified/issued rather than re-reading storage after verification (often)
+- Timeout/deadline enforcement on interactive flows (e.g., OAuth callback) (sometimes)
+
+**Apparent blind spots:**
+- Rust API shape and idiomatic error types — All comments focus on behavioral correctness and security; no comments address Clippy lints, ownership/lifetime choices, or error type design despite edits to Rust source files.
+- Documentation and changelog accuracy — No comments address rustdoc, inline comments, README, or changelog entries across all reviewed changes.
+- Performance and async scheduling — No attention paid to allocation patterns, async executor choices, or startup cost in the CLI despite multiple async flows being modified.
+- Dependency hygiene (Cargo.toml additions/pins) — Test CA and TLS fixture dependencies were removed as a security concern but there is no evidence of reviewing Cargo dependency additions or version constraints on their own merits.
+
+### tulsi-builder
+**Style:** advisory | **Signal quality:** low — All four PRs were approved with no recorded inline comments, making it impossible to identify any substantive focus area; the reviewer's approvals provide no actionable signal about what was actually evaluated.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- IPC boundary validation and command input sanitization — PRs #187, #66, #8, and #82 all touch UI and agent/chat logic that presumably crosses the Tauri IPC boundary, yet no comments address command signatures, input validation, or error shapes.
+- React hygiene (hook ordering, effect deps, render purity) — PRs #187 and #66 involve React UI changes (canvas labels, agent cards) with no recorded comments on Rules of Hooks, effect cleanup, or key usage.
+- TypeScript strictness (any casts, floating promises, unsafe narrowing) — Across four PRs covering UI logic and agent description rendering, no comments address type safety concerns.
+- E2E coverage of UI changes — PRs #187 (canvas labels), #66 (agent cards), and #8 (starter task restoration) ship visible UI changes with no recorded reviewer questions about Playwright test coverage.
+- Capability/permission scoping — No comments across any of the four PRs address which windows or webviews may invoke which commands, despite changes to agent and chat features that likely exercise IPC commands.
+- Telemetry privacy — PR #82 adds an always-on interaction norms preamble injected into chat, a feature with potential telemetry implications, but no comments address payload disclosure or opt-out behavior.
+- Accessibility — PR #187 adds text labels to a Home canvas and PR #66 renders agent cards — both UI-visible changes — with no WCAG or ARIA-related comments recorded.
+
+---
+
+## 3. Author Growth Profiles
+
+### NickTitle
+**Trajectory:** insufficient-data — Only one PR is available in the review window, which is insufficient to establish any trend or pattern.
+
+**Strengths:**
+
+**Growth areas:**
+
+### amlozano1
+**Trajectory:** insufficient-data — Only one approved PR with no inline review comments is available; no pattern can be established across this window.
+
+**Strengths:**
+
+**Growth areas:**
+
+### caregullin
+**Trajectory:** insufficient-data — Only two PRs are available and both landed on the same day, making chronological improvement signal impossible to distinguish from within-PR iteration.
+
+**Strengths:**
+- Responsive engagement with review feedback: consistently provides substantive replies to automated and human comments, explaining rationale or confirming fixes within the same review cycle (consistent)
+- Deliberate bounded retry logic: proactively introduced a per-payload retry cap (5) at the correct drain choke point so all trigger paths are covered, showing awareness of infinite-loop failure modes in async queues (emerging)
+- Cleanup correctness in hooks: fixed unmount flush to use latest refs rather than stale closure values, indicating familiarity with the ref-based cleanup pattern required by React's Rules of Hooks (emerging) — *https://react.dev/reference/rules/rules-of-hooks*
+
+**Growth areas:**
+- Input validation and enforced limits at the IPC/persistence boundary: in PR #209, prompt and title length limits were acknowledged as accurate findings but deferred rather than fixed, leaving the mapper able to silently truncate user content without surfacing an error (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** Before merging features that write user content through the IPC layer, add explicit validation (max-length checks with user-visible errors) on both the TypeScript side and the Tauri command handler. Review the Tauri security docs on validated inputs (https://v2.tauri.app/security/) and establish a team norm that 'deferred' limit enforcement is tracked with a blocking follow-up issue, not left as a silent truncation.
+- Precision of text-range mutation in rich-text widgets: the initial implementation in PromptPinWidget used a full-prompt indexOf search for agent mention replacement, which is fragile when the same token appears multiple times; the fix (recording the insertion range) was only landed after a P2 review comment (occasional) — *https://react.dev/reference/rules*
+  → **Support:** When writing hooks or widgets that mutate a string based on user-inserted tokens, write a Playwright test that inserts the same agent mention text twice and verifies only the intended occurrence is replaced. Consult Playwright best practices (https://playwright.dev/docs/best-practices) to anchor assertions on data-testid attributes rather than text content, making range-mutation bugs immediately visible in CI.
+- Proactive Playwright test coverage for new UI widgets: neither PR includes mention of end-to-end specs accompanying the new PromptPinWidget or the queue-drain fix, leaving behavioral regressions detectable only by manual review (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Adopt a team checklist item: every PR that introduces or modifies a visible widget or async state machine must ship at least one Playwright spec. For PromptPinWidget, write specs that cover pin/unpin round-trips and the debounce-flush-on-unmount path. For the queue hook, add a spec that simulates a pre-commit rejection and asserts the retry counter stops at 5. Reference Playwright best practices for structuring page-object models to keep specs maintainable (https://playwright.dev/docs/best-practices).
+
+### comp615
+**Trajectory:** improving — PR #243 required no substantive review feedback and was approved without comments, suggesting that the concurrency and state-machine lessons from PRs #214 and #215 were internalized and applied before submission.
+
+**Strengths:**
+- Responsive and thorough review resolution: consistently addresses reviewer feedback with precise, scoped fixes and detailed explanations of the remediation approach (e.g., capability separation, state-machine corrections, focus restoration) (consistent)
+- IPC and capability design awareness: correctly separated the new `feedbackSurveys` capability from the existing KGoose-dependent `feedback` capability when prompted, demonstrating understanding of capability scoping (emerging) — *https://v2.tauri.app/security/capabilities/*
+- Accessibility recovery: when the focus-management regression in SessionFeedbackSurvey was identified, the fix captured a stable pre-dismiss focus target and provided a fallback, with path coverage added (emerging) — *https://www.w3.org/TR/WCAG22/*
+- Virtual list measurement correctness: recognized and fixed the offscreen measurement gap for survey rows in VirtualMessageTimeline, adding regression coverage to verify height revision (emerging)
+
+**Growth areas:**
+- Cross-renderer and cross-process race conditions: in both PRs #214 and #215, initial implementations had concurrency gaps — non-atomic sequence allocation across renderers, post-await state overwrites between renderer realms, and process-local Mutex failing to protect against concurrent app instances (consistent) — *https://v2.tauri.app/security/*
+  → **Support:** Before submitting any feature that involves shared mutable state, explicitly map the concurrent actors (renderer realms, Tauri processes, OS-level concurrent instances) and the atomic unit of arbitration. Study the Tauri security model's trust boundary docs to internalize that the webview layer cannot be the authoritative arbiter of shared state — native-side commands with file or DB locks should own arbitration. Practice writing the concurrency contract in a comment before coding: 'Who can call this simultaneously? What is the atomic operation? What is the failure mode if two callers win?' Review Rust's std::sync primitives and consider whether process-local Mutex is sufficient given multi-instance support.
+- Schema versioning and backward compatibility at the IPC/config boundary: PR #214 introduced a new field to `RuntimeFeedbackConfig` under `deny_unknown_fields` without bumping the schema version, risking silent breakage for older clients (occasional) — *https://v2.tauri.app/reference/config/*
+  → **Support:** Adopt a personal checklist for any Rust struct that crosses the IPC or config boundary: (1) Is `deny_unknown_fields` present? If so, adding fields is a breaking change for older readers. (2) Does the struct carry a version discriminant? If not, adding one before the first field addition is safer than adding fields inline. (3) Who are the current deployed consumers, and can they receive the new schema? Document this reasoning in the PR description. Review the Tauri configuration reference for how tauri.conf.json itself handles versioning as a model.
+- Proactive accessibility consideration in interactive UI components: the focus-management gap in SessionFeedbackSurvey (focus falling to document body after programmatic Dismiss) was caught by review rather than authored with correct behavior from the start (occasional) — *https://www.w3.org/TR/WCAG22/*
+  → **Support:** For any component that programmatically manages focus (modals, dialogs, dismissible surveys), add a pre-implementation checklist step: (1) What element has focus when this component mounts? (2) Where should focus go when it unmounts or a primary action fires? (3) Is there a fallback if the saved element is no longer in the DOM? Reference WCAG 2.2 success criterion 2.4.3 (Focus Order) and 3.2.2 (On Input) before writing the component. Add a Playwright test that asserts the post-dismiss focus target for every interactive dismissal path.
+- Sampling/probability logic correctness: PR #215's basis-point rate was applied per eligible completion rather than per session, creating a compounding probability that heavily weights long, active sessions — this product-semantic issue was caught by review (occasional)
+  → **Support:** When implementing any stochastic or rate-limited feature, write the expected probability distribution in a comment and verify it matches the product intent before coding. For sampling specifically: distinguish 'sample per event' from 'sample per session/window' and confirm with the product spec. Include a small unit test that asserts the theoretical probability over N trials falls within an acceptable range, or at minimum documents the cumulative probability formula so reviewers can validate it quickly.
+
+### cynfria
+**Trajectory:** improving — Early PRs (#42, #83) required five or more review cycles to resolve cascading blocking issues, while later PRs (#93, #151, #217) resolve in one or two cycles with tighter fixes and clearer rationale, indicating meaningfully faster iteration and growing awareness of the domain's recurring failure modes.
+
+**Strengths:**
+- Responsive engagement with automated review feedback — consistently addresses blocking issues across multiple review cycles and resolves them before merge (consistent)
+- Localization awareness — proactively adding and updating Spanish translations alongside English copy, and correcting locale parity gaps when flagged (PRs #74, #124) (consistent)
+- Incremental scope management — smaller, focused PRs (e.g., #87, #95, #96, #217) pass review in a single round with no findings, showing growing ability to right-size changes (emerging)
+- Self-review quality in comment threads — responses to reviewer findings are detailed, explain rationale for accepted vs. declined changes, and often document the exact fix applied (consistent)
+
+**Growth areas:**
+- Async resource lifecycle and race-condition prevention — repeated blocking findings around races (ZIP worker stall, gallery-drop/picker generation counters racing, migration check-then-rename races) across PRs #42, #74, #83, #151, #124 (consistent) — *https://react.dev/reference/rules*
+  → **Support:** Work through the Rules of React section on effects and cleanup (useEffect return value, AbortController patterns) with concrete exercises pairing each async operation to a cancellation token. For Rust-side races, study the Rustonomicon's chapter on atomics and the Rust API Guidelines on error handling to internalize check-then-act anti-patterns before writing file-system code. Before opening a PR that introduces any async boundary, sketch the cancellation and error path on paper first.
+- File-system atomicity in Rust — the bundled_agents.rs migration attracted six separate blocking P1 findings across PRs #124 and #151, each a variant of non-atomic check-then-rename or recovery without replacement semantics (consistent) — *https://doc.rust-lang.org/nomicon/*
+  → **Support:** Study the Rustonomicon's coverage of safe abstractions and invariant preservation, then read the Rust API Guidelines on predictability. Pair with a senior engineer on one targeted spike: implement a correct atomic file-replacement helper (temp-write → fsync → rename-into-place) as a shared utility, add a unit test that injects a kill signal mid-rename, and use that helper for all subsequent migration code. This pattern exercise will build the muscle memory missing across these PRs.
+- React StrictMode / double-mount correctness — StrictMode mount/cleanup interactions caused blocking issues in PR #83 (gallery preparation aborted on second mount) and is a recurring source of subtle lifecycle bugs (consistent) — *https://react.dev/reference/rules/rules-of-hooks*
+  → **Support:** Run the development build with StrictMode explicitly enabled and treat any observable double-invocation as a required-passing test before opening a PR. Review the Rules of Hooks and Rules of React docs on effect cleanup; specifically study the pattern of ref-guarded generation counters and how they interact with double-mount. Add a StrictMode wrapper to the existing Playwright test harness so regressions surface in CI.
+- Snapshot schema versioning and backward compatibility — PR #124 introduced a hard validation rejection on profile.about for v1 snapshots that already existed in the wild without that constraint, requiring a rollback of the strict validation (occasional)
+  → **Support:** Before adding validation to any versioned schema field, explicitly document the invariant: 'was this field constrained in all prior versions?' Use a migration-version gate (e.g., apply strict limits only when version >= N) and add a regression test that round-trips a v1 fixture containing a long about value. Review the existing schema.ts versioning pattern with a senior engineer before adding new constraints.
+- Internationalization completeness at the point of authoring — hardcoded English copy and locale-agnostic operations (toLocaleUpperCase without a locale tag, whitespace-only text wrapping) recur across PRs #42, #74, #83, #124 (consistent)
+  → **Support:** Establish a personal pre-PR checklist: grep for string literals in JSX and TypeScript that would be user-visible, verify each has a matching key in both the English and Spanish catalogs, and run toLocaleUpperCase/toLocaleLowerCase calls with an explicit locale argument. Add a CI step (or extend the existing locale-parity test noted in PR #74) that diffs the key sets of all supported locale files and fails on asymmetry.
+- Arbitrary CSS utility usage vs. shared design tokens — PR #30 introduced a one-off pt-[3px] arbitrary Tailwind value rather than a shared spacing token, flagged as P3 (occasional)
+  → **Support:** Before using an arbitrary Tailwind value, search the codebase for the nearest existing spacing token and prefer it. If no token exists, open a separate PR to add it to the design system rather than inlining an arbitrary value. Ask the design reviewer to confirm the correct token during early feedback.
+
+### damienrj
+**Trajectory:** insufficient-data — Only one PR is available for review; while damienrj demonstrated responsiveness to feedback across multiple revision rounds within that PR, a single data point is insufficient to establish a directional trajectory.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: all P1 defects raised across multiple review rounds were addressed in subsequent commits, demonstrating a consistent pattern of closing loops on blocking issues. (emerging)
+- Architectural ambition on IPC and transport design: the SSH/ACP transport layering was judged sound by reviewers and required no fundamental redesign, only lifecycle and ownership corrections. (emerging) — *https://v2.tauri.app/security/*
+
+**Growth areas:**
+- Rust process-ownership and lifecycle correctness: multiple P1/P2 findings across all review rounds concerned stale PID records, missing generation guards on reconnect/shutdown races, and tunnel PIDs not cleared after child exit — indicating a recurring gap in reasoning about concurrent Rust state machines. (consistent) — *https://rust-lang.github.io/api-guidelines/*
+  → **Support:** Work through the Rustonomicon sections on ownership and the Rust API Guidelines on type safety (especially newtype patterns for generation tokens). Before each async state transition in remote_backend/mod.rs, write out the full set of concurrent callers and which lock or generation check gates each one; pair with a reviewer on a whiteboard session specifically for the reconnect/shutdown/supervisor state machine.
+- Shell scripting robustness in sidecar scripts: repeated P2 findings on remote_daemon.sh covered non-portable base64 flags, unbounded log growth, stale-lock recovery wedges, and orphaned child processes — indicating the author is not yet applying defensive shell idioms to daemon bootstrap scripts. (consistent)
+  → **Support:** Adopt a shell-script checklist for any sidecar script: (1) always use `set -euo pipefail`, (2) test on both GNU and BSD/macOS coreutils in CI, (3) impose a log-rotation cap before any append, (4) record child PIDs before backgrounding and implement a cleanup trap. Run shellcheck in CI against all scripts under src-tauri. Review the Tauri sidecar packaging docs to understand the full lifecycle contract expected of sidecar processes.
+- Trust-boundary enforcement at the IPC/experiment boundary: reviewers flagged that the experiment-disablement flag was not enforced at the transport resolver level (acpConnection.ts), allowing forbidden SSH transports to remain live during async setup — indicating the author is not yet treating the capability/experiment gate as a security invariant that must be checked at every async boundary. (consistent) — *https://v2.tauri.app/security/capabilities/*
+  → **Support:** Read the Tauri capabilities and security trust-boundary docs. Establish a design rule: any feature-flag or experiment gate must be checked synchronously on every async re-entry point of the transport setup path, not only at startup. Add an integration test (Playwright or Rust integration test) that toggles the experiment mid-session and asserts the transport is cleanly torn down before new connections are permitted.
+- UTF-8 safe string manipulation in Rust: a P3 finding flagged a `drain` call on a `String` at a byte offset derived from `len()`, which is unsound for multibyte characters — indicating unfamiliarity with Rust's UTF-8 string invariants. (occasional) — *https://doc.rust-lang.org/nomicon/*
+  → **Support:** Read the Rustonomicon chapter on working with strings and bytes. Enable Clippy in CI with at minimum `#![deny(clippy::string_slice)]` and review the full Clippy lint catalog for string-handling lints. Replace byte-offset drain patterns with char-boundary-safe alternatives such as `split_at` guarded by `is_char_boundary`.
+- Proactive multi-client and cross-window race condition analysis: several P2 findings (cross-client daemon record races, experiment reconciliation missing in secondary session windows) were not anticipated before review, suggesting the author does not yet systematically enumerate multi-process and multi-window scenarios during design. (consistent)
+  → **Support:** Before submitting PRs involving shared daemon state or experiment flags, write an explicit concurrency matrix: list every client process, every window, and every async entry point that touches shared state, then annotate which lock or generation token serializes each pair. For UI experiment flags, trace the flag through AppShell, each SessionWindowApp, and the transport resolver to confirm all three are gated consistently.
+
+### delkc
+**Trajectory:** insufficient-data — Three PRs over three days all received quick approvals with minimal reviewer commentary, making it impossible to detect improvement or regression in code quality from the available signal.
+
+**Strengths:**
+- Focused, well-scoped PRs with clear descriptions — each change addresses a single concern (display bug fix, preamble feature, settings consolidation) making review straightforward. (consistent)
+- Consistent approval cadence with no change-request cycles visible, suggesting code is submitted in a reviewable state. (consistent)
+
+**Growth areas:**
+- No Playwright or equivalent end-to-end test coverage accompanying UI changes — PRs #66 (agent card rendering), #82 (chat preamble injection), and #139 (settings page restructure) all touch visible UI surfaces but show no test additions or updates. (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Pair with a reviewer who enforces a 'test file required' checklist for every UI-surface PR. Walk through writing one Playwright locator-based spec together for PR #139's merged settings page (e.g., assert that the About section is reachable via the System settings route), then establish a PR template checkbox: 'E2E test added or existing test updated to cover this change.'
+- IPC trust-boundary and capability hygiene are not evidenced — none of the three PRs include review notes or author commentary about whether new Tauri commands, capability grants, or CSP entries were needed for the changes. (consistent) — *https://v2.tauri.app/security/*
+  → **Support:** Add a PR template section: 'Does this change add or modify a Tauri command, capability, or permission? If yes, link to the updated capability file.' Share the Tauri security overview (https://v2.tauri.app/security/) and capabilities reference (https://v2.tauri.app/security/capabilities/) as required reading, then do a 15-minute walkthrough of the project's existing capability JSON to build familiarity before the next feature PR.
+- Accessibility signal is absent — UI-affecting PRs (#66 agent cards, #82 chat preamble, #139 settings consolidation) carry no ARIA, focus-management, or WCAG commentary from author or reviewers. (consistent) — *https://www.w3.org/TR/WCAG22/*
+  → **Support:** Introduce a lightweight accessibility checklist in the PR template (keyboard navigable? contrast checked? meaningful labels on interactive elements?). For PR #139 specifically, retroactively verify that the merged About/System settings panel has correct heading hierarchy and focus order. Point delkc at WCAG 2.2 success criteria 1.3.1 (Info and Relationships) and 2.4.3 (Focus Order) as the two most common violations in settings-page restructures.
+- Reviewer feedback depth is thin — two of three approvals are near-empty (one blank, one automated), suggesting delkc may not be receiving substantive domain-specific code review to accelerate growth. (consistent)
+  → **Support:** Rotate delkc onto PRs reviewed by engineers who regularly comment on React hook correctness, TypeScript strictness, and IPC patterns. For delkc's own PRs, require at least one human inline comment thread before merge to build the habit of engaging with detailed feedback.
+
+### johnmatthewtennant
+**Trajectory:** improving — Early PRs (#131, #120, #123) required minimal review cycles, mid-window complex PRs (#150, #164, #184) accumulated many CHANGES_REQUESTED rounds on recurring lifecycle and IPC patterns, but the latest PRs (#230, #231, #241, #247) are approved in one or two passes, suggesting the author is internalizing the bounded-wait and ingress-validation patterns even as the scope of features being built continues to grow.
+
+**Strengths:**
+- Responsive ownership of review findings: consistently implements fixes for every P1 blocker raised, provides detailed commit-level replies, and resolves threads with substantive explanations rather than silent pushes (consistent)
+- Deep native/IPC boundary awareness: correctly designs generation-scoped, session-and-revision-authenticated Tauri commands (mute, lifecycle management, voice buddy) that prevent stale renderers from mutating live state (consistent) — *https://v2.tauri.app/security/*
+- Lifecycle serialization in Rust: repeatedly applies mutex-per-lifecycle patterns, bounded channel waits, and typed terminal outcomes to prevent unbounded worker threads and overlapping shutdown races (consistent) — *https://rust-lang.github.io/api-guidelines/*
+- Telemetry discipline: voice-start counter is emitted only after native startup and microphone reconciliation succeed, and is consent-gated, consistent with the project's telemetry policy (emerging) — *https://github.com/block/berd*
+- Test coverage accompanies fixes: regression tests are added for every accepted P1 (bounded shutdown, idempotent delivery, producer cleanup, mute-state reset), demonstrating disciplined test-first fix verification (consistent)
+- Cross-platform packaging awareness: correctly handles macOS-specific paths (Siri XPC, Apple Speech.framework, CoreAudio routing) with platform-gated code and aware of Info.plist capability requirements (emerging) — *https://v2.tauri.app/security/capabilities/*
+
+**Growth areas:**
+- IPC input validation at Tauri command ingress: renderer-supplied values (voice identifier, session ID, mute boolean) are accepted and used before re-validation against native state, raising trust-boundary violations that reviewers flag as P1 blockers across PRs #160, #164, #205 (consistent) — *https://v2.tauri.app/security/*
+  → **Support:** Before every new Tauri command, apply the ingress-validation checklist from the Tauri security docs: re-resolve any renderer-supplied identifier (voice name, session, window label) against authoritative native or OS state before acquiring shared locks or mutating playback state. Add a unit test that supplies a stale/fabricated value and asserts the command no-ops. Treat the pattern used in #205 (re-resolving the Siri voice against the native catalog before acquiring playback state) as the team's canonical template.
+- Unbounded async waits in native workers: repeated P1s across PRs #150, #164, #177, #184, #206, #234 for polling loops, grace intervals, and IPC acknowledgement paths that have no deadline, leaving the process hung indefinitely on a stuck native service or subprocess (consistent) — *https://doc.rust-lang.org/nomicon/*
+  → **Support:** Adopt a mandatory timeout wrapper for every cross-process or native-service await: use tokio::time::timeout (or a bounded channel recv_timeout) with a named constant deadline. Document the chosen deadline and the fallback action (kill + reap, release guard, return typed error) in a comment adjacent to the call. Review the Rustonomicon's discussion of blocking and the Rust API Guidelines on error handling to ensure every timeout expiry returns a typed outcome rather than a silent path change. The pattern fixed in #206 (bounding Finish by expected audio duration + allowance) is a good reference.
+- Concurrent write serialization for shared mutable settings: independent read-modify-write paths on the same settings record (Siri voice, speed, mute) appear without locking across PRs #160, #164, #192, leading to last-write-wins races that reviewers flag repeatedly (consistent) — *https://v2.tauri.app/security/*
+  → **Support:** Introduce a single process-wide serialized updater per settings domain (as was eventually done for Siri settings in #164). Before opening a new settings-write Tauri command, confirm whether any sibling command touches the same record; if so, route both through the same Mutex-guarded or channel-serialized writer. Apply the generation-counter pattern already used for mute intent to all new independent commands that share state.
+- Accessibility completeness on new UI surfaces: new voice/dialog components (buddy floating controls, Advanced VAD dialog, voice picker, interrupted-speech markup) consistently arrive with missing or incorrect ARIA semantics—wrong dialog anatomy, hardcoded English close labels, semantic del misuse, live-region gaps—caught across PRs #150, #177, #184, #192 (consistent) — *https://www.w3.org/TR/WCAG22/*
+  → **Support:** Add a pre-submission accessibility checklist for every new or modified interactive surface: (1) every Dialog must have a localized closeLabel and use DialogBody/DialogFooter anatomy; (2) live regions must announce state transitions (speaking, muted, error) in all supported locales; (3) progress bars must forward aria-valuenow via the shared primitive; (4) semantic elements (del, ins) must match their WCAG meaning. Run the project's accessibility lint pass locally before pushing, and include a WCAG 2.2 1.3.1/4.1.2 self-review note in the PR description for any new interactive component.
+- Localization coverage for user-visible strings: English template literals and hardcoded toast/error messages appear in new voice UI code across PRs #150, #160, #164, #184 even though the project supports multiple locales (consistent)
+  → **Support:** Before marking a PR ready for review, grep every new string literal in JSX/TSX for raw English text and confirm each has a corresponding localization key with at least one non-English translation entry. The Spanish coverage added in #170 (N/Ñ collation case) and the localized error messages in #150 are good templates. Treat any inline string that will be shown to the user as a build error, not a P2.
+- Design-system contract adherence for new shared UI primitives: feature-local color, spacing, and interaction-state classes are applied directly instead of through shared design-system components (ComposerActionButton, Button, RadioGroupCard, DialogBody) across PRs #150, #184, resulting in repeated P2 blocks about semantic styling and component anatomy (consistent)
+  → **Support:** Before adding className overrides to a shared component, check whether the shared primitive already exposes a semantic prop (e.g., destructive, speaking, activity). If not, propose the addition at the shared-component level with a discriminating test in the design-system explorer, rather than applying feature-local overrides. Use the VoiceConversationButton and ComposerActionButton fix in #150 as the model: move the treatment into the shared contract and add explorer coverage.
+- Idempotent delivery and deduplication completeness: delivery paths (monitor chunk send, queued message drain, idle send) are initially non-idempotent or deduplicate only a subset of paths, causing repeated P1 blocks across PR #234; the pattern recurs even after partial fixes as new paths are added (consistent)
+  → **Support:** For every new message-delivery path, draw the full failure graph before writing code: write-then-remove, crash-between-write-and-remove, concurrent delivery, and restart-replay. Require that every delivery ID be reserved atomically before async dispatch, checked post-hydration, and cleared only after acknowledgement. Use the serialized admission pattern from #234 (c9295c89) as the canonical template and add a concurrent-delivery regression test for each new path.
+
+### josereyes
+**Trajectory:** insufficient-data — Only one PR is available in the review window, providing no basis for trend assessment.
+
+**Strengths:**
+
+**Growth areas:**
+
+### kalvinnchau
+**Trajectory:** improving — Early PRs focused on infrastructure and build plumbing with some security gaps (PR #13 cache poisoning, PR #27 release logic) that required intervention; later PRs show more deliberate correctness thinking (validated inputs in #33/#45, cache state fix in #163, feature-gating in #262) and increasingly clean automated review passes, suggesting the author is internalizing domain expectations over the window.
+
+**Strengths:**
+- Release pipeline ownership and cross-platform packaging: consistently drives macOS signing, Windows build bootstrapping, provenance forwarding, and guarded release workflows with attention to correctness across OS targets (consistent) — *https://v2.tauri.app/distribute/sign/macos/*
+- Incremental correctness fixes with targeted regression coverage: PRs such as #163 (provider model cache) and #255 (sidebar session visibility) ship narrow, well-scoped fixes accompanied by discriminating tests that cover the failure mode (consistent)
+- Security-aware input validation at feature boundaries: PRs #33 (marketplace slug rejection) and #45 (doctor/agent-setup dispatch gating) show deliberate enforcement of trust boundaries before acting on external or user-supplied input (consistent) — *https://v2.tauri.app/security/*
+- Dependency and vulnerability hygiene: PR #4 patches Mermaid CVEs promptly and #236 keeps React/TypeScript dependencies current, indicating awareness of supply-chain health (emerging)
+- Responsive to review feedback: in PRs #27 and #163 the author engages directly with blocking findings, comments on resolution commits, and the reviewer confirms fixes — demonstrating a reliable close-the-loop habit (consistent)
+
+**Growth areas:**
+- CI workflow security — cache poisoning and artifact integrity: PR #13 received two automated zizmor findings flagging runtime artifacts vulnerable to cache poisoning in release.yml, both dismissed without visible remediation discussion in this window (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** Review the zizmor findings in PR #13 against the Tauri security model for the IPC and build pipeline trust boundary. Concretely: pin all third-party GitHub Actions to a full commit SHA, use `cache: false` or a cache key scoped to the exact lockfile hash for release-critical steps, and add a `permissions: contents: read` ceiling at the workflow level. Pair with a read of the GitHub Actions hardening guide and schedule a 30-min walk-through of the release.yml with a senior engineer who can review the artifact provenance chain end-to-end.
+- Release script race conditions and correctness under concurrent state: PR #27 required two blocking P1 findings (local tag truncation, stale main snapshot during approval window) before merging. Both were logic-level correctness gaps in the release orchestration script rather than surface bugs (occasional)
+  → **Support:** Before authoring release-critical scripts, write the state-machine invariants as comments first (what must be true at each decision point), then code to them. For git-based orchestration specifically: always filter tag lookups against the remote ref namespace (`git ls-remote --tags origin`) rather than local state, and re-snapshot any shared mutable state (e.g., `origin/main`) immediately before any user-approval gate. Consider adding a dry-run mode with assertion checks so the script can be tested in CI without actually publishing.
+- Tauri capability and permission scoping: across the 28 PRs there is no evidence of capability audits or least-privilege reviews when adding new native commands (e.g., #45 doctor dispatch, #265 folder attach/detach). Capabilities are not mentioned in PR descriptions or review threads (consistent) — *https://v2.tauri.app/security/capabilities/*
+  → **Support:** For every PR that adds or modifies a Tauri command, include a checklist item: 'Does this command require a new capability? Is the scope the minimum needed?' Read https://v2.tauri.app/security/capabilities/ and https://v2.tauri.app/security/permissions/ and map each new IPC surface to an explicit capability entry. Ask a reviewer to confirm the capability file diff as part of the standard review. Over the next two sprints, audit existing commands against declared capabilities to identify any over-permissioned surfaces.
+- Playwright / end-to-end test coverage accompanying UI changes: PRs #238 (Unity Catalog model names in chat composer), #255 (sidebar 'View all chats'), and #266 (model picker recency ordering) ship UI-visible behavior changes; no Playwright specs are mentioned in review threads for these (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Adopt a personal rule: any PR that changes a user-visible component or interaction flow must include at least one Playwright test that exercises the new state from a user action. Read https://playwright.dev/docs/best-practices, focusing on the 'test user-visible behavior' and 'use locators' sections. Start by adding a Playwright spec retroactively for PR #255's hasMoreSessions branch (the unit test is there but no E2E is referenced) — use it as a template for future UI PRs. Discuss with the team whether a CI gate requiring a Playwright coverage delta for UI-touching PRs would be appropriate.
+- Accessibility consideration for new UI surfaces: no WCAG or accessibility review signal appears across any of the UI-facing PRs (#238, #255, #266, #263) in this window (consistent) — *https://www.w3.org/TR/WCAG22/*
+  → **Support:** When adding or modifying interactive UI components (model picker, sidebar list, chat composer), run the axe-core accessibility linter in the Playwright test suite and check that new elements carry appropriate ARIA roles and labels. Reference WCAG 2.2 Success Criteria 1.3.1 (Info and Relationships) and 4.1.2 (Name, Role, Value) as a minimum bar. Add `@axe-core/playwright` to the E2E suite and include an accessibility assertion in at least one test per UI PR going forward.
+
+### kennylauren
+**Trajectory:** insufficient-data — Only one PR is available in the review window, providing no chronological signal to assess directional growth.
+
+**Strengths:**
+- UI polish and visual consistency — unifying hover states, dropdown surfaces, and border radii across components shows attention to cohesive design system implementation (emerging)
+
+**Growth areas:**
+
+### loganj
+**Trajectory:** improving — Early PRs (#17, #64, #65) required multiple blocking reviewer cycles to resolve race conditions and spec-precision issues, while later PRs (#86, #97 final) show loganj proactively adding normalization and telemetry documentation, with AI-assisted self-review (Carl/Princess Donut) catching regressions before human reviewers, indicating measurable improvement in pre-submission diligence.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: loganj consistently addresses blocking findings across multiple review cycles, often within the same PR thread, and verifies fixes are confirmed resolved before merge. (consistent)
+- Telemetry disclosure ownership: authored TELEMETRY.md (PR #86) to document telemetry behavior, demonstrating awareness of the published policy requirement for transparency. (emerging) — *https://github.com/block/berd*
+- TypeScript/React feature decomposition: IPC tool-call classification (subagentToolCalls.ts) and session-controller hook work show structured decomposition of complex async state into typed, discrete activities. (consistent)
+- Persistence/schema migration awareness: when prompted, loganj correctly introduced normalization for retired persisted IDs in PR #97, demonstrating understanding of versioned local-state compatibility. (emerging)
+
+**Growth areas:**
+- Forward-compatibility of persisted schema changes: In PR #97, loganj's initial removal of catalog IDs omitted migration/normalization for existing persisted onboarding records, requiring a blocking reviewer catch before the fix was added. This pattern — deleting identifiers without a backward-compat path — risks data loss for established users. (consistent)
+  → **Support:** Before merging any change that removes or renames an ID from a persisted store, require a written migration plan in the PR description covering: (1) how existing records are normalized on first read, (2) a test fixture that loads a v1 record with the old ID and asserts correct hydration. Pair with a reviewer checklist item that explicitly asks 'Does any persisted schema consumer reference this ID?' modeled after the Tauri capability/permission removal pattern (https://v2.tauri.app/security/capabilities/).
+- Race condition analysis in async state transitions: PR #64 required two P1 catches (migration racing active draft saves, stale path after promotion) that loganj did not anticipate. PR #78 (cancel superseded builder preparation) was dismissed, suggesting concurrent lifecycle paths are a recurring blind spot. (consistent) — *https://react.dev/reference/rules/rules-of-hooks*
+  → **Support:** Adopt a pre-PR self-review step for any async session or queue code: draw a concurrency diagram (even informal) listing every interleaved write path and the shared state they touch. Apply the Rules of Hooks mental model — effects must not depend on stale closures — to Rust/TS IPC callbacks as well. Consider adding a concurrent-path section to PR descriptions for session-lifecycle changes, prompting reviewers to verify each path independently.
+- Law/spec precision in documentation: PR #65 had two P1 findings from automated review about weakened contract wording — changing an if-and-only-if readiness definition to a one-directional 'only when' and loosening attempt-scoped outcome semantics — indicating that spec edits are not being reviewed against the original invariants before submission. (occasional)
+  → **Support:** When editing behavioral law documents (LAWS/CHAT.md or similar), diff the new wording against the old contract for each invariant and annotate in the PR whether the change is intentionally weakening, strengthening, or preserving the contract. Request a dedicated law-review pass from a second engineer before merge, distinct from implementation review.
+- Proactive Playwright/end-to-end test coverage for UI changes: PR #118 was explicitly a test-alignment fix (smoke assertions), but the pattern across PRs shows tests lagging behind behavioral changes rather than accompanying them, requiring reactive catch-up PRs. (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Apply Playwright best-practice guidance: each PR that changes a user-visible session state or queue behavior should include or update at least one Playwright spec exercising the new path with a stable, role-based locator. Make this a PR template checklist item. Use the smoke-test pattern from PR #118 as the baseline fixture style, and extend it per feature rather than in separate catch-up PRs.
+
+### matt2e
+**Trajectory:** improving — Early PRs (#14, #15, #61, #62) merged cleanly with minimal review friction; the complex telemetry PR (#16) required multiple review rounds but the author engaged substantively with each finding and resolved blocking issues; the most recent PRs (#179, #254) show faster resolution of blocking findings and a proactive security fix, suggesting the author is internalizing reviewer feedback.
+
+**Strengths:**
+- Responsive iteration under review pressure: when blocking findings are raised, the author addresses them in follow-up commits within the same PR cycle rather than abandoning or deferring (visible in PR #16 telemetry and PR #179 artifact viewer). (consistent)
+- Dependency hygiene and supply-chain awareness: proactively bumping a transitive js-yaml override to patch a known CVE (PR #254) with a clean, focused change and no collateral churn. (emerging) — *https://github.com/EmbarkStudios/cargo-deny*
+- IPC and session-lifecycle correctness: PRs #61 and #62 show clean reasoning about async session state (queuing messages until session creation completes, migrating deletion to a typed standard method), with approvals requiring no significant changes. (consistent) — *https://v2.tauri.app/security/*
+- Scoped, well-described commits: each PR is narrowly focused (build optimization, SDK regeneration, one bug fix, one refactor) rather than bundling unrelated changes. (consistent)
+
+**Growth areas:**
+- Trust-boundary hardening on Tauri commands: the telemetry command (PR #16) accepted an unbounded renderer-supplied string body and did not constrain the effective port on the gateway allowlist, exposing the native layer to renderer-driven overreach. These are canonical IPC trust-boundary gaps. (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** Before landing any new `#[tauri::command]` that accepts free-form strings or URLs from the renderer, apply the Tauri security checklist: (1) validate and clamp string lengths at the command boundary, (2) parse URLs fully and assert scheme + host + port against an explicit allowlist. Review https://v2.tauri.app/security/ and https://v2.tauri.app/security/capabilities/ specifically for the principle that the renderer is an untrusted origin.
+- Telemetry consent lifecycle correctness: PR #16 accumulated multiple blocking findings across several review rounds — consent revocation not stopping pending exports, the Windows rename-over-existing-file path (disputed but worth pre-checking), and onboarding advancing before the consent save completed. These are repeating within the same PR rather than caught before submission. (consistent) — *https://github.com/block/berd*
+  → **Support:** Before opening telemetry-related PRs, run through the berd TELEMETRY.md policy checklist explicitly: confirm that (a) opt-out is checked at every async suspension point in the export path, not only at entry, (b) consent writes are awaited before any UI navigation that depends on them, and (c) feature flags are symmetric across all target platforms (Windows parity for Cargo features). Draft a short internal checklist derived from https://github.com/block/berd and attach it to the PR description for reviewer orientation.
+- Cross-platform build integration: PR #16 introduced a Cargo feature for enforced telemetry that was present on Unix/macOS but omitted from the Windows build target, causing a blocking build-integration finding. Platform-conditional Cargo features require explicit verification on all targets before opening a PR. (occasional) — *https://v2.tauri.app/reference/config/*
+  → **Support:** Add a CI matrix step that builds the Rust crate with `--target x86_64-pc-windows-msvc` (or equivalent) whenever Cargo.toml or feature flags change. Locally, run `cargo check --target <windows-target>` before pushing. Consult the Tauri config reference (https://v2.tauri.app/reference/config/) to confirm that tauri.conf.json and Cargo feature sets are symmetric across all bundler targets.
+- Presentation-timeout discipline in async React effects: PR #179's artifact viewer left native filesystem awaits (statFile, readTextFile) without any timeout, causing a potential permanent loading state. The fix was supplied after reviewer escalation rather than anticipated. (occasional) — *https://react.dev/reference/rules*
+  → **Support:** For any React effect that awaits a Tauri command, establish a project-standard wrapper (analogous to the `withPresentationTimeout` introduced in PR #179) and use it consistently from the first commit. Review the Rules of React (https://react.dev/reference/rules) section on effect cleanup and the Playwright best practices guide (https://playwright.dev/docs/best-practices) for writing tests that detect stalled loading states — a timeout-aware Playwright assertion would have caught this class of bug before human review.
+- Onboarding cohort edge-case hardening: PR #16's onboarding path treated IPC failures, timeouts, and corrupt metadata as the 'unknown' cohort, which then entered the first-run flow incorrectly. Indeterminate states were not distinguished from affirmative known states. (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** When writing cohort or onboarding detection logic, enumerate all result states explicitly — success, known-failure, and indeterminate (timeout, IPC error, corrupt data) — and handle each with a distinct code path. Add a Playwright test that simulates a command failure or timeout at the IPC boundary (using Playwright's route interception or a mock Tauri backend) to verify that indeterminate states fall through to a safe default rather than triggering onboarding. See https://playwright.dev/docs/best-practices for guidance on mocking native backends in desktop E2E tests.
+
+### morgmart
+**Trajectory:** improving — Chronologically, the author moved from straightforward UI fixes and doc work toward more architecturally complex contributions (connection organization refactor, canvas graduation, Windows instance deduplication) and demonstrated improving review engagement quality, though test coverage and pre-submission edge-case analysis remain consistently underdeveloped throughout the window.
+
+**Strengths:**
+- UI polish and visual fidelity — consistently delivers pixel-level fixes (virtual transcript measurement, anchor stabilization, queued pill visibility, DMG artwork, text labels) that reflect strong attention to the rendered desktop experience (consistent)
+- Responsive to review feedback — in PR #76 the author responded substantively to two inline concerns, explained intentional design decisions clearly, and followed up with a verified commit, demonstrating good review collaboration (consistent)
+- macOS packaging and distribution awareness — authored both a DMG artwork improvement (PR #52) and a stable latest-installer publishing workflow (PR #69), showing familiarity with the macOS distribution pipeline (consistent) — *https://v2.tauri.app/distribute/sign/macos/*
+- Platform-specific native behavior — PR #237 (prevent duplicate instances on Windows by focusing existing window) demonstrates correct OS-level window management handling, a non-trivial desktop concern (emerging) — *https://v2.tauri.app/security/*
+- Queue and session state management — PRs #35, #51, and #68 form a coherent series stabilizing send-queue behaviour around session start, demonstrating the ability to reason through async IPC-adjacent state machines (consistent)
+
+**Growth areas:**
+- Regression awareness and edge-case coverage — PR #76 had two meaningful reviewer catches (duplicate-presentation of local extensions, orphaned migration banner mount point) that were not caught before submission, and PR #47 (preserve transcripts after invalid replay refreshes) suggests replay edge cases are discovered reactively rather than proactively considered (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Before each PR, write a short checklist of invariants the change could break (e.g., 'does any existing filter now run twice?', 'does every conditional render have its only mount point preserved?'). Back new UI-state changes with at least one Playwright test that exercises the regression scenario; the Playwright best-practices guide's section on testing user-visible behavior is the right starting point.
+- Test accompaniment for UI changes — across 18 PRs touching composer focus (PR #128), popover dismissal (PR #156), queued pills (PR #51), and virtual transcript measurement (PR #46), there is no visible evidence of Playwright specs being added or updated alongside the changes (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Adopt a personal rule: every PR that changes interactive UI behaviour ships with at least one Playwright locator-based assertion covering the happy path and, where the PR is itself a fix, a regression assertion that would have caught the original bug. Use Playwright's getByRole/getByLabel locators rather than CSS selectors to keep tests accessible-query-aligned.
+- Accessibility signal — PRs touching focus management (PR #128 — return focus to composer after closing pickers) and dismissal behaviour (PR #156) are directly in WCAG focus-management territory, but there is no evidence that ARIA roles, focus traps, or keyboard navigation were validated (consistent) — *https://www.w3.org/TR/WCAG22/*
+  → **Support:** For any PR that moves focus programmatically or opens/closes overlays, add a note in the PR description confirming keyboard-only navigation was tested and that focus returns to a logical element (WCAG 2.4.3 Focus Order, 2.1.1 Keyboard). Use Playwright's keyboard() API in tests to assert focus destination after picker close.
+- State ownership and dead-code hygiene — the PR #76 review surfaced that `disabledExtensions`, `bannerDismissedAt`, and `dismissBanner` became unused after the refactor, indicating that state ownership changes are not always traced to their full removal (occasional) — *https://typescript-eslint.io/rules/*
+  → **Support:** Enable the `@typescript-eslint/no-unused-vars` rule (error level) in the project's ESLint/Biome config and run it locally before pushing; this would have surfaced the orphaned state bindings mechanically. When refactoring a component's data dependencies, do a quick 'find all references' pass on every prop and store subscription you remove.
+- IPC and Tauri command design visibility — several PRs (queue sends during session start PR #68, preserve transcripts PR #47) touch logic that bridges the frontend and the Rust backend, but PR descriptions and review threads contain no discussion of input validation, typed payloads, or capability scope, making it impossible to confirm the trust boundary is being respected (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** When a PR touches or introduces a Tauri invoke() call, add a PR description section explicitly naming the command, its expected payload type, and which capability/permission scope it requires. Review the Tauri security model (https://v2.tauri.app/security/) and capabilities docs to confirm no new capability was silently broadened; make this a checklist item on your PR template.
+
+### mrohan-sq
+**Trajectory:** insufficient-data — Only one PR is available in the review window, making it impossible to assess directional trends.
+
+**Strengths:**
+
+**Growth areas:**
+- CSS layout precision for table containment: applying overflow-wrap without accounting for how automatic table layout computes intrinsic minimum column widths, leaving horizontal overflow unresolved for long unbroken tokens (URLs, paths, identifiers) (occasional)
+  → **Support:** Before shipping table scroll fixes, verify the full containment chain: set `table-layout: fixed` on the <table> element and an explicit `width` constraint on the containing block, then pair `overflow-wrap: break-word` with `word-break: break-all` (or `min-width: 0` on flex/grid ancestors) and confirm in a Playwright test that a cell containing a 200-character unbroken URL does not cause horizontal scroll. Review MDN's table-layout documentation and test in both the system WebView (macOS WKWebView, Windows WebView2) since rendering subtleties differ across Tauri's webview targets.
+
+### nathan-thillairajah
+**Trajectory:** improving — PR #38 required six blocking-findings rounds and multiple credential-safety regressions, but PRs #270 and #271 passed automated security review cleanly on first submission, indicating the author has absorbed the core trust-boundary and authentication-flow patterns from the earlier intensive feedback cycle.
+
+**Strengths:**
+- Responsive iteration on security findings: across PR #38's many review cycles, the author consistently addressed each blocking finding and produced working fixes, including restoring removed test coverage, removing dangerous Cargo features, and tightening credential handling. (consistent) — *https://v2.tauri.app/security/*
+- IPC trust-boundary awareness at the design level: PRs #270 and #271 received clean automated approvals, showing the author has internalized the pattern of building authenticated, typed command flows without introducing new trust-boundary gaps. (emerging) — *https://v2.tauri.app/security/*
+- Structured credential flow design: after guidance, the author correctly threaded verified credentials through the call stack without re-reading storage, demonstrating growing understanding of TOCTOU risks in authentication paths. (emerging) — *https://rust-lang.github.io/api-guidelines/*
+
+**Growth areas:**
+- Trust-boundary isolation of test infrastructure: PR #38 repeatedly introduced test helpers (Cargo features, DNS overrides, environment-variable transport overrides, embedded CAs) that were compilable into release binaries and accepted arbitrary credential recipients. This pattern appeared across at least five separate review rounds. (consistent) — *https://v2.tauri.app/security/*
+  → **Support:** Before writing any test shim that touches credentials or network destinations, require the author to sketch how the shim is gated (cfg(test), dev-dependencies only, never a public Cargo feature) and have a senior reviewer sign off on the boundary before implementation. Pair-program one session on the Rust cfg(test) / dev-dependency model and walk through the Tauri security docs section on capability scoping so the principle generalises from Tauri capabilities to any trust-controlling gate.
+- Proactive removal of test coverage during refactors: PR #38 deleted successful built-binary end-to-end tests in multiple successive commits, only restoring them after a blocking review finding each time. This suggests the author does not yet treat test preservation as a first-class constraint during refactoring. (consistent) — *https://playwright.dev/docs/best-practices*
+  → **Support:** Establish a personal pre-PR checklist item: run the full test suite locally and confirm no previously-passing process-level or e2e tests have been removed or skipped without an explicit replacement. Introduce a CI gate (e.g., a test count assertion or a required-tests manifest) so deletion is caught automatically. Review Playwright best practices on test durability as an analogue for the Rust integration test layer.
+- Input validation at trust ingress points: PR #38 required multiple rounds to produce loopback-URL validation that rejected remote IPs, HTTPS schemes, localhost names, userinfo, path, query, and fragment. The author reached the correct solution but only after successive reviewer-identified gaps, indicating the author is not yet systematically enumerating the attacker-controlled input surface before writing validation logic. (consistent) — *https://v2.tauri.app/security/capabilities/*
+  → **Support:** Adopt a threat-modelling micro-step for every function that accepts an externally-supplied URL or path: write a comment block listing what an attacker controls and enumerate at least five invalid cases before writing the validator. Reference the Tauri capabilities docs as a model for the principle of minimum allowable surface, and study the Rustonomicon chapter on working with untrusted input to build the habit of explicit enumeration over implicit trust.
+- Credential hygiene in response handling: the author introduced a response-sanitization pass but initially implemented it in a way that could silently collapse distinct object keys when both contained the session token. The gap required an additional review round. (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** When writing any data-transformation that touches credential material, add a property-based or table-driven test that specifically covers collision cases (two keys that map to the same sanitized form) before submitting. Review the Tauri security trust-boundary docs to reinforce why silent data loss in sanitization paths is a security property, not just a correctness one.
+
+### tirsen
+**Trajectory:** insufficient-data — Only two PRs are present and both received approval with strong security-boundary praise, but the sample is too small to distinguish a trend from a baseline.
+
+**Strengths:**
+- IPC and trust-boundary discipline: reviewer notes explicitly praise exact HTTPS GitHub URL validation, canonical URL reconstruction, and shell-free bounded `gh` invocations across both PRs (consistent) — *https://v2.tauri.app/security/*
+- Subprocess and input validation hygiene: SQL parameterization, prompt disabling, bounded timeouts, and typed IPC payloads noted positively in both reviews (consistent) — *https://v2.tauri.app/security/permissions/*
+- Coherent state and UI refactoring: scroll/state-dir refactors described as coherent, suggesting clean React component and state management practices (emerging) — *https://react.dev/reference/rules*
+
+**Growth areas:**
+- Feature flag / experiment gating before default rollout: PR #113 required the reviewer to withdraw approval and re-approve only on the condition that the PR tracker feature is not default-on for all users, indicating the author shipped or proposed a significant feature without a gating strategy (occasional)
+  → **Support:** Before landing non-trivial new UI surfaces, explicitly document the rollout plan (capability-scoped, experiment-gated, or opt-in) in the PR description. Review Tauri capabilities docs to scope new IPC commands behind explicit, minimal capability grants so features can be enabled per-build or per-user rather than globally; see https://v2.tauri.app/security/capabilities/.
+
+### tulsi-builder
+**Trajectory:** improving — The only substantive review friction appeared in the earliest PR in the window (PR #41) and was fully resolved within that PR; the three subsequent PRs all earned direct approvals, suggesting the author is building reviewer trust and shipping cleaner work over this short window.
+
+**Strengths:**
+- Responsive to review feedback: blocking race condition identified in PR #41 was diagnosed, fixed, and regression-covered within the same PR cycle without requiring a second round of substantive review (emerging)
+- Iterative UI/UX work across multiple PRs (avatar affordances, custom avatars in chat, agent routing) ships cleanly and earns direct approvals without substantive change requests, suggesting solid React component and routing discipline (consistent) — *https://react.dev/reference/rules*
+
+**Growth areas:**
+- Concurrency correctness at the IPC/hook boundary: PR #41 shipped a queue-replay race where overlapping window-close events could trigger multiple reclaim refreshes against stale session state, a class of bug that is particularly risky in Tauri apps where the webview lifecycle and native backend state can diverge (occasional) — *https://v2.tauri.app/security/*
+  → **Support:** Before opening PRs that touch background drain hooks or any logic that runs across webview window lifecycle events, author should trace every async path for overlapping invocation: draw a sequence diagram covering concurrent callers and verify a single serialized mutex or queue guards shared state. Review the Tauri security model's trust-boundary guidance to understand why stale-queue replays can surface as both a correctness and a security issue when queued messages contain sensitive payloads. Pair with a senior reviewer on the first two background-task PRs to build the habit of writing the race scenario as a test before writing the fix.
+- Internationalization completeness: PR #41 added new user-visible strings (failure toast title and message) only to the English locale, leaving the Spanish catalog incomplete until review caught it (occasional)
+  → **Support:** Add a local lint step (or expand the existing test gate) that asserts all locale catalogs contain identical key sets, so a missing translation is a CI failure rather than a reviewer catch. Author should adopt a personal checklist item: any PR that adds a key to any locale file must diff every other supported locale file in the same commit. The focused locale coverage added in ce14a6e9 is the right pattern — make it the default starting point, not a remediation step.
+
+---
+
+## 4. Team Gap Analysis
+
+### Where the team is strong
+| Area | Evidence | Standard |
+|------|----------|----------|
+| Release pipeline integrity and updater signing discipline | Multiple signals show annotated-tag binding to verified merge commits, updater public-key sourced from repository secrets, commit reachability checks before tagging, and lockstep version synchronization across package.json/Cargo/Tauri config — all reviewed by matt2e on kalvinnchau's work. | https://v2.tauri.app/plugin/updater/ |
+| IPC boundary input validation in the Rust core | loganj explicitly called out subprocess/IPC-validation/SQL-parameterization/timeout/URL-boundary work as 'unusually careful'; a subsequent signal confirms exact HTTPS GitHub host and PR path shape validated before invoking `gh`, preventing canonicalization bypass from webview-supplied URLs. | https://v2.tauri.app/security/ |
+| Correctness-focused review of subtle lifecycle and state-machine bugs | caregullin caught debounce-flush-on-unmount races, mention/range-rewrite precision, and rejection-bounding gaps. comp615 flagged concurrent-instance state-ownership races. Both are high-signal, domain-appropriate findings. | — |
+| Unit test density for new features | 49 Vitest tests and 3 Rust tests shipped with the PR-tracker feature; loganj explicitly enumerated them as a positive. The team clearly expects test coverage alongside features. | — |
+| Experiment-gate discipline before broad feature rollout | loganj conditioned approval on the polling feature not being default-on, requiring an experiment gate to control blast radius — a mature product-engineering practice. | — |
+
+### Gaps and blind spots
+| Area | Gap Type | Missing Standard | Recommendation |
+|------|----------|-----------------|----------------|
+| Playwright E2E coverage for new UI surfaces | knowledge_gap | https://playwright.dev/docs/best-practices | Add a PR-template checklist item requiring Playwright test evidence for any new interactive UI surface (popover, dialog, panel). Gate merge on the checklist being checked. The absence of E2E for the new PR-tracker popover was noticed by loganj but not blocked — elevate this to a checklist rule so it is not left to per-reviewer memory. |
+| Unsafe block justification and unsafe growth in the dependency tree | blind_spot | https://doc.rust-lang.org/nomicon/ | Add cargo-geiger to CI and configure it to fail or warn on unsafe-count regressions. Add a CONTRIBUTING checklist item requiring SAFETY comments on every new unsafe block. Train reviewers to flag unsafe blocks without soundness rationale during code review. |
+| Dependency supply-chain hygiene — advisory and license auditing for both npm and crates | blind_spot | https://github.com/EmbarkStudios/cargo-deny | Introduce cargo-deny with deny.toml covering advisories, licenses, and duplicate crates as a CI gate. Add npm audit or Socket.dev to the frontend pipeline. Neither appears in the review record at all across 159 PRs — this is a full coverage gap at the tooling level and must be addressed with ci-gate additions, not just reviewer awareness. |
+| CSP configuration review — unsafe-inline/remote source scrutiny in tauri.conf.json | blind_spot | https://v2.tauri.app/security/csp/ | Add a checklist item to the PR template: 'Does this PR change tauri.conf.json CSP or add remote URLs? If so, has the CSP been reviewed for unsafe-inline and remote-source allowances?' Run a one-time audit of the current CSP and document the rationale for any existing relaxations. No reviewer in the window touched CSP. |
+| Capability minimality — per-window permission scoping and deny-by-default review | knowledge_gap | https://v2.tauri.app/security/capabilities/ | Although tauri-capabilities files exist (institutionalized gate), no reviewer comment in the window challenges whether a capability scope is broader than necessary or whether a new command should have a narrower allow list. Add a review checklist prompt: 'For new Tauri commands, is the capability scoped to the minimum required window and path?' Train reviewers on the deny/scope pattern in Tauri v2 capabilities. |
+| React effect dependency hygiene and cleanup beyond what Biome catches | knowledge_gap | https://react.dev/reference/rules/rules-of-hooks | caregullin's debounce-cleanup comment addresses runtime correctness but is not framed as an effect-dependency or Rules of Hooks violation. Biome enforces the static rules deterministically, but dynamic correctness (stale closures, missing cleanup for subscriptions, effect re-runs from unstable dependencies) requires human review. Add a checklist item for effects with timers, subscriptions, or async operations and run a team workshop on common stale-closure patterns. |
+| Accessibility beyond Biome a11y static rules — keyboard operability and ARIA semantics | blind_spot | https://www.w3.org/TR/WCAG22/ | No review comment in the window touches keyboard navigation, focus management, or ARIA roles for new interactive surfaces (popover, PR-tracker panel, scroll container). Biome's a11y rules cover static markup but not focus-trap correctness, keyboard shortcuts, or dynamic ARIA updates. Add axe-core to the Playwright test suite for automated WCAG 2.2 AA checks, and add a checklist item for new interactive surfaces requiring manual keyboard-operability verification. |
+| Telemetry event review against published policy — path sanitization, identifier hashing, opt-out | blind_spot | https://github.com/block/berd | No reviewer in the window comments on telemetry event payloads, raw-path inclusion, or opt-out compliance. Given the PR-tracker and work-status features likely emit new events, add a checklist item: 'Do new telemetry events comply with TELEMETRY.md — no raw paths, identifiers hashed, opt-out honored?' Assign a privacy-policy owner to review any PR that touches telemetry instrumentation. |
+| Per-platform sidecar packaging and target-triple correctness | blind_spot | https://v2.tauri.app/reference/config/ | No review comment across the window addresses externalBin target-triple coverage, per-platform config merges, or bundle resource completeness. Add a checklist item for PRs that add or change sidecar binaries or bundle resources: 'Is this binary staged for all supported target triples (x86_64-apple-darwin, aarch64-apple-darwin, x86_64-pc-windows-msvc)?' Consider adding a CI matrix smoke-test that verifies bundle artifact presence for each platform. |
+| macOS notarization and Windows code-signing review for release artifacts | knowledge_gap | https://v2.tauri.app/distribute/sign/macos/ | The updater public-key discipline is strong (institutionalized via secrets), but no reviewer comment addresses macOS notarization status, Windows Authenticode signing, or release-channel promotion gates beyond the tag workflow. Add a release-checklist step confirming notarization receipt from Apple and Authenticode timestamp validity before marking a release as stable. Cross-train at least two team members on the signing pipeline. |
+
+### Review culture
+The team exhibits a mature release-engineering culture with strong investment in updater signing, tag integrity, and version synchronization, and individual reviewers (loganj, caregullin, comp615) demonstrate high-signal correctness reviews on subtle race conditions and lifecycle bugs. However, the review record has large structural blind spots — supply-chain hygiene, CSP, telemetry privacy, accessibility beyond static linting, and per-platform packaging — where no reviewer commented across 159 PRs, indicating these dimensions are entirely left to tooling that either does not exist yet or is insufficient. The gap between the team's depth on correctness and its shallowness on security-adjacent and platform-specific concerns is the most actionable finding: closing it requires targeted tooling additions (cargo-deny, axe-core, packaging matrix) plus explicit PR-template checklist items rather than reviewer training alone.
+
+---
+
+## Methodology & Caveats
+
+- **Window:** 2026-08-12 → 2026-09-02 | **PRs analyzed:** 159 | **PRs skipped (no reviews):** 0
+- **Lens:** product-engineering-desktop (v1, experimental)
+- **Tooling gates present:** biome, tsc, playwright, vitest, lefthook, tauri-capabilities
+- **What this analysis cannot see:** verbal review culture (Slack), reviewer availability constraints, domain ownership, or PRs merged without review.
+
+---
+
+## Appendix: Reference Standards
+
+- **Security (trust boundaries and the IPC layer)**: https://v2.tauri.app/security/
+- **Capabilities**: https://v2.tauri.app/security/capabilities/
+- **Permissions**: https://v2.tauri.app/security/permissions/
+- **Content Security Policy (CSP)**: https://v2.tauri.app/security/csp/
+- **Configuration (tauri.conf.json reference)**: https://v2.tauri.app/reference/config/
+- **Updater plugin**: https://v2.tauri.app/plugin/updater/
+- **macOS Code Signing**: https://v2.tauri.app/distribute/sign/macos/
+- **Windows Code Signing**: https://v2.tauri.app/distribute/sign/windows/
+- **Rust API Guidelines**: https://rust-lang.github.io/api-guidelines/
+- **Clippy lint catalog**: https://doc.rust-lang.org/clippy/lints.html
+- **The Rustonomicon**: https://doc.rust-lang.org/nomicon/
+- **Lint Levels (rustc book)**: https://doc.rust-lang.org/rustc/lints/levels.html
+- **cargo-deny**: https://github.com/EmbarkStudios/cargo-deny
+- **cargo-geiger**: https://github.com/geiger-rs/cargo-geiger
+- **Biome linter and rule catalog**: https://biomejs.dev/linter/
+- **typescript-eslint rules**: https://typescript-eslint.io/rules/
+- **Rules of React**: https://react.dev/reference/rules
+- **Rules of Hooks**: https://react.dev/reference/rules/rules-of-hooks
+- **Playwright Best Practices**: https://playwright.dev/docs/best-practices
+- **Web Content Accessibility Guidelines (WCAG) 2.2**: https://www.w3.org/TR/WCAG22/
+- **block/berd TELEMETRY.md and README** *(secondary)*: https://github.com/block/berd

--- a/tricorder/2026-09-04-anthropics__claude-cookbooks.md
+++ b/tricorder/2026-09-04-anthropics__claude-cookbooks.md
@@ -1,0 +1,252 @@
+---
+date: 2026-09-04
+repo: anthropics/claude-cookbooks
+window: 2026-06-09 → 2026-09-03
+pr_count: 24
+contributors: ['Briiick', 'PedramNavid', 'aravind-ant', 'benlehrburger-ant', 'bradabrams', 'cj-ant', 'mattmccarley-ant', 'mengtingli-ant', 'mohammaddaoudfarooqi', 'nikblanchet', 'paulchen-go']
+visibility: private
+generated_by: tricorder v1.1.0
+lens: agent-engineering
+---
+
+# PR Review Analysis — anthropics/claude-cookbooks — 2026-09-04
+
+> Window: 2026-06-09 → 2026-09-03 | 24 PRs | 11 contributors
+
+---
+
+## 1. Patterns Ready to Institutionalize
+
+| Pattern | Category | Current Maturity | Next Step | Standard |
+|---------|----------|-----------------|-----------|----------|
+| PR checklist for cookbook submissions (problem statement, expected outputs, local testing, registry entry) | — | guidance | Convert checklist items into required fields enforced by a GitHub Actions PR template validator that blocks merge if boxes are unchecked; remove the current pattern of approving despite unchecked items. | rule |
+| Notebook execution CI gate (fail job when changed notebook errors) | — | convention | Extend the gate to assert on output content for agent notebooks — at minimum that the final cell output matches an expected structure — promoting it from 'runs without crashing' to 'produces correct outputs'. | deterministic |
+| Task budget / iteration guard as an explicit configuration parameter in agentic loops | — | judgment | Codify as a repository convention in a CONTRIBUTING or agent-authoring guide: all agentic loop examples must expose max_iterations or equivalent and document the escalation path. Add a lint rule that flags loop constructs lacking a guard. | rule |
+| Registry.yaml catalog entry required for every new cookbook | — | convention | Add a CI check that detects new notebook files not present in registry.yaml and fails the build, removing reliance on reviewer memory or checklist compliance. | deterministic |
+
+---
+
+## 1b. Oversight Density
+
+Computed from the harvested record, no model involved. In agentic development, review is where human oversight concentrates; this section shows where it does and does not land.
+
+- PRs with no human engagement (approve-only or nothing): **19 of 24**
+- Silent approvals (approve with no comment): **14 of 19**
+
+| Axis | High-stakes | PRs touching | Without any human comment | Silent share | Comments | Reviewers |
+|---|---|---:|---:|---:|---:|---:|
+
+| Reviewer | PRs | Approvals | Silent approvals | Silent share | Inline comments / PR |
+|---|---:|---:|---:|---:|---:|
+| cj-ant | 8 | 8 | 8 | 100% | 0.0 |
+| nikblanchet | 4 | 4 | 2 | 50% | 0.0 |
+
+---
+
+## 2. Reviewer Focus Fingerprints
+
+### PedramNavid
+**Style:** advisory | **Signal quality:** low — Only one PR reviewed with a single approval emoji and no substantive inline comments, providing insufficient evidence to identify real focus areas.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- Prompt scope and output contracts — No comments on system prompt boundaries, what the agent must/must not do, or explicit output format definitions in the roadtrip planner cookbook.
+- Tool description precision — No review of whether tool descriptions are sufficiently precise for the model to select and invoke them correctly.
+- Loop safety and stop conditions — Managed agent agentic loops were not scrutinized for termination conditions or runaway behavior.
+- Error handling and surfacing — No comments on how tool failures or unexpected model outputs are surfaced to the caller.
+- Testing and evals — Cookbook PR approved without any comment requesting golden traces, evals, or runnable tests of the agent behavior.
+- Security and prompt injection — No review of injection risks in user-supplied route or location inputs passed into tool calls or prompts.
+
+### cj-ant
+**Style:** advisory | **Signal quality:** low — Nearly all reviews are bare approvals with no substantive inline comments captured, making it impossible to distinguish genuine satisfaction from superficial review.
+
+**Primary focus areas:**
+- Approval throughput — most PRs are approved with minimal or no blocking comments (always)
+- Notebook execution correctness — engaged on CI job that validates changed notebooks execute cleanly (sometimes)
+- Registry metadata accuracy — noted or approved fix restoring Tools category on registry entry (sometimes)
+
+**Apparent blind spots:**
+- Prompt scope and output contracts — No comments recorded on system prompt definitions, output format constraints, or what agents must not do across any of the 8 PRs, including PRs adding full agent cookbooks (Fraud Review Agent, cost optimization, content moderation).
+- Tool description precision — PRs #754, #759, and #831 introduce agent tools and skills with no recorded feedback on tool description clarity, parameter contracts, or MCP compliance.
+- Security / prompt injection — Content moderation (PR #831) and fraud review (PR #759) cookbooks process untrusted external content; no injection-guardrail feedback was recorded on either PR.
+- Evals and golden traces — Multiple agent cookbook PRs merged with no recorded questions about evaluation harnesses, test coverage of tool outputs, or golden traces.
+- Error handling — tool failures surfaced vs. swallowed — No comments on how any of the introduced agents handle tool errors or surface failures to the caller across any reviewed PR.
+- Context management and token cost — PR #754 explicitly concerns cost optimization via coordinator patterns, yet no recorded feedback on context window pressure, prompt caching, or token budgets.
+- Loop safety and stop conditions — Agentic loop PRs (#754, #759) received no recorded scrutiny on termination conditions or runaway-loop risk.
+
+### mattmccarley-ant
+**Style:** advisory | **Signal quality:** low — A single approval with no inline comments across one PR provides no meaningful pattern to analyze.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- All agent-engineering dimensions — Only one PR reviewed, approved with a simple ship-it emoji and no substantive inline comments — insufficient signal to identify any consistent focus area.
+
+### nikblanchet
+**Style:** advisory | **Signal quality:** low — All 4 PRs were approved with emoji-only or empty commentary, providing no substantive signal about what the reviewer actually evaluated or cares about.
+
+**Primary focus areas:**
+- Rubber-stamp approval with minimal substantive review (always)
+
+**Apparent blind spots:**
+- Prompt scope and output contracts — No comments observed on system prompt boundaries, what the agent must or must not do, or output format contracts across all 4 PRs.
+- Tool description precision — PR #793 rewrites a crop/zoom tool; no inline feedback on tool descriptions, parameter contracts, or edge cases was recorded.
+- Evals and golden traces — Multiple cookbook PRs adding new agent capabilities (content moderation, managed agents, repo skills) were approved with no comments requesting eval coverage or test cases.
+- Security and prompt injection — PR #831 adds content moderation — a high-risk surface for injection — with no recorded security review per OWASP LLM Top 10.
+- Context discipline — PR #811 adds budgets, advisor, repo skills, and inference-geo cookbooks; no comments on what enters the context window or token budget concerns.
+- Loop safety and stop conditions — PR #792 covers subagent live-streaming (an agentic loop pattern); no feedback on stop conditions, runaway loop risks, or escalation paths.
+- Observability — No comments on tracing agent decisions, replayability, or logging across any of the 4 PRs.
+- Error handling — No comments on how tool failures are surfaced or swallowed in any of the cookbook implementations.
+
+---
+
+## 3. Author Growth Profiles
+
+### Briiick
+**Trajectory:** insufficient-data — Only one PR with an approval and no substantive reviewer comments is insufficient to establish any trend or pattern.
+
+**Strengths:**
+
+**Growth areas:**
+
+### PedramNavid
+**Trajectory:** insufficient-data — Only one PR in the window with no substantive review comments, providing no basis for trend analysis.
+
+**Strengths:**
+
+**Growth areas:**
+
+### aravind-ant
+**Trajectory:** insufficient-data — Only one PR with approvals and no substantive reviewer comments is insufficient to establish any pattern or trajectory.
+
+**Strengths:**
+
+**Growth areas:**
+
+### benlehrburger-ant
+**Trajectory:** insufficient-data — Only two PRs with minimal reviewer commentary are available, providing no meaningful signal to assess growth trajectory in agent engineering practices.
+
+**Strengths:**
+
+**Growth areas:**
+
+### bradabrams
+**Trajectory:** insufficient-data — Only one PR is available for review, making it impossible to establish a directional trend in the author's agent-engineering practices.
+
+**Strengths:**
+- Architectural pattern documentation: contributed a coordinator-pattern cookbook demonstrating orchestrator/subagent cost decomposition, which aligns with multi-agent design thinking around big-model planning and small-model execution (emerging) — *https://www.anthropic.com/research/building-effective-agents*
+
+**Growth areas:**
+- Eval coverage attached to prompt or pattern changes: no evidence of golden traces or benchmark results accompanying the cookbook contribution to validate that the recommended pattern actually reduces cost without degrading task success (occasional) — *https://www.anthropic.com/research/building-effective-agents*
+  → **Support:** When submitting agentic pattern cookbooks, include a small eval harness or at minimum a table of representative traces showing coordinator overhead, subagent accuracy, and end-to-end cost vs. a single-model baseline. Pair with the reviewer on defining a measurable success criterion before the PR is opened.
+- Tool and prompt contract precision: insufficient signal to assess whether the cookbook defines explicit input/output schemas, stop conditions, or negative-case handling for the coordinator loop (occasional) — *https://modelcontextprotocol.io/docs*
+  → **Support:** Add a section to the cookbook that specifies the coordinator's system prompt scope (what it must NOT do), the subagent tool descriptions with typed parameters, and an explicit stop condition or budget guard. Reference the MCP spec for tool-description best practices and ask reviewers to verify these elements as a checklist item.
+- Loop safety and error surfacing: no reviewer commentary visible on whether the coordinator pattern includes guards against runaway delegation, cost overruns, or loud failure propagation from subagents (occasional) — *https://www.anthropic.com/research/building-effective-agents*
+  → **Support:** Incorporate a 'safety considerations' section in every agentic cookbook covering: maximum delegation depth, cost/token budget enforcement, how subagent errors are surfaced to the coordinator, and what human-in-the-loop checkpoints exist. Request explicit reviewer sign-off on this section.
+
+### cj-ant
+**Trajectory:** insufficient-data — All five PRs received minimal-signal approvals with no substantive reviewer comments, making it impossible to detect improvement or regression in craft quality across the window.
+
+**Strengths:**
+- Consistent delivery of multi-agent and managed-agent cookbook examples across diverse domains (Sentry triage, road trip planner, live-streaming, repo skills, budget/advisor agents), demonstrating breadth with agentic loop patterns. (consistent) — *https://www.anthropic.com/research/building-effective-agents*
+- Iterative refinement of tool design — PR #793 explicitly rewrites a cookbook to center on a more precisely measured zoom tool, showing willingness to improve tool contracts rather than ship the first workable version. (emerging) — *https://modelcontextprotocol.io/docs*
+
+**Growth areas:**
+- Reviewer feedback is absent or minimal across all five PRs (shipit emoji approvals, no substantive review comments visible). This makes it impossible to determine whether prompt scope, negative-case handling, output contracts, or loop safety are being reviewed at all — meaning these gaps may exist undetected. (consistent) — *https://www.anthropic.com/research/building-effective-agents*
+  → **Support:** Request a structured review checklist for cookbook PRs that explicitly covers: (1) prompt scope with at least one documented negative case, (2) tool description precision and input/output contracts, (3) stop conditions and loop safety guards, (4) error surfacing strategy. Apply this to the next PR (#811 onward) so reviewers engage on substance, not just style.
+- No evidence of eval harnesses or golden traces attached to any of the five cookbook PRs. Prompt and tool changes are shipped without measurable correctness signal. (consistent) — *https://www.anthropic.com/research/building-effective-agents*
+  → **Support:** For the next cookbook PR, add a minimal eval artifact: a set of golden input/output traces or assertion-based tests that exercise the happy path and at least one failure mode. Even a small pytest fixture or a recorded trace file demonstrates the habit and gives reviewers something concrete to approve against.
+- No visible prompt-injection or adversarial input handling in examples that ingest external data (e.g., Sentry issues in PR #698, road trip data in PR #750). Cookbooks are likely copied and adapted by users, making unsafe patterns a downstream risk. (consistent) — *https://owasp.org/www-project-top-10-for-large-language-model-applications/*
+  → **Support:** Add a short 'security considerations' section to each cookbook README that calls out which inputs are untrusted, and demonstrate at least one sanitization or scoping pattern in the agent prompt (e.g., explicit system-prompt boundaries, input validation before tool invocation). Reference OWASP LLM Top 10 LLM01 (Prompt Injection) in the PR description to signal awareness.
+- Model selection rationale is not surfaced in any PR description. Cookbooks likely hardcode a model without explaining why that model is appropriate for the task complexity or cost profile. (consistent) — *https://docs.anthropic.com*
+  → **Support:** Add a one-paragraph 'Model choice' section to each cookbook README explaining why the chosen model tier (e.g., Haiku vs. Sonnet vs. Opus) fits the latency, cost, and capability requirements of the example. This disciplines the author to think about model selection as a design decision rather than a default.
+
+### mattmccarley-ant
+**Trajectory:** insufficient-data — Only one PR is available for review, providing no chronological signal to assess trajectory.
+
+**Strengths:**
+
+**Growth areas:**
+
+### mengtingli-ant
+**Trajectory:** insufficient-data — Only one PR with a single approval emoji and no substantive review comments; no evidence base exists to assess strengths, gaps, or directional change.
+
+**Strengths:**
+
+**Growth areas:**
+
+### mohammaddaoudfarooqi
+**Trajectory:** insufficient-data — Only one PR in the review window with no substantive reviewer feedback, making it impossible to assess growth trends.
+
+**Strengths:**
+
+**Growth areas:**
+
+### nikblanchet
+**Trajectory:** insufficient-data — Only two PRs are available, both approved cleanly, but the sample is too small to establish a directional trend in agent-engineering practice.
+
+**Strengths:**
+- Prompt correctness and model compatibility: identified and removed an assistant prefill that caused 400 errors on current models, demonstrating awareness of model API contracts and prompt output boundaries (emerging) — *https://docs.anthropic.com*
+- CI and test harness reliability: proactively improved the notebook-tests job to fail on execution errors, strengthening the eval and execution harness pipeline (emerging) — *https://www.anthropic.com/research/building-effective-agents*
+
+**Growth areas:**
+- Eval coverage and golden traces: neither PR includes evidence of attached eval results, golden traces, or before/after model output comparisons to validate that the metaprompt fix produces correct outputs post-change (occasional) — *https://www.anthropic.com/research/building-effective-agents*
+  → **Support:** When modifying prompt assets or removing prompt constraints (e.g., assistant prefills), attach a small set of golden input/output traces showing pre- and post-fix model responses. This can be as lightweight as appending a markdown table to the PR description with 2–3 representative prompts and their outputs, validating the fix doesn't shift intended behavior.
+- Prompt-injection and scope documentation: the metaprompt fix touches a system-level prompt asset but includes no commentary on whether the removed prefill had a safety or scope-bounding role, leaving that rationale implicit (occasional) — *https://owasp.org/www-project-top-10-for-large-language-model-applications/*
+  → **Support:** When removing or altering prompt constraints, add a brief PR description section explaining the original intent of the removed element and confirming it served no injection-guarding or output-scoping function. This establishes a reviewable audit trail for prompt asset changes.
+
+### paulchen-go
+**Trajectory:** insufficient-data — Only one PR with minimal reviewer signal (approval only, no substantive comments) is insufficient to establish any trend.
+
+**Strengths:**
+
+**Growth areas:**
+
+---
+
+## 4. Team Gap Analysis
+
+### Where the team is strong
+| Area | Evidence | Standard |
+|------|----------|----------|
+| Async multi-agent orchestration patterns with shared message hubs and dynamic subagent lifecycle management | paulchen-go's PR introduced two async multi-agent coordination patterns; reviewer maheshmurag explicitly noted the architectural substance and confirmed notebook outputs from a real top-to-bottom run | Building Effective Agents — https://www.anthropic.com/research/building-effective-agents |
+| Model-as-judge evaluation for open-ended agentic search outputs | mengtingli-ant's benchmark harness included an F1 grader for evaluating open-ended agentic outputs, signaling awareness that evals require graders beyond simple exact-match | — |
+| Task budget / iteration guard surfacing as a first-class parameter | mengtingli-ant's long-horizon agentic loop PR exposed task budget configuration explicitly, recognized by reviewer mattmccarley-ant | Building Effective Agents — https://www.anthropic.com/research/building-effective-agents |
+| Registry and documentation metadata conventions | Multiple PRs enforce registry.yaml entries and README links; cj-ant approved a dedicated fix restoring a missing Tools category on a registry entry, showing some institutional habit around catalog hygiene | — |
+| Notebook CI execution gate | cj-ant engaged on and approved PR #772 that fails the notebook-tests job when a changed notebook fails to execute, adding a lightweight correctness gate | — |
+
+### Gaps and blind spots
+| Area | Gap Type | Missing Standard | Recommendation |
+|------|----------|-----------------|----------------|
+| System prompt scope and output format contracts never reviewed — no reviewer asked whether prompts constrain what the agent must not do or define explicit output schemas | blind_spot | Anthropic model documentation and prompt engineering guide — https://docs.anthropic.com | checklist — add mandatory PR checklist items: (1) system prompt explicitly states prohibited behaviors, (2) output format is typed and documented, (3) prompt scope is narrow to stated task. Pair with a review training session using Anthropic's prompt engineering guide. |
+| Tool names, descriptions, and parameter contracts never scrutinized across any of the 24 PRs, including PRs adding MCP tools and agentic skills | blind_spot | Model Context Protocol specification — https://modelcontextprotocol.io/docs | checklist — require reviewers to verify: (1) tool names are unambiguous, (2) descriptions are self-contained for model selection, (3) all parameters are typed and documented. Add a tooling gate (e.g., a JSON schema lint on tool manifests) to enforce parameter typing deterministically. |
+| Context-window content selection, trimming, and caching never discussed — only one incidental mention of server-side compaction with no reviewer probing deliberate context design | blind_spot | Building Effective Agents — https://www.anthropic.com/research/building-effective-agents | training — run a team session on context discipline (what goes in, what gets trimmed, what should be cached). Add a convention-level checklist item for any PR touching system prompts or retrieval steps. |
+| Loop stop conditions, iteration guards, and human escalation paths never reviewed — scheduled and async agentic loops merged without any recorded scrutiny of termination logic | blind_spot | Building Effective Agents — https://www.anthropic.com/research/building-effective-agents | checklist — gate every agentic loop PR on documented answers to: (1) what is the maximum iteration count or token budget?, (2) what triggers human escalation?, (3) what terminates the loop on repeated failure? Pair with a ci-gate that rejects loops lacking a max_iterations or equivalent guard. |
+| Tool failure surfacing — no reviewer in the entire window asked how any agent surfaces errors from tool calls to the operator or to the agent itself | blind_spot | Building Effective Agents — https://www.anthropic.com/research/building-effective-agents | checklist — require every tool-using agent PR to document: (1) tool errors are returned as structured error payloads visible to the model, (2) repeated tool failures escalate rather than silently continuing, (3) operator-facing error logs exist. Consider a ci-gate that static-analyzes tool call sites for bare exception swallowing. |
+| Eval harness and golden traces absent from nearly all agent cookbook PRs — only one PR showed model-as-judge grading; the rest merged with no recorded eval coverage | coverage_gap | Building Effective Agents — https://www.anthropic.com/research/building-effective-agents | ci-gate — require that any PR introducing or modifying an agent's core prompt, tool set, or loop logic ships with at least one golden trace in a standard format (e.g., a JSON fixture under tests/evals/). The notebook-tests CI job is a start; extend it to assert on output content, not just execution success. |
+| Agent decision and tool call tracing — observability of agent runs never discussed; no reviewer asked how a failure could be replayed | blind_spot | Claude Code SDK documentation — https://docs.anthropic.com/en/docs/claude-code/sdk | convention — establish a team convention that every agent example must include or document a tracing strategy (e.g., structured logging of each tool call and response, session IDs, or integration with an observability SDK). Add a checklist item: 'agent decisions and tool calls are logged in a replayable format.' |
+| Prompt injection and adversarial input handling — content moderation and fraud review cookbooks that process untrusted external content merged with zero recorded injection-guardrail review | blind_spot | OWASP Top 10 for LLM Applications — https://owasp.org/www-project-top-10-for-large-language-model-applications/ | training + checklist — conduct a team session on OWASP LLM Top 10, specifically indirect prompt injection (LLM01). Add a mandatory checklist item for any PR where agent input originates from user-supplied or external data: 'untrusted inputs are sanitized or sandboxed before inclusion in prompts; model outputs are validated before acting on them.' |
+| Model selection rationale never documented or reviewed — no PR in the window records a reviewer asking why a specific model was chosen or whether it is pinned | coverage_gap | Anthropic model documentation and prompt engineering guide — https://docs.anthropic.com | checklist — require each agent PR to state in the description: (1) which model is used and why (capability vs. latency trade-off), (2) that the model version is pinned, not floating. This is low-cost to add to the existing PR template. |
+
+### Review culture
+The team operates in a high-throughput, low-friction mode: 19 of 24 PRs received approve-only or no engagement, and the majority reviewer (cj-ant) functions primarily as a merge facilitator rather than a substantive technical reviewer. This culture is appropriate for low-risk documentation updates but is structurally misaligned with an agent-engineering repository where prompt scope, loop safety, injection risks, and eval coverage are correctness concerns that cannot be caught by style linters alone. The single most actionable cultural change is establishing that any PR touching a system prompt, tool definition, or agentic loop requires at least one reviewer to affirmatively answer the agent-specific checklist items before approval — the current norm of approving despite unchecked boxes signals that the checklist is decorative rather than functional.
+
+---
+
+## Methodology & Caveats
+
+- **Window:** 2026-06-09 → 2026-09-03 | **PRs analyzed:** 24 | **PRs skipped (no reviews):** 0
+- **Lens:** agent-engineering (v2, experimental)
+- **Tooling gates present:** pre-commit
+- **What this analysis cannot see:** verbal review culture (Slack), reviewer availability constraints, domain ownership, or PRs merged without review.
+
+---
+
+## Appendix: Reference Standards
+
+- **Anthropic model documentation and prompt engineering guide**: https://docs.anthropic.com
+- **Model Context Protocol specification**: https://modelcontextprotocol.io/docs
+- **Building Effective Agents**: https://www.anthropic.com/research/building-effective-agents
+- **Claude Code SDK documentation**: https://docs.anthropic.com/en/docs/claude-code/sdk
+- **OWASP Top 10 for LLM Applications**: https://owasp.org/www-project-top-10-for-large-language-model-applications/

--- a/tricorder/2026-09-04-block__buzz.md
+++ b/tricorder/2026-09-04-block__buzz.md
@@ -1,0 +1,935 @@
+---
+date: 2026-09-04
+repo: block/buzz
+window: 2026-08-17 → 2026-09-03
+pr_count: 272
+contributors: ['Chessing234', 'Illuminfti', 'Maxwellimus', 'TheSentinel454', 'atishpatel', 'baxen', 'bradseiler', 'brow', 'evanchen7', 'jedwards27', 'jmecom', 'kalvinnchau', 'klopez4212', 'kruegermj', 'kursmark-sq', 'loganj', 'lucasisaza', 'mahanti', 'matt2e', 'morgmart', 'ngthuydiem', 'philazar', 'ravarora2', 'salman1993', 'tellaho', 'thomaspblock', 'tlongwell-block', 'tulsi-builder', 'wesbillman', 'wpfleger96']
+visibility: private
+generated_by: tricorder v1.1.0
+lens: product-engineering
+---
+
+# PR Review Analysis — block/buzz — 2026-09-04
+
+> Window: 2026-08-17 → 2026-09-03 | 272 PRs | 30 contributors
+
+---
+
+## 1. Patterns Ready to Institutionalize
+
+| Pattern | Category | Current Maturity | Next Step | Standard |
+|---------|----------|-----------------|-----------|----------|
+| Security review of CI/CD credential scope and untrusted-code access | — | judgment | Codify a workflow security checklist (secrets scoped to minimum jobs, no secret access in jobs that check out untrusted forks) and enforce via GitHub Actions permission audits or a reusable workflow template. | rule |
+| Deterministic regression tests for previously flaky or race-condition bugs | — | guidance | Formalize a convention: every bug fix PR must include a deterministic regression test that is red on the unfixed HEAD and green after. Document this in CONTRIBUTING.md and add it as a PR template checklist item. | convention |
+| Input validation before casting or arithmetic on externally supplied numeric values | — | judgment | Add a clippy lint gate for integer casts and panicking arithmetic in production code paths; document the pattern (validate → cast → use) in a short internal style guide entry. | rule |
+| Structured review framing: acknowledge the fix, then raise remaining gaps | — | judgment | Share Chessing234's review pattern as a named internal standard in onboarding materials and retrospective discussions to propagate it across the wider team. | convention |
+
+---
+
+## 1b. Oversight Density
+
+Computed from the harvested record, no model involved. In agentic development, review is where human oversight concentrates; this section shows where it does and does not land.
+
+- PRs with no human engagement (approve-only or nothing): **61 of 272**
+- Silent approvals (approve with no comment): **124 of 354**
+
+| Axis | High-stakes | PRs touching | Without any human comment | Silent share | Comments | Reviewers |
+|---|---|---:|---:|---:|---:|---:|
+
+| Reviewer | PRs | Approvals | Silent approvals | Silent share | Inline comments / PR |
+|---|---:|---:|---:|---:|---:|
+| tlongwell-block | 4 | 4 | 4 | 100% | 0.0 |
+| klopez4212 | 3 | 2 | 2 | 100% | 0.0 |
+| kalvinnchau | 10 | 8 | 7 | 88% | 0.2 |
+| wesbillman | 99 | 75 | 56 | 75% | 0.13 |
+| brow | 9 | 8 | 5 | 62% | 0.56 |
+| jmecom | 5 | 4 | 2 | 50% | 1.0 |
+| wpfleger96 | 62 | 61 | 30 | 49% | 0.52 |
+| atishpatel | 9 | 9 | 3 | 33% | 0.44 |
+| ravarora2 | 3 | 3 | 1 | 33% | 0.0 |
+| jedwards27 | 118 | 168 | 11 | 6% | 0.03 |
+| themiguelamador | 11 | 1 | 0 | 0% | 0.0 |
+| Chessing234 | 8 | 0 | 0 | — | 0.0 |
+| philazar | 4 | 3 | 0 | 0% | 0.0 |
+
+---
+
+## 2. Reviewer Focus Fingerprints
+
+### Chessing234
+**Style:** thorough | **Signal quality:** high — Comments are consistently structured, technically precise, cite specific code patterns, and distinguish the valid core fix from residual gaps — demonstrating deep domain understanding rather than surface-level scanning.
+
+**Primary focus areas:**
+- Correctness of edge cases and logic gaps in the core fix — verifying the stated fix is complete and doesn't introduce new failure modes (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Security: secrets and credentials scoped too broadly, especially in CI/CD workflows touching untrusted code (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Test quality and behavioral coverage — ensuring tests pin the exact invariants that matter, not just happy paths (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Access control and authorization ordering — ensuring policy gates are applied in both code paths and in the correct sequence (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Acknowledging the correctness of the primary fix before raising concerns — structured as 'fix is right, but here are the remaining gaps' (always)
+- Completeness of migration or schema changes — ensuring all relevant code paths (not just the new one) are updated consistently (often)
+- UX-level correctness: state transitions that can leave users stuck or cause unintended behavior (often)
+
+**Apparent blind spots:**
+- Performance implications — no comments across any PR about latency, query cost, bundle size, or allocation overhead — Zero mentions of performance concerns across 8 PRs covering DB schema, CI, desktop UI, and backend policy logic, despite multiple opportunities (FTS index changes, channel agent reuse, segmented controls).
+- Observability — no comments about logging, metrics, or tracing for new behavior — PRs touching agent provisioning, security gating, and DB migrations have no observability feedback despite these being areas where runtime visibility matters.
+- Dependency hygiene — no review of new dependencies, version pins, or supply-chain risks beyond the single SHA-pin acknowledgment in CI — The only dependency mention is approving existing pinned action SHAs; no scrutiny of any new library or transitive dependency introduced.
+- Documentation of decisions — no requests for ADRs, changelog entries, or inline explanation of non-obvious design choices — The benchmark PR's README table is praised but no documentation gaps are called out across any PR, even for complex policy precedence rules or migration strategies.
+
+### TheSentinel454
+**Style:** advisory | **Signal quality:** medium — Comments are substantive and push on real issues (duplication, doc accuracy, CI hygiene), but several are questions that defer resolution to the author rather than blocking on specific standards, and whole categories like security and error-handling go completely unaddressed.
+
+**Primary focus areas:**
+- Test organization, placement, and CI discoverability — ensures tests run in the right lane, are not duplicated across jobs, and follow established conventions for discovery scripts (always)
+- Documentation accuracy and operational explicitness — docs must match actual artifacts (e.g., image tag format), and must state scope, restrictions, and non-obvious caveats clearly (often)
+- CI timeout hygiene — job timeouts must be set to realistic values, not overly conservative defaults (sometimes)
+- Code duplication and DRY violations — questions repeated utility functions and pushes toward consolidation (sometimes) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+- Correctness of logic changes — asks for explicit rationale when values or behavior changes in ways that are not self-evident (sometimes)
+- Observability and metrics for operational unknowns — flags missing metrics when decisions (e.g., timeouts) lack empirical data (sometimes)
+- Architectural debt acknowledgment — explicitly calls out structural problems (e.g., run-on-boot migrations) even if they are not fixed in the current PR (sometimes)
+
+**Apparent blind spots:**
+- Security review — no comments across four PRs touch authz, secrets handling, injection, or trust boundaries, even in a PR that adds CI workflows and env-var-driven configuration — PR #6229 introduces env-var-parsed DB credentials/timeouts and PR #6709 adds a workflow publishing Docker images; neither prompted any security-oriented comment from this reviewer.
+- Error handling and failure modes — no comments examine what happens when DB operations fail, timeouts fire, or CI steps error out — The timeout PR (#6229) is focused on configuration correctness but the reviewer never asks about client-visible failure behavior when timeouts are hit.
+- Performance implications — no comments address query plans, index usage, or test suite runtime cost beyond CI job-level wall-clock time — PR #6730 restructures a large test suite; no discussion of per-test cost or database state overhead appears in the reviewer's comments.
+- API contract stability and versioning — no comments about backward compatibility when env-var names or public library interfaces change — PR #6229 renames/moves env-var parsing across binaries with no comment from this reviewer about whether dependent callers are updated or whether the change is breaking.
+
+### atishpatel
+**Style:** advisory | **Signal quality:** medium — Reviews are substantive on prompt correctness and structural concerns but are sparse across most PRs, with several approvals carrying only boilerplate or no inline comments, limiting pattern confidence.
+
+**Primary focus areas:**
+- Prompt content correctness and behavioral coverage — ensuring removed or simplified prompt sections don't leave agents without necessary instructions or discovery paths (often)
+- Benchmark dataset structure and organization — preferring cleaner directory layouts and appropriate model tier selection (sometimes)
+- Prompt specificity — ensuring context surfacing instructions are precise enough to be actionable (sometimes)
+- End-to-end tracing of change impact through rendering/delivery paths before approving (often)
+
+**Apparent blind spots:**
+- Test coverage for new behavior — no comments across any PR about adding or improving unit/integration tests for code changes — Across 9 PRs, test-related commentary is limited to noting that existing benchmark CI passed; the reviewer never requests new test cases or questions coverage gaps for changed logic.
+- Security hygiene — no comments on auth, secrets, or trust boundaries — None of the review comments touch on security concerns despite reviewing prompt injection surfaces and MCP scoping changes where trust-boundary issues could arise.
+- Error handling — no comments on failure modes or error propagation — No inline or summary comments across any PR raise questions about what happens when tool calls fail, prompts are malformed, or edge cases occur.
+- API contract stability — no comments on versioning or backward compatibility — PRs touching base prompt structure and ACP context delivery could break downstream consumers; the reviewer does not flag these risks explicitly.
+
+### baxen
+**Style:** thorough | **Signal quality:** high — Every comment is reproducible (includes exact file paths, repro steps, and test cases), the reviewer self-corrects when wrong, distinguishes priority levels (P1/P2), and tracks whether fixes fully close the stated invariant gap.
+
+**Primary focus areas:**
+- API contract invariants: ensuring wire-level constraints (request/response correlation, field presence, action matching, outcome validation) are enforced by types and validators rather than documented convention (always)
+- Serialization determinism and idempotency: ensuring bytes frozen at validation time are the only bytes sent on the wire, preventing re-serialization drift across retry attempts (always)
+- Strict deserialization: rejecting unknown fields, explicit nulls, and unexpected siblings at every wire boundary including nested types and re-exported types (always) — *OWASP Top 10*
+- Identity correlation correctness: ensuring identifiers (UUIDs, pubkeys, cursors) are canonicalized before comparison so that semantically equivalent values are never rejected or confused (often)
+- Error model correctness: ensuring error variants carry accurate side-effect semantics (pre-dispatch vs. post-dispatch, retryable vs. terminal) and are not contradicted by documentation (often)
+- Test coverage quality: ensuring tests represent durable structural invariants rather than surface-level heuristics that can be bypassed by renaming or wrapping (often)
+- Deployment environment tracing: verifying that security-critical configuration changes are safe across all non-dev deployment paths before approval (sometimes)
+- Pagination cursor design: ensuring cursor-based pagination cannot loop or skip records due to non-opaque, non-unique cursor values (sometimes)
+
+**Apparent blind spots:**
+- CI/build infrastructure review — PR #7168 splitting CI into reusable workflows received only 'Looks clean' with no inline comments despite being a structural change to the build system; baxen applied no scrutiny comparable to source-code reviews.
+- Observability and logging — Across all three PRs, no comments address logging, tracing, metrics, or alerting hooks, even in the broker contract PR where action outcomes and error codes would be natural observability attachment points.
+- Performance characteristics — No comments address latency, allocation patterns, or throughput concerns across any PR, even in the broker client where serialization and retry loops are performance-sensitive paths.
+- Documentation of decisions (ADRs, inline rationale) — Baxen writes detailed rationale in review comments and fix responses but never requests that this rationale be captured in code comments, ADRs, or changelogs for future maintainers.
+
+### brow
+**Style:** advisory | **Signal quality:** high — Comments are precise, cite specific line ranges and measured outcomes (including mutation test results and reproducible probes), and consistently distinguish blocking from non-blocking findings.
+
+**Primary focus areas:**
+- Test coverage gaps for newly introduced or modified logic branches (often) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Mutation testing to verify that new guard conditions are actually falsifiable by the test suite (sometimes)
+- State transition correctness in asynchronous/reactive mobile flows (e.g., backgrounding, resuming, UI state flags) (sometimes)
+- Edge cases in retry and backoff logic producing degenerate zero-delay windows (sometimes)
+- Event replay/buffering correctness when chunk or socket lifecycle changes mid-stream (sometimes)
+- CI/CD build pipeline correctness — exercising real linker paths rather than stub scripts (sometimes)
+
+**Apparent blind spots:**
+- Security review of audio/relay data flows and push-gateway endpoints — PRs #6056, #6558, and #7158 touch audio bridging, Huddle protocol downgrade, and push-gateway deployment — all trust-boundary-crossing surfaces — yet no security-oriented comments appear from brow on authorization, data exposure, or input validation.
+- API contract stability and versioning — Protocol downgrade (PR #6558) and push-gateway schema changes (PR #7158) could break existing clients or require versioning discipline; brow left no comments on backward compatibility or semver implications.
+- Observability hooks (logging, metrics, alerting) — Across 11 PRs covering cold-startup performance, relay sessions, and push infrastructure, brow never comments on whether new latency paths, error rates, or retry storms are instrumented for production visibility.
+- Documentation of non-obvious design decisions — Complex design choices — protocol downgrade rationale, chunk supersession logic, relay lifecycle — receive no requests for inline comments or ADRs from brow across any reviewed PR.
+- Performance regressions in newly introduced code paths — PR #6996 is explicitly about cold startup and rendering performance, yet brow's comments focus on correctness and test coverage, not on whether the changes introduce allocations, N+1 patterns, or new startup costs.
+
+### evanchen7
+**Style:** advisory | **Signal quality:** low — Only one PR with two inline comments is available, making it impossible to establish reliable patterns or distinguish consistent priorities from one-off observations.
+
+**Primary focus areas:**
+- Accessibility of dynamic UI updates: live regions for count changes and descriptive button labels (sometimes)
+- Scoping and deferring architectural concerns (e.g., on-demand loading, IPC/UI-state redesign) out of focused fixes (sometimes) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Performance bounding of expensive operations (e.g., file preview caps) (sometimes)
+
+**Apparent blind spots:**
+- Test coverage for new behavior — No comments reference unit, integration, or snapshot tests for the UI changes or the backend pagination cap; only one PR reviewed so sample is very small.
+- Security hygiene and input validation — No comments touch trust boundaries, path traversal risks in the repository tree logic, or authz concerns despite backend file-system access being involved.
+- Error handling and failure modes — No comments address what happens when the backend returns errors, partial data, or exceeds the 250-file cap in unexpected ways.
+- API contract stability between frontend IPC and backend commands — The reviewer explicitly deferred IPC redesign to a future PR without flagging versioning or backward-compatibility implications of the current interim contract.
+
+### jedwards27
+**Style:** blocking | **Signal quality:** high — Every blocking finding is tied to a specific file, line range, and concrete failure scenario with a reproduction path; verdicts clearly distinguish P1/P2 severity, track resolution across multiple rounds, and require causal test coverage before approving.
+
+**Primary focus areas:**
+- Async state boundary correctness: detached/unawaited operations that can complete after community/identity/relay switches, writing stale data to the wrong tenant or user (always)
+- Race conditions in concurrent async operations where a later result can overwrite a newer authoritative value (stale-refresh/stale-write races) (always)
+- Security: trust-boundary enforcement — relay-signed events must be verified before authorization decisions; forged or author-claimed fields must not substitute for signed authority (always) — *OWASP Top 10*
+- Test regression oracle quality: tests must exercise the actual production wiring, not a parallel test-only path; mutations that bypass production code must be caught (always)
+- Accessibility: keyboard navigation completeness (Tab order, Shift+Tab, focus return after dismissal, inert/aria-hidden coverage of visually covered layers), WCAG contrast compliance (always)
+- Native lifecycle correctness: camera, audio, recorder, and platform-view teardown/replacement must be fenced against races between disposal, re-initialization, and cancellation (often)
+- Exact-head CI gate enforcement: will not approve when required CI is red or cancelled, even when code is otherwise clear (often)
+- API contract stability: relay filter semantics, NIP protocol correctness (NIP-01/NIP-10/NIP-45/NIP-OA), and Tauri IPC wire contracts must not silently change behavior (often) — *Semantic Versioning 2.0.0*
+- Fail-closed defaults: indeterminate or error states must not silently degrade to a permissive/empty/ordinary-channel result (often)
+- Cross-tenant/cross-identity isolation: persisted state, query-cache keys, and UI must be scoped to relay+pubkey to prevent one community's data leaking into another (often)
+- Error-handling completeness: failures in multi-step operations (delete, upload, save) must not partially succeed and leave durable inconsistent state; rollback must be atomic (often)
+- Reduced-motion and accessibility animation: OS prefers-reduced-motion must be honored for new CSS transitions (sometimes)
+- CI/supply-chain policy: GitHub Actions action references must be pinned to full SHA; composite actions within the repo must also be covered by the same policy (sometimes)
+
+**Apparent blind spots:**
+- Performance characteristics of new relay/network code (N+1 queries, unbounded fanout) — raised only once (PR #6712 workflow grid), not systematically across all relay-querying PRs — Dozens of PRs introduce new relay subscriptions or queries with no comment on query cost or fanout; the single N+1 finding in #6712 appears to be an exception triggered by an obvious regression, not a consistent pattern.
+- Dependency additions and version pins for non-CI dependencies (Flutter packages, npm packages, Cargo crates) — No review comment across 119 PRs questions why a new library was added, whether it is maintained, or checks its transitive footprint; focus is entirely on behavioral correctness of the code using existing dependencies.
+- Observability: logging, tracing, and metrics coverage for new production paths — New relay admission, audio, push notification, and agent-wake paths are reviewed for correctness but no comment ever requests a log line, metric, or trace span to make failures observable in production.
+- Documentation of non-obvious architectural decisions (ADRs, inline comments explaining why) — Review comments are exclusively about runtime behavior; no comment across any PR asks for a comment explaining why a particular concurrency strategy, rollback approach, or protocol choice was made.
+- Style/lint hygiene and naming conventions — Zero comments on naming, formatting, or idiomatic style across all 119 PRs; all feedback is behavioral.
+
+### jmecom
+**Style:** advisory | **Signal quality:** high — Every inline comment names the exact code path, explains the root cause, and gives a concrete exploit or failure scenario, indicating high-signal, well-reasoned reviews.
+
+**Primary focus areas:**
+- Input validation and integer safety: catches numeric casts that can wrap, overflow, or panic (u64→i64 cast feeding chrono::Duration::seconds) (often)
+- Trust-boundary and authorization bypass: flags paths where canonicalization gaps or missing normalization let crafted inputs skip intended access control checks (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Audit trail and durable records for privileged mutations: flags upsert/delete operations on security-critical tables that leave no history (sometimes)
+- Validation-normalization split: identifies cases where validation accepts a value but discards the normalized form, letting unnormalized data propagate to execution (often)
+- Type invariant preservation: notes when a parsed type claims a semantic invariant (e.g., valid secp256k1 pubkey) that isn't actually enforced at parse time (sometimes)
+- CI/dependency version pinning and supply-chain hygiene: verifies version bumps are justified, pinned, and that upstream fixes are confirmed (sometimes)
+
+**Apparent blind spots:**
+- Test coverage for new behavior — Across all substantive code PRs (#3777, #6742) the reviewer raised no comments about missing or inadequate tests for the new auth paths, validation logic, or action contract; correctness concerns were flagged without requiring tests to demonstrate them.
+- Observability and logging — No comments on logging, metrics, or tracing hooks were made across any PR, including #3777 which introduced deployment-wide admin auth roles—a high-value place to add audit logs beyond the DB record the reviewer did mention.
+- API contract stability and versioning — PR #6742 defined a public agent-to-broker action contract but the reviewer left no comments about backward compatibility, versioning strategy, or what happens to existing callers if the contract changes.
+- Documentation of non-obvious decisions — No comments requested documentation, ADRs, or inline explanations for design choices (e.g., why upsert vs. insert-only, why the 64-hex type doesn't validate the curve point at parse time).
+
+### kalvinnchau
+**Style:** thorough | **Signal quality:** high — Comments are highly specific, citing exact file paths and line numbers, reproducing the logic flaw precisely, and stating the concrete failure mode — findings are independently verifiable and actionable rather than vague suggestions.
+
+**Primary focus areas:**
+- State machine completeness: exhaustive enumeration of status/lifecycle variants with no fall-through to wrong terminal states (often)
+- Protocol/API contract fidelity: ensuring request/response fields (e.g., nonces, capability lists, lifecycle kinds) are correctly included or checked at every code path (often)
+- Stale state / race conditions in UI state machines: detecting cases where toggling or transitioning leaves residual data from a prior runtime/config (sometimes)
+- Error propagation vs. graceful degradation: blocking critical user-facing operations on non-critical enrichment steps (sometimes)
+- Data normalization consistency: ensuring canonicalization applied at ingest is applied before lookups so case/format mismatches don't cause silent misses (sometimes)
+- Regression test coverage for specific fixed behaviors: verifying that the fix is exercised by tests, not just that tests exist (often)
+- Security hygiene for auth/relay systems: fail-closed config, constant-time validation, token lifecycle, CSP (sometimes) — *OWASP Top 10*
+
+**Apparent blind spots:**
+- Observability: logging, metrics, and tracing hooks are never mentioned across any PR — None of the 11 PRs include any comment about missing or inadequate logging, metrics, or distributed tracing, even in PRs touching network I/O, agent spawn bridges, and catalog discovery where observability would be expected.
+- Dependency justification and supply-chain hygiene — No comments about new crate/npm dependencies, version pinning, or supply-chain risk appear in any reviewed PR, including PRs that add new features in Rust and TypeScript.
+- Performance: latency, allocation, or N+1 query concerns — No performance-oriented comments appear across the 11 PRs, including PRs touching database migrations, catalog queries, and media bucket operations where query efficiency is relevant.
+- Documentation of non-obvious design decisions (ADRs, inline rationale) — Reviews confirm behavior is correct but do not flag absent explanations of why specific design choices (e.g., why older-workspace compatibility admits empty metadata) are made, suggesting documentation completeness is not checked.
+
+### klopez4212
+**Style:** blocking | **Signal quality:** high — Every comment cites a precise reproduction path or invariant violation, names the exact fix commit, and describes an added regression test that demonstrates the broken behavior, making the feedback unambiguous and verifiable.
+
+**Primary focus areas:**
+- Race conditions and concurrency correctness: overlapping async operations, stale closures capturing old relay/identity/session context, and missing scope fences across community switches, sign-outs, and reconnects (always)
+- Regression test coverage for every bug fixed: every fix comment cites an added regression test proving the broken path fails without the fix (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Security hygiene for relay-authenticated endpoints: NIP-98 replay guard, membership gate, validated input bounds before rate-limit token consumption, and credential/auth header scoping (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Resource lifecycle and cleanup: unreleased streams, orphaned temp files, unbounded concurrent Promises, object URL leaks, camera disposal during lifecycle transitions, and codec/muxer cleanup on timeout (often)
+- API contract stability between client and relay/native layers: wire format compatibility, protocol versioning in mesh framing, method-channel contracts, and cross-platform voice-note Markdown/imeta pairing (often) — *Semantic Versioning 2.0.0 — https://semver.org/*
+- Idempotency and duplicate-action guards: double-tap, repeated callbacks during animation transitions, overlapping async completions firing multiple times (often)
+- Public API documentation: doc comments on constructors, fields, lifecycle contracts, and ownership semantics for every exported symbol (often)
+- Bounded resource consumption: per-response size caps, request timeouts, rate-limit configuration, download limits, and image downsampling ceilings (often)
+- Module boundary enforcement: preventing cross-feature imports that couple sibling features, extracting shared widgets to the shared layer (sometimes)
+- Accessibility: VoiceOver/TalkBack semantics nodes, WCAG contrast, Dynamic Type scaling, and accessible action labels on custom controls (sometimes)
+- File size ceiling enforcement: source files must stay under 1,000 lines; oversized files are split into focused siblings (sometimes)
+- Fail-closed defaults for security-sensitive feature gates: Huddle availability, identity resolution, and relay membership must default to hidden/disabled until all providers settle (sometimes)
+
+**Apparent blind spots:**
+- Dependency additions and supply-chain changes — Across 27 PRs spanning Rust crates, Flutter packages, and npm packages, no comment mentions a new dependency being added, its justification, version pinning, or license. The reviewer never flags a new pub.dev, crates.io, or npm package.
+- CI/build infrastructure and configuration changes — Several PRs touch Tauri build configs, Gradle, and Swift package files; the reviewer never comments on build scripts, CI workflow files, or runner configuration.
+- Observability: logging, metrics, and tracing hooks — The reviewer never mentions whether new features (GIF search, Huddles, voice notes, profile editing) emit structured logs, metrics, or distributed traces, even though these are network-heavy, latency-sensitive features.
+- Error user-facing messaging quality — The reviewer fixes machine-token exposure once (relay_membership_required) but never independently raises whether error messages shown to users are helpful, localized, or safe. User-visible error strings in Dart and Swift are not called out.
+- Backward compatibility of stored/persisted data formats — With the exception of the Pollen migration PR, the reviewer does not raise questions about schema migrations, SQLite column changes, or Shared Preferences key renames that could affect users upgrading from older app versions.
+
+### loganj
+**Style:** blocking | **Signal quality:** medium — The reviewer (or their AI proxy) leaves detailed, commit-pinned, technically specific findings, but the small sample of 3 PRs and the explicit 'I'm Larry' AI-proxy framing make it difficult to attribute consistent human judgment patterns with high confidence.
+
+**Primary focus areas:**
+- Correctness of boundary conditions and edge-case behavior in new feature logic (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- End-to-end causal contract verification: ensuring that every transformation stage (input → intermediate → compiled output) is tested as a single chain rather than in isolation (always)
+- Scope discipline — approvals are explicitly scoped to a specific commit hash and a defined behavioral slice; out-of-scope changes are flagged as requiring a separate review round (always)
+- Silent failure / discard of inputs that should be rejected or surfaced to the caller (often)
+- API/transport contract stability across build variants and deep-link routing (often) — *Semantic Versioning 2.0.0 — https://semver.org/*
+
+**Apparent blind spots:**
+- Security hygiene (auth boundaries, injection, privilege escalation) — Across three PRs touching CLI input parsing, named build isolation, and agent wake-up workflows — all common surfaces for trust-boundary issues — no security-category comment appears.
+- Observability (logging, tracing, metrics) — No comment in any PR references whether new code paths emit logs, traces, or metrics; this is especially notable for the agent wake-up PR where observability of workflow events would be expected.
+- Documentation of decisions (ADRs, inline comments for non-obvious design choices) — Reviews focus entirely on runtime behavior and test coverage; no comment requests explanation of why a design choice was made or asks for inline documentation.
+- Dependency additions or version pinning — No PR review mentions new dependencies, their justification, or supply-chain risk, even in the Cargo/build.rs context where dependency changes are plausible.
+
+### matt2e
+**Style:** thorough | **Signal quality:** high — Comments are precise, reproduce concrete edge cases with specific inputs, explain the causal chain from the defect to observable failure, and include the corrected behavior — consistently high signal with no vague or stylistic noise.
+
+**Primary focus areas:**
+- Byte vs. character encoding boundary errors in string length validation and truncation (sometimes)
+- React memoization invalidation from unstable object/JSX references created inline per-render (sometimes)
+- Logic gate mismatches between condition checks and the actual action target — silent wrong-target side effects (sometimes)
+- Keyboard modifier key handling in input event disambiguation (e.g. Shift+Space vs plain Space) (sometimes)
+- Test coverage pinning specific regression scenarios with realistic edge-case inputs (often)
+
+**Apparent blind spots:**
+- Security implications of the changes (authz gaps, trust boundaries, injection risks) — Neither PR review mentions security concerns despite changes that modify channel membership and message routing — areas where incorrect actor assignment or channel targeting could be a trust-boundary issue.
+- Observability and logging for failure paths — The silent wrong-channel member-add bug is identified as a logic error but no suggestion is made to add logging or alerting when the fallback path executes; error visibility is not raised.
+- API contract stability and backward compatibility — No comments across either PR address whether changes to project channel or mention-resolution APIs break existing callers or require versioning.
+- Documentation of non-obvious decisions — Complex business logic (agent bot membership gating, mention debounce flushing) receives no prompts for inline documentation or ADRs in either review.
+
+### morgmart
+**Style:** advisory | **Signal quality:** low — Only one PR reviewed with two inline comments, providing insufficient data to establish reliable patterns or blind spots.
+
+**Primary focus areas:**
+- Visual rendering correctness of UI preferences — verifying that spacing/density settings are applied consistently across all surfaces (conversation rows, inbox rows, markdown, preview) (always)
+- Scope documentation for UI preference changes — ensuring that the copy/UI text accurately describes which surfaces a setting affects (always)
+- Single source of truth for CSS token ownership — checking that a single variable controls spacing rather than competing hard-coded values (always)
+
+**Apparent blind spots:**
+- Test coverage for new preference behavior — No comments reference unit or integration tests verifying that font size or density preferences persist, render, or apply correctly; all observed comments are about visual outcome validation rather than automated test presence.
+- Accessibility implications of density/font-size changes (e.g., minimum touch target sizes, WCAG contrast at smaller sizes) — Comments focus on pixel values and spacing rendering but do not raise accessibility compliance concerns for compact or small-font modes.
+- Performance implications of CSS variable usage or re-renders triggered by preference changes — No comments address render cost, style recalculation scope, or whether preference changes cause expensive repaints.
+- API contract / persistence layer for user preferences — Comments are exclusively about visual rendering; no mention of how preferences are stored, synced, or whether the schema is backward-compatible.
+
+### philazar
+**Style:** advisory | **Signal quality:** low — The vast majority of reviews are brief approvals ('lgtm') with minimal substantive feedback, providing very few data points about what the reviewer consistently evaluates.
+
+**Primary focus areas:**
+- High-level architectural and metric design for evaluation systems (sometimes)
+- Correctness of test fixture content (e.g., accidentally committed AI-generated placeholder data) (sometimes)
+
+**Apparent blind spots:**
+- Test coverage of new behavior — Across 5 PRs including a feature addition, benchmark layers, and a bug fix, there are no comments requesting or evaluating test coverage for new code paths.
+- Security hygiene and trust boundaries — No security-related comments appear across any PR, including the desktop ACP session experiment which introduces session scoping.
+- Error handling — No comments address error propagation or failure behavior in any of the reviewed PRs, including the fix for cold memory retrieval.
+- API contract stability — No comments address backward compatibility or versioning despite PRs touching benchmark structure and desktop session experiments.
+- Observability and logging — No mention of logging, metrics, or tracing hooks across any PR.
+
+### ravarora2
+**Style:** terse | **Signal quality:** low — All three reviews consist solely of 'lgtm' approval comments with no substantive feedback, making it impossible to infer meaningful focus patterns.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- Test coverage of new behavior — No comments across any of the 3 PRs addressing whether new tests were added or existing tests adequately cover the fix.
+- API contract stability and backward compatibility — PR #6062 involves a camelCase field rename in a config-write payload, which could be a breaking change for existing clients, yet no comment was made about compatibility.
+- Error handling and edge cases — All three PRs received immediate approval with no discussion of failure modes, edge cases, or error propagation.
+- Correctness and logic review — Reviewer left only 'lgtm' comments with no substantive analysis of the fixes in any PR, suggesting no deep review of logic.
+- Observability and operational impact — PR #6898 disables a database vacuum truncation heartbeat — a potentially significant operational change — with no comment on monitoring, rollback, or alerting.
+
+### salman1993
+**Style:** advisory | **Signal quality:** medium — Comments are substantive and technically grounded when present, but coverage is sparse across PRs — several approvals have no inline feedback at all, and entire categories (security, observability, API contracts) are never engaged.
+
+**Primary focus areas:**
+- Correctness of environmental assumptions and runtime context (e.g., HOME availability after env_clear on Windows) (often)
+- Test determinism: flaky or self-healing timers that can false-green on buggy code (often)
+- Realism and representativeness of benchmark/test fixtures and task inputs (sometimes)
+- Prompt/documentation progressive disclosure — avoiding unnecessary complexity for the common case (sometimes)
+- Benchmark configuration consistency (model held constant, configs symmetric across variants) (sometimes)
+
+**Apparent blind spots:**
+- Security review (e.g., path traversal in read_file/str_replace, injection risks) — PR #6271 touches path expansion logic (leading ~ in file paths) — a classic path traversal vector — and the reviewer's only comment addresses an environmental accuracy issue, not whether the expansion is safely bounded to allowed directories.
+- Dependency justification and supply-chain hygiene — PR #6222 is a security-motivated dependency bump (RUSTSEC advisory) and received only an approval with no comment on the version chosen, pinning strategy, or whether the bump is minimal.
+- API contract stability and backward compatibility — PR #6264 adds a new TTL field to `channels search` output; no comment was made about whether this is a breaking or additive change for existing consumers of that output.
+- Observability and error-handling — Across all seven PRs, no comment addresses logging, metrics, tracing hooks, or explicit error propagation paths, even in PRs touching network/IPC paths.
+
+### tellaho
+**Style:** advisory | **Signal quality:** low — Only one PR is available for analysis, and all visible comments are AI-generated resolution summaries rather than original reviewer comments, making it impossible to reliably infer the reviewer's own priorities or style.
+
+**Primary focus areas:**
+- State initialization correctness: ensuring create/duplicate operations produce the correct explicit default values rather than relying on backend defaults (sometimes)
+- UI safety guardrails: ensuring destructive or consequential state transitions (e.g., enabling a workflow) surface appropriate warnings to users (sometimes)
+- Form state correctness: preventing unintended side effects when editing one field from broadening or mutating other unrelated fields (sometimes)
+- Input normalization and parsing robustness: handling multiple valid formats (e.g., cron field arities, hex case) consistently and defensively (sometimes)
+- Test coverage for edge cases: expecting regression tests for the specific bugs caught (uppercase hex, frequent cron schedules at each arity) (often)
+
+**Apparent blind spots:**
+- Security review — No comments touch authentication, authorization, input sanitization for injection, or trust boundaries despite the PR touching workflow triggering logic.
+- Performance and scalability — No comments address rendering cost, query efficiency, or bundle impact despite changes to UI components.
+- API contract stability — The PR involves backend field conventions (enabled flag, cron format) but no comments address versioning or backward compatibility with older clients or API consumers.
+- Documentation — No comments request or acknowledge updates to READMEs, changelogs, or inline documentation for non-obvious decisions introduced by the PR.
+- Error handling — No comments address how failures (e.g., malformed cron, invalid hex) are surfaced to users or logged.
+
+### thomaspblock
+**Style:** blocking | **Signal quality:** high — The reviewer consistently identifies specific, reproducible security and correctness defects with exact file paths and call-path traces, and verifies fixes at named commit SHAs, producing highly actionable and verifiable feedback.
+
+**Primary focus areas:**
+- Cross-signer / cross-relay identity and authority boundary enforcement: ensuring that a channel, repository, or project owned by one signer/relay cannot be hijacked or reused by a foreign principal to route commands or gain authority (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Workspace state isolation and reset on identity/signer scope changes: verifying that mutable workspace state is fully cleared and reloaded when the active signer or project context changes, preventing stale state from leaking across sessions (always)
+- Adversarial routing analysis: tracing full call paths from entry points (ACP, CLI, managed-agent startup) through authorization checks to ensure no path bypasses authority validation (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- React memo/useMemo dependency completeness: catching incomplete dependency arrays that break memoization and cause stale closures or missed re-renders at component boundaries (sometimes)
+- UTF-8 / multi-byte string truncation correctness: ensuring string truncation happens at character boundaries (not byte offsets) to avoid mojibake or panics with CJK and other multi-byte content (sometimes)
+- CI failure triage: distinguishing pre-existing or unrelated CI failures from failures caused by the PR under review, and directing reviewees to retry rather than conflate (sometimes)
+
+**Apparent blind spots:**
+- Test coverage for new behavior: no comments request new unit or integration tests for the authorization paths, routing logic, or workspace reset behavior being introduced or fixed — Across all three PRs the reviewer audits logic and authority boundaries in detail but never asks for test additions. The only test mention is confirming an existing CJK regression test already passes.
+- Observability and logging: no comments on whether failed authority checks, identity mismatches, or routing rejections emit actionable logs or metrics — Security-critical rejection paths (foreign signer, ambiguous slug, require_repo_channel_binding failures) are traced for correctness but the reviewer never asks whether these paths surface diagnostic signals.
+- Documentation of non-obvious security decisions: no requests for inline comments or ADRs explaining why specific authority checks are required at each call site — The reviewer identifies and verifies the presence of guards but does not ask for documentation that would help future contributors understand why the guards exist.
+- Performance implications of repeated authority checks or workspace reconciliation on hot paths — The reviewer traces correctness of reconciliation and scoped event sync but never raises latency, allocation, or N+1 concerns even when tracing multi-step resolution chains.
+
+### tlongwell-block
+**Style:** advisory | **Signal quality:** low — With only approval actions and no recorded inline comments across all 4 PRs — spanning feature work, a security revert, and a race condition fix — there is insufficient signal to characterize meaningful review patterns.
+
+**Primary focus areas:**
+- Approving PRs without leaving substantive inline comments (always)
+
+**Apparent blind spots:**
+- Test coverage of new behavior — No comments observed across any of the 4 PRs regarding test presence, quality, or coverage gaps — including for PRs involving feature work (model capabilities manifest) and bug fixes (TipTap race condition).
+- API contract stability and breaking changes — PR #5597 drives model capabilities from a manifest — a potentially breaking change to how consumers discover capabilities — yet no comments were left about backward compatibility or versioning.
+- Security implications — PR #6311 reverts a security gate on relay-signed workflow messages, which has direct trust-boundary implications, yet no inline scrutiny was observed.
+- Error handling and edge cases — PR #6779 fixes a race condition in editor mounting; no comments were left examining whether the fix covers all race variants or handles failure states.
+- Correctness of revert rationale — PR #6311 is a revert of a security fix with no observed challenge to the rationale or request for a follow-up plan, despite the regression risk.
+
+### wesbillman
+**Style:** blocking | **Signal quality:** high — Reviews are pinned to exact SHAs, cite specific file paths and line numbers, reproduce failure scenarios, and track findings across multiple revision rounds with clear acceptance criteria — though nearly all substantive content is produced by automated sub-reviewer personas acting on wesbillman's account.
+
+**Primary focus areas:**
+- Security boundary enforcement: trust validation of external/attacker-controlled data before it affects application state, UI, or prompts (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- State machine correctness: lifecycle transitions must be complete, idempotent, and exhaustive — no wedged states, silent no-ops, or missing terminal paths (always)
+- Cross-scope/cross-tenant isolation: community, workspace, and identity boundaries must not leak data or actions across contexts (always)
+- API contract stability between layers: type definitions, wire formats, and field names must stay consistent across frontend/backend/mobile surfaces (always)
+- Race conditions and concurrent mutation ordering: shared state must be protected against interleaved writes, in-flight invalidation, and stale closure captures (always)
+- Error propagation and failure surface: errors must not be silently swallowed, must reach observable UI/caller state, and must not be confused with empty/success results (always)
+- Resource bounds: memory, concurrency, and process/file-descriptor limits must be global, not per-item, to prevent aggregate exhaustion (often)
+- Deterministic test coverage: tests must prove the specific invariant claimed, not just pass by accident due to retry windows or timing (often)
+- Cryptographic and protocol correctness: event IDs, replay guards, algorithm-to-key binding, and nonce uniqueness must be correct end-to-end (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Activation/workflow guard semantics: explicit disabled states and confirmation gates must be preserved across create, duplicate, edit, and toggle paths (sometimes)
+
+**Apparent blind spots:**
+- Accessibility: ARIA roles, labels, focus management, and contrast ratios are almost never raised proactively; they appear only when a separate automated lane surfaces them — Across 109 PRs the only accessibility findings visible in review text were surfaced by named sub-reviewers (Carl/Princess Donut personas), not by wesbillman's own observations — e.g., the ManageChannelSheet label finding and the thread-detail landing-target finding were both attributed to the automated lane.
+- Observability hooks: no review comment mentions missing logging, tracing, or metrics for new failure paths, even on complex distributed features like push notifications and OAuth single-flight — Despite many reviews of backend Rust services and complex async flows (PR #5545, #6269, #6776, #7109) there are zero visible comments requesting spans, counters, or structured log fields.
+- Dependency justification and supply-chain: new crate/package additions are never questioned for necessity, provenance, or version pinning — PRs like #6222 (h2 bump for RUSTSEC) received instant approval with no discussion of the upgrade scope, and no PR shows wesbillman questioning a new dependency addition.
+- Documentation of non-obvious decisions (ADRs, inline comments for protocol choices): approved without requesting explanation of why a specific algorithm or data structure was chosen — Approvals on protocol-heavy PRs (NIP-FI verifier #6776, NIP-98 admin auth #3777, NIP-30 emoji #7259) carry no requests for rationale comments or spec cross-references beyond what the automated reviewer raised.
+
+### wpfleger96
+**Style:** blocking | **Signal quality:** high — Reviews are consistently pinned to exact commit SHAs, blockers are traced to specific source lines with reproduction evidence, and each re-review explicitly verifies prior findings point-by-point, producing highly actionable and verifiable signal.
+
+**Primary focus areas:**
+- Security trust-boundary enforcement: NIP-98 auth, membership checks, replay guards, key material isolation, and access policy propagation are all traced end-to-end before approval (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Correctness of state machine and lifecycle logic: cancelled effects, generation fences, tenant-scope leaks, and race conditions between async steps are consistently caught (always)
+- Test coverage of new handler/boundary behavior: consistently requests tests for auth rejection, quota rejection, error paths, and integration seams when tests are absent (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- API contract stability and consistency across call sites: breaking changes to field names, endpoint paths, response shapes, and multi-interpreter parity are flagged as blockers (always) — *Semantic Versioning 2.0.0 — https://semver.org/*
+- Exact-head verification discipline: every review is pinned to an exact commit SHA and re-verified after each push, never approving on a stale head (always)
+- Observability hooks: metrics, audit trails, and advisory lock instrumentation are verified to be complete and semantically correct (often)
+- Performance: connection pool reuse, per-request resource allocation, and quota-charge ordering are flagged (sometimes)
+- Documentation accuracy: PR titles, inline comments, and config examples must match actual behavior; mismatches in docs that describe wrong semantics are blocked (sometimes)
+- Maintainability: shared constants to prevent drift, options objects over long positional parameter lists, and config-knob externalization (sometimes) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+
+**Apparent blind spots:**
+- Dependency additions and supply-chain hygiene: no comments across 63 PRs call out new crate/npm dependency justification, version pinning rationale, or license compatibility — Despite reviewing PRs that add new Rust crates and npm packages, no review comment addresses why a dependency was chosen, whether it's pinned, or supply-chain risk — only a single PR about a dependency cooldown policy was approved without substantive comment.
+- User-facing error message quality and localization: machine error tokens surfacing to UI are noted only once as a nit, never as a blocker — Only one nit comment mentions that a raw machine token (`relay_membership_required`) reaches the picker error state; in all other PRs with UI error paths, error message quality is not examined.
+- Bundle size and frontend performance impact: no comments on JavaScript bundle cost, lazy-loading, or render performance despite many desktop/React PRs reviewed — Multiple PRs touch desktop React components and add new UI features, but no review comment ever flags bundle size, code-splitting, or render cost.
+
+---
+
+## 3. Author Growth Profiles
+
+### Chessing234
+**Trajectory:** insufficient-data — Only one PR is available in the window, making it impossible to establish a chronological trend.
+
+**Strengths:**
+- Targeted bug fixes with clear intent — the PR addresses a specific broken wire contract (camelCase config-write payload fields) with a focused change (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Scope discipline — applying changes beyond what is necessary to fix the immediate issue (adding rename_all_fields to ConfigFieldType where it has no effect), creating noise in the diff and potential for future confusion (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before submitting, audit each changed file and ask: 'Does removing this change break the fix?' If no, omit it. Reviewers flagged this as P3 in a single PR — practice narrowing diffs by drafting a checklist of which symbols are in the critical path of the bug and limiting changes to only those.
+
+### Illuminfti
+**Trajectory:** insufficient-data — Only one PR is available in the review window, making it impossible to assess directional trends.
+
+**Strengths:**
+- Minimal, focused patches: the single PR targets a precise bug fix with the smallest complete repair, avoiding scope creep (emerging) — *https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Contribution compliance hygiene: DCO sign-off was missing from the commit, flagged as a blocking issue by reviewers (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Walk the author through the project's DCO/sign-off requirement (e.g., git commit -s) and add a local git hook or pre-push check to catch missing sign-offs before submission. Share the project's contributing guide if one exists.
+
+### Maxwellimus
+**Trajectory:** improving — Earlier PRs passed review with no blocking findings; the one CHANGES_REQUESTED cycle (PR #6460) was resolved quickly and completely, and the only surviving gap (stale description bullet) is minor — suggesting the author is internalizing review feedback across the window.
+
+**Strengths:**
+- Focused, well-scoped performance work: each PR targets a single, clearly named optimization (roster off critical path, prefetch on hover intent, render-cheap Projects surface), making changes easy to review and reason about. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive to reviewer feedback: in PR #6460 both P1 findings were resolved between review rounds, demonstrating willingness to act on substantive critique quickly. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Consistent use of conventional-commit prefixes (perf, fix, chore) that communicate intent and support automated changelog tooling. (consistent)
+
+**Growth areas:**
+- PR description hygiene: in PR #6460 an obsolete 'Contribution graph' optimization bullet was left in the description after the corresponding code was removed, requiring a follow-up reviewer comment to flag it. Stale descriptions mislead future readers and complicate bisection. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a personal checklist step before marking a PR ready-for-review: re-read the description against the final diff and strike any bullet that no longer corresponds to shipped code. A simple PR template with a 'Description matches final diff?' checkbox would enforce this habit.
+- Proactive dormancy/lifecycle guards on performance optimizations: PR #6460 initially shipped incremental card counters that remained active outside their intended layout context (a P1 finding). Similar lifecycle concerns surfaced in PR #6458 (fan refetch running after leave). The pattern suggests optimizations are conceived but their activation bounds are not fully audited before submission. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening any perf PR, run through an explicit lifecycle checklist: (1) What conditions must be true for this optimization to activate? (2) What conditions must be true for it to deactivate/clean up? (3) Is there a code path where it could fire outside those bounds? Adding a brief 'activation bounds' note to each PR description would surface this thinking for reviewers and build the habit.
+- Test coverage accompanying performance changes: none of the six PRs show reviewer commentary confirming new or updated tests for the optimized paths (hover-intent cleanup, fetch-lifecycle guards, render suppression). Observable correctness for performance code is particularly important because regressions are silent. (consistent) — *DORA research — https://dora.dev/research/*
+  → **Support:** For each perf PR, add at least one test that exercises the boundary condition being optimized (e.g., assert the fetch does not fire after a component unmounts, or assert prefetch is not triggered on a forum channel). Start small — a single lifecycle test per PR builds the habit and gives reviewers a clear signal that the bounds were considered.
+
+### TheSentinel454
+**Trajectory:** improving — Early PRs required reverts or many review rounds for correctness gaps, while later PRs (db runtime extraction, CI workflow split) show tighter scoping, faster reviewer convergence, and proactive documentation — though pre-submission completeness remains a recurring drag.
+
+**Strengths:**
+- Systematic, incremental refactoring: repeatedly breaks large modules into focused domain stores (replaceable events, community, channel membership, database runtime) with clean, verifiable pure-move semantics (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Observability mindset: proactively adds database pressure metrics, transaction timers, and advisory-lock instrumentation as first-class concerns alongside functional changes (consistent)
+- Infrastructure and CI improvement: consistently invests in build/test reliability (isolated Postgres lane, reusable workflow split, staged delivery qualification gate) (consistent) — *DORA research — https://dora.dev/research/*
+- Responsive iteration on reviewer feedback: addresses multi-round CHANGES_REQUESTED findings thoroughly and documents resolutions inline, enabling reviewers to verify each point (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Pre-submission completeness: multiple PRs (feat(db) session timeouts, ci Postgres lane, fix(acp) relay-signed messages) required 3+ review rounds or a full revert due to defects that could have been caught before posting — including migration-path gaps, audit-loss bugs, and CI reliability holes (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Establish a personal pre-push checklist for each PR type: for database changes verify migration idempotency and all pool consumers; for CI changes run the full workflow locally or in a fork before posting. Pair with a senior engineer on the first two PRs in each new domain to calibrate the expected completeness bar before opening for review.
+- Explicit error-path and edge-case coverage in tests: reviewer flagged a low-value ownership test for removal (PR #6777), and session-timeout tests initially missed the migration-pool exemption and audit-pool coverage — indicating test design tends toward happy-path first (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When writing tests, explicitly enumerate the failure modes for each new code path (timeout on migration lock, audit pool bypass, cross-tenant collision) and add at least one negative or boundary test per mechanism. Request a design review of the test plan from a reviewer before implementation to surface gaps early.
+- PR titling and commit conventions: PR #6777 landed with a non-conforming title despite CONTRIBUTING.md requiring Conventional Commits format; this was caught by the reviewer, not the author (occasional)
+  → **Support:** Add a git commit-msg hook or a local lint step (e.g. commitlint) that enforces Conventional Commits format before push; this eliminates the class of issue entirely without relying on reviewer catch.
+- Security hygiene in CI workflows: PR #7168 triggered multiple zizmor findings for commit SHAs not matching their version comment tags across all new reusable workflow files, indicating the security scanning implications of pinned-action patterns are not yet internalized (occasional) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** Run zizmor (or equivalent action-security linter) locally as part of the pre-push checklist for any CI workflow change. Review the team's pinned-action policy and add a one-time pairing session with a security-aware engineer to understand SHA-pinning best practices for GitHub Actions supply-chain integrity.
+
+### atishpatel
+**Trajectory:** insufficient-data — Only one PR is available for review, providing insufficient chronological signal to determine a trend.
+
+**Strengths:**
+- Functional correctness of implementation: the core logic change (routing mode 'set' to override_system_prompt) was verified as correct by the reviewer (emerging)
+- Defensive fallback handling: local method-not-found fallback was retained alongside the functional fix (emerging)
+
+**Growth areas:**
+- Repository attribution and policy compliance: the PR was blocked by a reviewer citing repository attribution policy violations, suggesting unfamiliarity with contribution norms around attribution or provenance of referenced external revisions (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before submitting PRs that reference or integrate external codebases or revisions (e.g., citing a specific Goose revision), review the project's CONTRIBUTING guide and attribution policy. If none exists, ask the maintainer to document expectations. Reviewers should point to the specific policy document at change-request time to make the requirement unambiguous.
+
+### baxen
+**Trajectory:** insufficient-data — Only one PR is available for review, so no chronological trend can be established, though the within-PR arc shows strong iterative improvement.
+
+**Strengths:**
+- Thorough API contract design and progressive hardening: baxen systematically identified wire invariants (retry idempotency, pagination cursors, response correlation, null handling, unknown fields) and iterated to close each gap across multiple commits, demonstrating sustained attention to explicit error paths and backward-compatible API evolution. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive and honest code review engagement: when reviewers (jmecom, Codex bot) identified real contradictions or bypass cases, baxen conceded clearly, reproduced findings before fixing them, and documented the correction reasoning inline — modeling the reviewer–author collaboration loop. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Observable validation layering: baxen introduced structured validation types (PreparedRequest, validate_for, exhaustive error-code tables, deny_unknown_fields) that make invariants machine-checkable rather than comment-only, aligning with the expectation that observable code carries its contracts in the type system. (consistent)
+
+**Growth areas:**
+- Catching wire-boundary invariants before review: multiple P1/P2 gaps (null-as-omission, unknown envelope fields, non-canonical UUID spellings, secp256k1 point validity, normalized-then-discarded arguments) were first surfaced by reviewers or the automated scanner rather than by baxen's own pre-submission validation pass. Each gap required a separate commit cycle to close. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR that defines a wire contract, run a self-review checklist that covers: (1) every Option<T> with serde(default) has a separate test for explicit JSON null, (2) every struct at a trust boundary uses deny_unknown_fields or a documented reason it cannot, (3) every string identity comparison has a canonicalization test with alternate spellings, and (4) every validate() call that produces a normalized value stores rather than discards it. Pair this with a short design-doc section listing each invariant and the type or test that enforces it, reviewed before the first commit.
+- Test coverage accompanying contract changes: the secret-scanner test file was removed as conceptually unsound, and several invariants (cursor round-trip, correlation with non-canonical UUIDs, BrokerResult direct deserialization) were proved only by reviewer-prompted reproduction steps rather than pre-existing tests shipped with the PR. (consistent) — *DORA research — https://dora.dev/research/*
+  → **Support:** Adopt a personal norm: every new validation rule ships with at least one positive test (valid input passes) and one negative test (the specific invalid input the rule targets fails). For PR #6742-style contracts, write the negative tests first as a design step — if the test is hard to write, the invariant is probably not yet represented in the type system. Review the DORA fast-feedback research to frame this as a cycle-time investment, not overhead.
+- Scoping initial invariant surface accurately: the PR started with a 'structurally unable to leak secrets' claim backed by a scanner that reviewers immediately showed was bypassable. Overstating what a mechanism guarantees created a correction burden and delayed approval. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When writing security or correctness claims in PR descriptions or doc comments, explicitly state the threat model and the specific bypass paths the mechanism does not cover. A sentence of the form 'This check does not defend against X' is more defensible than a universal claim, and surfaces scope discussions before review rather than during it.
+
+### bradseiler
+**Trajectory:** insufficient-data — Three PRs across a four-day window are too few to distinguish a directional trend, though the documentation feedback in PR #6709 is the only notable review signal and was resolved promptly.
+
+**Strengths:**
+- Delivering focused, well-scoped changes that earn approval with minimal reviewer friction (consistent) — *https://google.github.io/eng-practices/review/*
+- Addressing infrastructure and credential concerns (IRSA S3, versioned media bucket deletion) with targeted fixes (emerging)
+
+**Growth areas:**
+- Documentation accuracy and completeness: example code and operating contracts in docs fall out of sync with actual implementation details (occasional) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that includes documentation, do a final pass to verify every example reflects the exact tag/artifact format produced by the current code. Additionally, add an explicit 'Scope and Restrictions' section to any workflow doc that touches staging or release artifacts, clearly stating what environments the artifact may NOT be used in.
+- Proactive contract definition for staging/pre-release workflows: the operating boundaries (pre-merge only, not release-qualified, not for production or Kargo promotion) were absent until reviewer-prompted (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** When introducing new CI/CD staging lanes, include a short 'Operating Contract' block in the PR description and the accompanying docs at authoring time. A checklist item in the PR template—'Does this workflow produce non-release artifacts? If yes, document promotion restrictions.'—would make this a low-friction habit.
+
+### brow
+**Trajectory:** stable — Across all five PRs spanning August–September 2026, brow consistently reaches approval after multiple review cycles, but the same categories of gap — async lifecycle fencing, durable error recovery, and regression coverage — reappear in each successive PR without evidence of proactive mitigation, indicating a stable rather than improving pattern.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: brow consistently addresses blocking findings across multiple review cycles and reaches approval without abandoning PRs, demonstrating persistence through high-risk change sets (consistent) — *https://google.github.io/eng-practices/review/*
+- Scope of ambition: brow regularly authors complex, high-risk features (relay-backed channel discovery, push notification MVP, deployment infrastructure) indicating strong product engineering range (consistent)
+- Inline comment engagement: brow replies to inline review comments with substantive explanations of how findings were addressed, facilitating efficient re-review (emerging) — *https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Async lifecycle and tenant/identity boundary correctness: across PR #6243, #5915, and #6269, reviewers consistently flagged that detached async operations (directory loads, unread sync, push bootstrap, invite recovery) were not fenced against community switches, identity rotations, or sign-out, causing state leaks or liveness failures across tenant boundaries (consistent)
+  → **Support:** Before submitting any PR that introduces a detached async operation, brow should complete a self-checklist: (1) identify every async gap (await points and callbacks), (2) verify that the owning scope (community ID, signing identity, relay generation) is re-checked after each gap, and (3) add a unit or integration test that changes the active community or signs out mid-operation and asserts no state bleed. Pair with a senior reviewer specifically on the lifecycle section of each PR before requesting a full review.
+- Durable error and failure-recovery paths: PR #5915 (invite recovery not persisted across restarts), PR #6269 (push revocation not durable, bootstrap failures not retried), and PR #7158 (incremental DB migration missing) all show a recurring pattern of happy-path implementation without corresponding durable recovery or rollback logic (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For every new persistent state change or external enrollment step, brow should explicitly design the failure and partial-completion cases before writing the implementation. A lightweight design doc or PR description section titled 'Failure modes and recovery' should be required for high-risk PRs. Reviewers should be asked to evaluate this section first. For push and relay registration specifically, sketch a state machine with terminal failure and retry states before coding.
+- Regression test coverage accompanying fixes and infrastructure changes: PR #7187 fixed an iOS linker regression without a falsifiable regression guard, and PR #7158 changed the deployment schema snapshot without an incremental migration — both are patterns where the fix is correct but leaves the codebase vulnerable to recurrence (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Establish a personal norm: every bug fix PR includes at least one test that would have caught the original bug. For infrastructure/CI changes, add a path filter to CI that re-runs the relevant guard when the changed file is touched. Pair with the team on setting up a schema migration test harness so incremental migrations are verified automatically, reducing reliance on reviewer detection.
+- Security-sensitive surface area — token custody, APNs configuration, and deployment trust: PR #6269 saw multiple rounds of changes around APNs topic/environment misconfiguration and App Attest authority; PR #7158 had a deployment verification step that only retrieved an artifact rather than validating its integrity (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** When working on push token custody, APNs entitlements, or deployment artifact verification, brow should reference OWASP guidelines on cryptographic failures and software integrity before opening the PR. For deployment PRs specifically, have a security-focused reviewer audit the verification steps in documentation. Consider creating a team checklist for 'push security review' covering: token scope, environment/topic alignment, revocation durability, and artifact integrity checks.
+
+### evanchen7
+**Trajectory:** insufficient-data — Only one PR is available in the window, so no chronological trend can be established.
+
+**Strengths:**
+- Scoped, focused fixes: the PR targets a specific bug (truncated repository trees) without sprawling into unrelated areas, keeping the change reviewable and well-bounded. (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive to reviewer feedback: inline comments show the author (via Codex) acknowledged accessibility and IPC payload concerns and addressed the aria-live region gap in a follow-up commit. (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Incomplete feature parity after truncation removal: the backend returns all paths but `parse_ls_tree` / `parse_worktree_files` still set `preview_content = None` beyond the eager-preview cap, leaving files visible but unopenable — a P1 correctness gap caught by a reviewer rather than the author. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before submitting, walk through each user-facing action enabled by the change (open file, preview content) and verify it works end-to-end, not just that the data appears in the list. A short self-review checklist — 'can the user do X with every item now returned?' — would catch this class of regression before review.
+- IPC payload and memory impact not assessed: removing the file-list cap can produce very large payloads for big repositories; no size ceiling or streaming strategy was included or discussed in the PR description. (occasional) — *DORA research — https://dora.dev/research/*
+  → **Support:** When a change shifts data-volume constraints (e.g., removing a cap), include a brief impact note in the PR description estimating worst-case payload size and whether it is acceptable. For desktop IPC, consider documenting a follow-up ticket for backend pagination so the trade-off is explicit and tracked rather than deferred silently.
+- Accessibility considerations not proactively included: the aria-live region for the paginated count was only added after a reviewer raised it, suggesting a11y is not yet part of the author's default UI checklist. (occasional)
+  → **Support:** Add an accessibility spot-check to the personal definition-of-done for any UI change: dynamic content updates (counts, list changes) should have an aria-live region; interactive controls should have descriptive labels. Pairing with a team member on one accessibility-focused review session would help internalize the pattern.
+
+### jedwards27
+**Trajectory:** insufficient-data — Only two PRs are available and they span different artifact types (code fix vs. docs), making it impossible to establish a directional trend; more PRs touching similar surfaces are needed before a trajectory can be assessed.
+
+**Strengths:**
+- Targeted, well-scoped fixes: PR #6058 addresses a specific orientation bias in video resolution validation with a clean short/long-edge normalization approach that preserves the existing pixel envelope without breaking backward compatibility. (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Documentation discipline: PR #7061 proactively captures review-proven failure-path and async-state rules in contributor-facing docs, showing awareness that hard-won knowledge should be codified. (emerging) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+
+**Growth areas:**
+- Test coverage accompanying changes: neither PR surfaces evidence of added or updated tests. For a validation change like #6058 (portrait resolution acceptance), explicit unit tests covering the new orientation-agnostic boundary cases are expected in product-engineering work. (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** In the next PR that touches validation or parsing logic, require at least one new parameterized test covering the changed behavior (e.g., portrait vs. landscape dimension pairs at the boundary). Pair with a reviewer who can model what a complete test matrix looks like for the specific module, and reference the project's existing test patterns in crates/buzz-media as a template.
+- Explicit error-path documentation in code changes: the validation fix in #6058 changes acceptance criteria but reviewer notes do not indicate that error messages, user-facing rejection reasons, or logging were updated to reflect the new logic, leaving observability of the corrected path unclear. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When submitting fixes to validation logic, include a brief PR description section titled 'Error paths touched' listing any changed rejection messages, log lines, or metrics. A one-time pairing session with a senior engineer to walk through the observability checklist for buzz-media would help build this habit early.
+
+### jmecom
+**Trajectory:** improving — Early PRs (#6838, #6816) required multiple CHANGES_REQUESTED rounds for missed production paths, while later PRs (#6913, #7004) received single-round approvals with no blocking findings, suggesting the author is internalizing reachability feedback over the window.
+
+**Strengths:**
+- Security-focused engineering: consistently ships changes that address real security boundaries — access policies, signing keys, authorization time bounds, and advisory routing — with clear threat modeling evident in the work (consistent) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Responsiveness to review feedback: across multiple PRs (especially #6838 and #6816) the author iterates quickly on CHANGES_REQUESTED cycles, addressing blocking correctness and security findings and landing approvals (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Small, focused changesets: PRs have narrow scope (remove a fallback, enforce a cooldown, fix authorization) which supports fast review cycles and low blast radius (consistent) — *DORA research — https://dora.dev/research/*
+
+**Growth areas:**
+- Full-path coverage before opening a PR: in #6838 the fix only covered one provisioning path; two production call-sites (useMentionSendFlow.ts, useQuickBotDrop.ts, template application) that omit respondTo were missed, requiring two additional CHANGES_REQUESTED rounds. In #6816 the review-freshness contract omitted baseSha, requiring another round. This pattern of incomplete reachability analysis appears across multiple PRs. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a security or correctness PR, explicitly enumerate every call-site or code path that touches the affected invariant (e.g., grep/AST search for all callers of the changed function, all jobs that read the changed contract). Add a checklist in the PR description listing each path and confirming coverage. A pairing session with a senior engineer on one upcoming PR to walk through this reachability exercise together would accelerate the habit.
+- Test coverage accompanying security fixes: reviewer feedback in #6838 noted the helper test was mutation-sensitive but the real composer identity-reuse path still bypassed the helper, suggesting the test did not exercise the actual production flow. No reviewer comments across the window celebrate strong test additions for security-critical paths. (consistent) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** For every security-fixing PR, require at least one integration or end-to-end test that exercises the exact production entry point being hardened — not just the extracted helper. Pair with the team's test infrastructure owner to identify the right test layer (e.g., Playwright for the composer flow in #6838). Reference the failing state (test red before fix, green after) in the PR description to make coverage intent explicit.
+- Proactive documentation of trust boundaries and invariants in PRs: reviewers in #6816 and #6838 had to independently trace the trust model (auth re-resolution, head pinning, policy precedence). The author does not appear to pre-document these in PR descriptions, which increases reviewer load and the chance of missed edge cases. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a short security-PR template: (1) state the invariant being enforced, (2) list every path that must satisfy it, (3) describe how the change closes the gap on each path, (4) note paths explicitly out of scope. This shifts reachability analysis from reviewers back to the author and shortens review cycles.
+
+### kalvinnchau
+**Trajectory:** stable — Across all five PRs the pattern is consistent — competent initial implementation with recurring gaps in runtime validation and edge-case coverage that are caught by review rather than self-caught, with no clear reduction in reviewer-identified issues from the earliest to the most recent PR.
+
+**Strengths:**
+- Responds to review feedback and iterates to resolution without abandoning PRs (consistent) — *https://google.github.io/eng-practices/review/*
+- Delivers self-contained, well-scoped features and fixes (manifest alignment, catalog discovery, UI controls) that reviewers can trace end-to-end (consistent)
+- Works across the full stack (Rust backend, TypeScript frontend, Playwright E2E) indicating broad ownership of changes (consistent)
+
+**Growth areas:**
+- Pre-merge runtime verification — multiple PRs ship with bugs caught only by automated reviewer E2E runs (Global Defaults label not persisting, floating-point zoom accumulation, UC model service admission without API-type screening), suggesting changes are not manually or locally validated against the full user-visible flow before submission (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Establish a personal pre-PR checklist that includes running the project's E2E suite locally (pnpm build:e2e + playwright test) and exercising the specific UI state that changed — especially persisted/closed picker states and boundary conditions — before opening the PR. Pair once with the reviewer to walk through their E2E capture workflow so the author internalizes what signals to look for.
+- Explicit error-path and edge-case coverage — reviewer-identified gaps (FQN special-casing only on Rust side, missing supported_api_types screening, floating-point endpoint drift) indicate edge cases are not being considered during initial implementation (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For each new code path, explicitly enumerate: (1) what happens at the minimum and maximum valid inputs, (2) what happens when an optional field is absent or empty, and (3) whether both sides of a dual-implementation (Rust + TS) receive the same logic. Add a brief comment in the PR description documenting these cases considered, which creates accountability and a review anchor.
+- Cross-interpreter parity — logic added to one interpreter (Rust or TypeScript) is repeatedly not mirrored in the other, requiring reviewer correction (FQN check absent from TS side in PR #6918) (emerging)
+  → **Support:** When a behavioral rule must exist in both Rust and TypeScript interpreters, create a shared test fixture or integration test that exercises both paths and fails if they diverge. If the codebase lacks such a harness, propose adding one as part of the PR that introduces dual-interpreter logic.
+- Dead-code hygiene — reviewer found immediately-overwritten assignments (dead `capability_model` field in PR #6918), suggesting insufficient self-review before submission (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before marking a PR ready, do one pass reading only the diff (not the full file) looking specifically for assignments, imports, or branches that are never read downstream. Enable and address compiler/linter warnings as a forcing function.
+
+### klopez4212
+**Trajectory:** improving — Later PRs (7121, 7112, 6978, 6583) show klopez4212 addressing more reviewer findings per cycle and shipping increasingly comprehensive fixes, but the same foundational gaps in async lifecycle, test coverage, and accessibility appear repeatedly, indicating the improvement is in execution speed rather than in eliminating root causes.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback — consistently addresses blocking findings across multiple revision cycles without abandoning the PR (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Cross-platform scope — ships coordinated changes across Flutter/Dart, Swift/iOS, Kotlin/Android, Rust relay, and TypeScript/desktop in a single PR lifecycle (consistent)
+- Security-aware relay proxy design — GIF proxy PR (5554) correctly keeps API key server-side, implements NIP-98 verification, replay guard, membership enforcement, per-pubkey quota, and response-size cap (emerging) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Test accompaniment — adds focused widget regressions, Playwright E2E specs, and unit tests alongside production code changes when prompted; coverage is improving across the window (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- File-size discipline — responds to 1,000-line ceiling violations by splitting files into focused siblings (profile editor tests, NativeEmojiPicker, image capture sub-widgets, AppDelegate packager) (consistent)
+
+**Growth areas:**
+- Shipping incomplete error and lifecycle paths — consistently misses terminal error handling, cancellation fences, and teardown races in async native/Dart code on first submission (Huddles MVP, voice notes, profile editing, emoji picker, camera capture all had P1/P2 lifecycle blockers) (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that touches async lifecycle (recording, playback, upload, camera, community switch), author should produce a written teardown/cancellation checklist: for every async operation, document what happens if (a) the widget/route unmounts, (b) the community changes, (c) the operation partially succeeds. A senior reviewer should sign off on this checklist rather than discovering gaps post-submission.
+- Proactive regression test coverage — tests are added reactively after reviewers flag missing coverage rather than shipped with the initial PR; the same gap appears in voice notes, profile editing, emoji picker, huddle presence, timeline tail, and message actions (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal pre-PR checklist: for every new public API or behavioral invariant, write at least one focused widget/unit test before opening the PR. Pairing with jedwards27 or wesbillman to review a draft test plan before coding would surface coverage gaps earlier and reduce the number of change-request rounds.
+- Accessibility completeness — VoiceOver/TalkBack semantics, live regions, Dynamic Type, and contrast are consistently flagged as missing on first submission across mobile emoji picker, message actions, profile editing, avatar editor, activity highlight, and voice note waveform (consistent)
+  → **Support:** Add an accessibility checklist to the PR template for mobile changes: (1) every interactive widget has a semantics label, (2) live-region announcements cover async state changes, (3) Dynamic Type is exercised with a large-text widget test, (4) new iOS native controls pass VoiceOver manual verification. Running TalkBack/VoiceOver on a device against each new surface before opening the PR would eliminate the majority of these late-cycle findings.
+- Intentional deferral of valid reviewer concerns — repeated pattern of marking reviewer-raised bugs as 'intentional' or 'out of scope' when they are later confirmed to be real defects (emoji category rail, keyboard inset, skin-tone sync, iOS theme mismatch, Reduce Motion avatar handoff) (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** When declining a reviewer suggestion, write a falsifiable technical reason (e.g., 'UIKit already handles this at layer X') rather than citing design intent. If a reviewer re-raises the same concern, treat that as a signal to prototype the fix before deciding. A lightweight async post-mortem after each PR that required >4 change-request rounds would help identify which 'intentional' replies were actually mistaken.
+- API and public symbol documentation — doc comments on new public constructors, callbacks, constants, and exported helpers are consistently absent on first submission and added only after P1 reviewer flags (consistent)
+  → **Support:** Add a pre-commit lint step or CI check that enforces doc comments on all public Dart/Swift symbols introduced in the diff. Treat documentation as part of the definition of done before opening the PR, not as a separate cleanup task. Reviewing one well-documented PR from a colleague before opening each new PR would build the habit quickly.
+- State machine correctness in distributed/concurrent scenarios — replay ordering, generation fencing, admission tombstoning, and stale settlement in the Huddle presence runtime required a very large number of change-request rounds across PRs 7112, 6056, 6312, and 6297 (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For features involving relay-backed lifecycle state (presence, roster, liveness), author should draw an explicit state machine diagram including all terminal and retry states before writing code, and share it with jedwards27 for review. Deterministic property-based or sequential-replay unit tests against the state machine model should ship with the initial PR rather than being added incrementally after regressions are identified by reviewers.
+
+### kruegermj
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to establish a directional trend.
+
+**Strengths:**
+- Targeted, coherent CSS stacking-context fix with clear scoping rationale (emerging)
+
+**Growth areas:**
+
+### kursmark-sq
+**Trajectory:** insufficient-data — Only one PR is available in the review window, which is insufficient to establish any trend or pattern.
+
+**Strengths:**
+
+**Growth areas:**
+
+### loganj
+**Trajectory:** improving — Early PRs in the window (e.g., #6222) show process gaps like missing DCO, while later high-complexity PRs (#7127, #7129) show loganj self-reviewing intermediate states and writing targeted fixes that satisfy reviewers more quickly across iterations, suggesting growing review-loop efficiency even if first-submission correctness on state-handling remains a recurring gap.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: across multiple high-risk PRs (e.g., #7122, #7127, #7129), loganj consistently pushes targeted follow-up commits that directly address reviewer blockers, often closing findings within the same review cycle. (consistent) — *https://google.github.io/eng-practices/review/*
+- Scoped, well-bounded changes: PRs tend to address a single concern (e.g., autocomplete filtering in #6156, mention spacing in #7128, provenance markers in #7129), making them tractable to review and limiting blast radius. (consistent) — *https://google.github.io/eng-practices/review/*
+- Security and dependency hygiene: proactive dependency bump for a published CVE/RUSTSEC advisory (#6222) demonstrates awareness of supply-chain risk and timely response. (emerging) — *https://owasp.org/www-project-top-ten/*
+
+**Growth areas:**
+- Correctness of state/availability semantics on first submission: PRs #7122 and #7127 both required multiple CHANGES_REQUESTED rounds for the same class of defect — unknown/pending states being collapsed into a concrete value (e.g., 'Offline') rather than preserved as undefined. This is a recurring first-attempt gap in handling ambiguous or unresolved runtime state. (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR that touches presence, availability, or any tri-state/nullable status field, add a checklist item: 'Does every consumer of this value handle undefined/unknown without collapsing it to a default?' Add a unit test asserting that an unresolved input produces an unresolved output, not a fallback sentinel. Pair with a reviewer early (design-level comment) on any PR touching signed runtime or policy state.
+- Test coverage accompanying production changes: multiple high-risk PRs (especially #7122 and #7127) required reviewer-prompted test additions or synchronization repairs late in the review cycle rather than including them in the initial commit. Tests for edge-state paths (e.g., failed/disconnected reads, retry journeys) arrived as follow-up commits. (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal pre-push gate: for any PR touching data derivation or UI state, include at least one test covering the 'unknown/error' path before opening for review. Reference the DORA finding that fast feedback loops require test coverage at the PR level. Consider a PR description template with a required 'Tests added for happy path, error path, and unknown/pending state' checkbox.
+- DCO/commit hygiene: PR #6222 received a P1 flag for a missing Signed-off-by trailer, indicating the commit signing workflow is not yet habitual. (occasional)
+  → **Support:** Configure a local Git hook (prepare-commit-msg or commit-msg) that automatically appends the Signed-off-by trailer, or add 'git commit -s' as a muscle-memory alias. This is a one-time setup that eliminates the class of error permanently.
+- Nondeterministic test gates added within PRs: PR #7129 was blocked because a reviewer-required smoke gate added by the PR was itself nondeterministic at the initial head, and PR #7127 required multiple E2E synchronization repairs for async races in the test harness. (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Run newly added E2E or integration tests locally at least three times before pushing to catch flakiness. For async/event-driven tests, apply an explicit wait-for-state assertion rather than timing-based waits, and document the synchronization strategy in a comment. Consider a local script that re-runs only the PR-added tests N times and reports pass rate.
+
+### lucasisaza
+**Trajectory:** insufficient-data — Only one PR is available in the review window, providing no basis for trend analysis.
+
+**Strengths:**
+
+**Growth areas:**
+
+### mahanti
+**Trajectory:** stable — All three PRs follow the same pattern of correct eventual delivery after multiple reviewer-identified defect cycles, with no clear reduction in the number of blocking findings per PR over the review window.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: across all three PRs, mahanti consistently revises and resubmits until blockers are resolved, demonstrating a productive review loop (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Delivering user-visible and platform-spanning features (avatar rendering, experiment gating, persistent agent experience) that require coordinating multiple subsystems (consistent)
+- Sustaining work through high reviewer round-trip counts (PR #6902 had 10+ review cycles) without abandoning the PR, indicating persistence and ownership (consistent) — *DORA research — https://dora.dev/research/*
+
+**Growth areas:**
+- Atomic, safe state mutation and rollback correctness: reviewers flagged fail-open resolvers (PR #6902), partial-deletion leaving inconsistent state (PR #7223), and rollback failures that durably tear assignments across scopes (PR #7223). The same class of defect — incomplete or non-atomic cleanup — appeared across two PRs. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Pair with a senior engineer on a focused session covering transactional state-machine design: model each destructive operation as acquire-mutate-commit with explicit compensation on any failure branch before touching persistent state. Practice by rewriting PR #7223's delete_managed_agent flow on a whiteboard showing the exact ordering of process stop, assignment clear, and persist steps, and identifying which failures require rollback.
+- Compile-time / runtime capability boundary enforcement: PR #6902 required multiple cycles to correctly separate OSS and protected-build module graphs; the fail-open default and missing explicit disable in child workspaces were caught by reviewers, not surfaced proactively. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before submitting any PR that introduces a feature flag or build-time gate, author a short design note (even a PR description section) that explicitly states: (1) what is included/excluded in each artifact, (2) the default when the capability is absent, and (3) how the OSS child explicitly disables rather than omits the flag. Ask a reviewer to validate this note before code review begins to catch boundary mismatches early.
+- Error-path coverage and explicit failure handling: across PR #6902 (fail-open resolver) and PR #7223 (unguarded pre-deletion of assignments), the happy path was implemented but failure branches were under-specified, requiring reviewer discovery. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a personal checklist item before each PR submission: for every destructive or async operation, enumerate at least two failure modes in a code comment or test, and assert the system is left in a valid state for each. Start by adding these assertions retrospectively to PR #7223's with_agent_assignment rollback path as a learning exercise.
+- Upfront scope and risk articulation: several PRs were initially rated medium risk by reviewers but escalated to high (PR #6902 packaging boundary, PR #7223 cleanup durability) after deeper inspection, suggesting the author's own risk assessment lags behind reviewer findings. (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, write a one-paragraph risk section in the description that names the blast radius (which platforms, which persistent stores, which concurrent actors). Share it with a peer for a 10-minute verbal review before opening the PR formally. This surfaces high-risk paths earlier and reduces late-cycle REQUEST CHANGES cycles.
+
+### matt2e
+**Trajectory:** improving — Earlier PRs (August) sailed through with zero or one review round; the more complex async and focus-ownership work in late August and September attracted multi-round cycles, but the author closed every blocker within the same PR, and reviewers on the final PRs note prior findings resolved — indicating growing ability to handle harder problem classes even if initial coverage still has gaps.
+
+**Strengths:**
+- Narrow, well-scoped fix PRs: the majority of PRs target a single, clearly identified bug with contained blast radius (UI thread offloading, scrolling stabilization, right-click tray hiding, mention draft space, pulsing agents). Reviewers consistently note changes are 'narrowly scoped' and approve with minimal iteration. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive iteration on reviewer feedback: when blockers are raised (e.g., mixed-selection link paste in #6684, Shift+Space regression in #6862, keyboard accessibility in #6860), the author produces corrective commits in the same PR cycle rather than abandoning or reopening. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Test coverage accompanies behavioral changes: reviewers on #6862 and #6684 specifically call out test guard-rails ('the guard rails in the tests are the good part') as correctly pinning edge cases like partial-name matches, modifier-key guards, and IME composition states. (consistent)
+- Correct use of UI-thread separation for runtime/native calls: PR #6445 was approved without blocking findings after reviewers traced the full members-sidebar gate and native command contract, indicating solid platform-layer discipline. (emerging)
+
+**Growth areas:**
+- Keyboard accessibility coverage in interactive UI components: PR #6860 required six consecutive CHANGES_REQUESTED rounds across multiple heads because focus ownership and Shift+Tab keyboard paths to overlay controls were repeatedly dropped or regressed. The same class of omission (keyboard user path to mention Options) recurred across every iteration until explicitly restored. (consistent)
+  → **Support:** Before submitting any PR that modifies focus management, overlays, or composer controls, run a self-audit checklist covering: Tab/Shift+Tab traversal into and out of all interactive children, keyboard-only activation of every overlay trigger, and focus restoration on dismiss. Pair with an accessibility-aware teammate for a 30-minute walkthrough on the first PR after this review to build muscle memory for the pattern.
+- Concurrency and lifecycle ordering in async publish flows: PR #7154 generated the longest review cycle (8+ CHANGES_REQUESTED rounds) because the publish-before-wake ordering introduced multiple races — premature 'message sent' UI confirmation before relay acceptance, detached wake without settled authorization, duplicate deployment on A→B→A community switches, and a 200 ms grace window that still published without confirmed auth. These are distinct but structurally related failures in async sequencing. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For any PR that reorders async operations (publish, wake, deploy, authorize), produce an explicit sequence diagram or state-machine sketch before writing code and attach it to the PR description. Review it against these three questions: (1) Can the UI report success before the server confirms? (2) Can a detached async branch outlive its owning context? (3) Is authorization re-evaluated after all suspensions? Schedule a design review with a senior engineer before implementation on high-risk async PRs to catch ordering assumptions early.
+- Anticipating partial/mixed-state edge cases in editor operations: PR #6684 initially missed the case where a mixed markable/unmarkable selection would be consumed after only partial link application. This is consistent with the mention-space PR (#6862) missing the Shift+Space modifier and the autocomplete PR (#6860) missing keyboard-only paths — a pattern of 'happy path' completeness with gaps in mixed or adversarial input states. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a pre-submission adversarial test habit for editor/input PRs: enumerate at least three 'what if the selection is not clean?' scenarios (mixed node types, modifier keys held, IME composing, empty range) and write or verify a test for each before requesting review. Reviewing one prior PR per quarter where an edge-case gap was caught can help internalize the pattern.
+- Force-push hygiene: in PR #6860 a force-push dropped a previously approved keyboard-accessibility fix, requiring the reviewer to flag the regression explicitly. This added at least one extra review round. (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** When rebasing or amending during an active review, diff the outgoing force-push against the previously approved head before pushing and call out in the PR comment what was intentionally removed vs. preserved. Consider using fixup commits instead of force-pushes during the review window to keep reviewer context intact.
+
+### morgmart
+**Trajectory:** improving — Chronologically, PRs move from multi-round changes-requested cycles (#6529) toward clean first-pass approvals (#6892, #6665), suggesting the author is internalizing surface-coverage thinking and landing tighter changes over the window.
+
+**Strengths:**
+- Placing fixes at the correct contract owner — changes are scoped to the authoritative source (e.g., Rust producer for feed categories, root rem for zoom) rather than patching symptoms at call sites (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive iteration on reviewer feedback — across multiple PRs (especially #6359 and #6529) the author resolves raised issues and lands clean re-reviews, indicating strong collaboration hygiene (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Appropriately narrow feature scope — changes are consistently described as deliberately bounded (e.g., narrow link parser, small ownership split for zoom), reducing blast radius per change (consistent)
+
+**Growth areas:**
+- Validation and ordering correctness on first submission — PR #6359 required a revision to fix local validation ordering for the explicit target form before it could be approved, indicating the initial implementation missed an edge-case sequencing invariant (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that involves multi-step input parsing or validation chains, write out the intended execution order as inline comments or a brief doc-comment on the entry function, then verify each step in a test. Add at least one unit test per distinct input path (canonical link, malformed link, missing fields) to catch ordering regressions before review.
+- Sustained changes-requested cycles on UI interaction PRs — PR #6529 accumulated three consecutive CHANGES_REQUESTED rounds before approval, suggesting shared-surface UI changes (toolbar, reaction rail) ship without fully mapping all interaction contexts (keyboard, touch, narrow layout, inbox) upfront (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** For shared message-action surface changes, create a short pre-PR checklist that enumerates every consumer surface (channel, thread, inbox, keyboard shortcut, touch, narrow layout) and confirm each is handled or explicitly out of scope. Share this checklist in the PR description to make coverage visible to reviewers and reduce round-trips.
+- CI readiness at time of review request — PR #6193 received an initial COMMENT verdict specifically because required CI had not completed successfully at the exact head, adding unnecessary review latency (occasional) — *DORA research — https://dora.dev/research/*
+  → **Support:** Adopt a personal discipline of waiting for all required status checks to pass on the exact PR head before requesting review. Use GitHub's draft PR state during active iteration and convert to ready-for-review only after CI is green, reducing reviewer context-switching and rebase churn.
+
+### ngthuydiem
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to establish a meaningful trajectory.
+
+**Strengths:**
+- Test correctness and precision: identified and fixed a subtle test fragility caused by a separator character collision with wordlist entries, demonstrating careful attention to test reliability (emerging)
+
+**Growth areas:**
+
+### philazar
+**Trajectory:** insufficient-data — Only one PR is available, so no chronological trend can be established; the author shows responsiveness and a testing instinct but needs to develop more rigorous pre-submission verification habits.
+
+**Strengths:**
+- Responsive to reviewer feedback: acted quickly on inline comments (e.g., slug realism) and iterated through multiple change-request cycles without abandoning the PR (emerging) — *https://google.github.io/eng-practices/review/*
+- Regression test coverage: proactively added a benchmark regression task alongside the memory-retrieval fix, demonstrating awareness of observable, verifiable behavior (emerging)
+
+**Growth areas:**
+- Grader/verifier correctness: the score_evidence() function accepted semantically negated answers (e.g., 'Do not use net_gpv') because it matched on token presence alone, requiring multiple change-request rounds before the logic was sound (occasional)
+  → **Support:** Before submitting evaluation or scoring code, explicitly enumerate false-positive and false-negative cases in a comment or docstring, and add at least one negation-phrased test fixture to confirm the grader rejects it. Pair-review grader logic with a teammate before opening the PR to catch logical blind spots early.
+- Test fixture realism: a randomly generated slug ('7f2a') was committed without intentional design, only corrected after a reviewer question (occasional) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a personal checklist for test fixtures: every hardcoded value should have a one-line comment explaining its origin and why it was chosen. For seed data, prefer values that are either semantically meaningful or explicitly documented as arbitrary, reducing reviewer cognitive load.
+
+### ravarora2
+**Trajectory:** insufficient-data — Only two PRs in the window, both approved cleanly on consecutive days, which is positive but too small a sample to establish a directional trend.
+
+**Strengths:**
+- Observable instrumentation: both PRs add well-scoped, meaningful metrics (readiness signals and pool acquisition tracking) with no critical findings across independent review lanes (emerging)
+- Clean, reviewable changesets: reviewers found no critical or important issues in either PR, suggesting disciplined scoping and self-review before submission (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Test coverage accompanying instrumentation changes: review summaries do not mention tests validating new metric emission paths or correctness of recorded values (occasional) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For each new metric path, add at least one unit or integration test that asserts the metric is emitted with expected labels/values under a known condition; reviewers should explicitly check for this in future PRs to build the habit.
+- Explicit error path coverage in metrics: neither PR summary mentions handling or recording failure/timeout states in the new metric instrumentation (occasional)
+  → **Support:** When adding observability code, document and test the failure branch (e.g., pool acquisition timeout, unhealthy readiness state) so dashboards and alerts can distinguish error conditions from absence of data.
+
+### salman1993
+**Trajectory:** improving — Earlier PRs show raw correctness gaps caught by reviewers (Windows path parity, scripted-event races, resource lifecycle), while later PRs demonstrate salman1993 self-reviewing and responding to agent-reviewers with precise, well-explained fixes, suggesting growing internalization of reviewer expectations even as new feature surface area continues to introduce fresh edge cases.
+
+**Strengths:**
+- Prompt engineering and agent instruction design: consistently delivers focused, purposeful changes to base prompts and ACP guidance with clear rationale for each addition or removal (consistent)
+- Benchmark infrastructure: builds well-structured evaluation harnesses with layered regression and workflow task separation, verifier adversarial coverage, and clear README documentation (consistent)
+- Iterative responsiveness to review feedback: consistently addresses reviewer blockers with follow-up commits and explicit comments explaining how each concern was resolved (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Cross-cutting feature scoping: PRs are tightly scoped to a single concern (session policy, tilde expansion, deduplication), making them straightforward to review and merge (consistent) — *DORA research — https://dora.dev/research/*
+
+**Growth areas:**
+- Edge-case and resource lifecycle handling in infrastructure code: multiple PRs (session pool LRU/TTL in #6732, Windows HOME vs USERPROFILE parity in #6271, scripted-event completion race in #6448/#6487) required reviewers to identify missing bounds or correctness gaps before merge (consistent) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that introduces a new resource pool, concurrent state, or OS-dependent path, author a checklist of failure modes (exhaustion, race, platform divergence) and document how each is handled or explicitly deferred. Pair with a senior reviewer for a pre-PR walkthrough of the lifecycle diagram so gaps surface before the formal review cycle rather than through multiple CHANGES_REQUESTED rounds.
+- Deterministic test design: E2E tests in #6887 relied on timing-based assertions (4s delay inside a 5s Playwright retry window) that could false-green on the buggy implementation, requiring two rounds of reviewer-identified rework before a correct manual gate was introduced (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a practice of explicitly asking 'can this test pass on the broken code?' for every new assertion before submitting. For UI/async tests, prefer explicit gates or intercept stubs over time-based tolerances, and write at least one negative assertion (e.g., assert the stale value appears before the fix lands) to prove the test actually detects the bug.
+- Completeness of UI feature delivery: #7208 shipped a new agent preset without the required catalog copy entry, leaving a visible gap in the product UI that reviewers had to catch (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Maintain a per-feature checklist for UI additions (copy strings, help text, icons, accessibility labels) and run through it before marking a PR ready-for-review. A short PR template section ('UI checklist: [ ] copy added [ ] help text updated') would surface these gaps at authoring time rather than review time.
+- Anticipating downstream behavioral impact when removing prompt or code guardrails: #6340 removed CLI command discovery guidance without pairing it with an improved --help output, and #6501 initially dropped workspace grounding without a behavioral replacement, each requiring a reviewer to flag the regressive impact (consistent) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When a PR removes existing guidance or guardrails, explicitly document in the PR description what previously-covered behavior is now covered elsewhere, or what new mechanism replaces it. If no replacement exists, treat the removal as a breaking change and either add the replacement in the same PR or defer the removal.
+
+### tellaho
+**Trajectory:** improving — Later PRs (#6837, #6718, #7242) resolve in fewer review rounds and receive first-round or near-first-round approval, suggesting tellaho is internalizing reviewer expectations around test quality and contract completeness, even though the same structural gaps still appear in new feature work.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: consistently addresses blocking findings across multiple review rounds and ships to approval (consistent) — *https://google.github.io/eng-practices/review/*
+- Scoped, focused PRs: changes are generally narrowly targeted to a specific feature or fix area (composer, workflows, sidebar, desktop layout) rather than sprawling across unrelated systems (consistent)
+- UI/UX surface coverage: delivers user-visible features and polish (chip wrapping, tooltip contrast, sidebar overflow, composer caret) with consistent attention to behavioral correctness (consistent)
+- Engagement with inline review comments: in PR #6470 the author actively commented on reviewer findings and acknowledged fixes commit-by-commit (emerging) — *https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Test oracle quality and regression proof: reviewers repeatedly flag that added tests do not deterministically cover the failure being fixed (PR #6606 WebKit stale path, PR #6581 nondeterministic tooltip regression, PR #6897 smoke contract not updated), requiring additional iterations solely to strengthen test evidence (consistent)
+  → **Support:** Before opening a PR, write the regression test first and confirm it fails on the pre-fix code, then passes after the fix. For UI/layout regressions, make the test assertion deterministic by awaiting a stable DOM condition rather than relying on timing. Pair with a senior engineer to review the test oracle before the PR is posted, targeting the 'tests accompanying changes' expectation of the product-engineering lens.
+- Cross-surface contract consistency: features are initially implemented on one code path but the same contract is missing from sibling paths (PR #6009: WS REQ fixed but HTTP /query, COUNT, and cache paths left broken; PR #6008: enable/disable path silent on failure), requiring multiple CHANGES_REQUESTED rounds to achieve full coverage (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before marking a PR ready, enumerate every call site or transport surface that participates in the changed contract (e.g., HTTP, WebSocket, cache, and event-bus paths) and verify each one is covered by the implementation and by at least one test. A checklist comment in the PR description listing each surface and its disposition would both surface gaps early and communicate intent to reviewers.
+- Explicit error path handling: silent failures appear repeatedly (PR #6008: rejected update_workflow calls left visible status unchanged; PR #6470: activation boundary bypassable without warning), indicating that unhappy paths are not systematically considered during initial implementation (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a 'what happens when this call fails?' checklist for every async operation or state mutation: decide explicitly whether the failure should surface an error state, revert optimistic UI, or be logged. Document the decision in a code comment. Add at least one test for the rejection/error path alongside the happy-path test before opening the PR.
+- Accessibility correctness on first submission: nested interactive elements and missing reduced-motion support surface as blocking P1/P2 findings across multiple PRs (PR #6008 nested Radix Switch inside menuitemcheckbox, PR #6000 collapse animation lacking prefers-reduced-motion guard) (consistent)
+  → **Support:** Run axe-core or a similar automated accessibility audit locally as part of the development loop before opening any PR that adds or modifies interactive UI. Add a prefers-reduced-motion check to a shared animation utility and require its use in code review guidelines for any new CSS transition or animation. A short pairing session with the team's accessibility lead to review ARIA role constraints would help build intuition for nested-interactive patterns.
+- State invariant completeness in complex UI features: initial submissions of multi-state features (workflow editor dirty state, agent addressing persistence, composer mention lifecycle) frequently miss edge-case invariants — Back/Forward bypass of dirty guard (PR #6575), module-global clear tombstone scope leak (PR #6793), duplicate-mention deletion loop (PR #6956) — each requiring 3–5 additional review rounds (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For features with persistent or lifecycle state, write a state-machine diagram or prose invariant list (e.g., 'enabled field is never absent after save', 'automatic mention ownership is cleared on user deletion') before coding. Include that invariant list in the PR description so reviewers can validate against it. Consider property-based or scenario-table tests that enumerate state transitions, not just the happy path.
+
+### thomaspblock
+**Trajectory:** improving — Later PRs (#6980, #7013, #7137) resolved blockers in fewer review rounds and with cleaner fixes than the highly iterative early PRs (#6003, #6590), indicating that thomaspblock is internalizing reviewer feedback on trust-boundary correctness and test coverage, though the same root-cause patterns still appear at submission time.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: consistently addresses blocker findings across multiple review rounds and lands PRs after thorough remediation (consistent) — *https://google.github.io/eng-practices/review/*
+- Self-directed adversarial/security review: proactively conducts and posts Cassandra security re-reviews on own and adjacent PRs, tracing trust boundaries through mutable relay/identity state (consistent) — *https://owasp.org/www-project-top-ten/*
+- Feature scope management: delivers focused, well-scoped PRs (UI polish, navigation, empty states, error surfaces) alongside larger architectural changes (consistent)
+- Cross-boundary defect recognition: demonstrates growing ability to identify and fix cross-tenant, cross-identity, and cross-relay state leaks after initial reviewer flags (emerging) — *https://owasp.org/www-project-top-ten/*
+
+**Growth areas:**
+- Catching async/concurrent trust-boundary defects before review: repeated P1 blockers across PRs #6003, #6368, #6590, #6939 involve mutable relay/identity state being read at different points in async flows, leading to cross-tenant or stale-authority context leaking to agents (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** Before submitting any PR that touches agent startup, relay selection, or project authority resolution, apply a written checklist: (1) identify every async await point in the flow, (2) verify that relay URL and signing identity are captured as immutable locals before the first await and never re-read from mutable state afterward, (3) confirm that failure modes close rather than fall through to a degraded context. Pair with a senior reviewer to walk through one PR using this checklist explicitly before submission.
+- Test coverage accompanying changes: multiple PRs required reviewer-demanded regression tests (e.g., #6429 mention caret, #7013 channel history retry, #6980 empty-state assertion scope) before approval; tests were added reactively rather than proactively (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal pre-submission rule: every new observable behavior (error state, retry, caret insertion, auth boundary) must have at least one Playwright or unit test that would fail if the production wiring broke. Reference the project TESTING.md contract. Before marking a PR ready, add a checklist item confirming each new code path has a corresponding test that exercises the real wiring, not a mock-only path.
+- Accessibility and keyboard lifecycle correctness: PRs #6901 and #6429 both required multiple rounds to fix focus management, tab-order isolation for covered elements, and focus-return after dismissal (consistent)
+  → **Support:** For any PR that adds, removes, or layers UI panels (sheets, drawers, threads), run a manual keyboard-only walkthrough as part of personal QA before submission: Tab through all interactive elements, confirm covered content is inert and AX-hidden, verify Escape and close-button dismissal returns focus to a logical target. Add a corresponding Playwright accessibility assertion covering at least the covered-inert and focus-return cases.
+- Atomic, self-contained fix commits: several PRs (notably #6003 and #6590) accumulated many round-trip fix commits addressing one or two blockers at a time rather than batching related fixes, increasing review overhead (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** When addressing multiple related P1 blockers in a single round, batch all fixes into one commit (or a small logical set) with a clear description of which finding each change resolves. This reduces reviewer context-switching and makes the diff easier to verify. Discuss with the team whether a pre-review 'fix bundle' convention should be formalized.
+- API/function signature hygiene: inline reviewer note on #6003 flagged an 11-positional-parameter function with five consecutive undefined arguments; suggests insufficient attention to interface design when adding parameters (occasional) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When a function call requires more than three or four positional arguments, refactor to an options object before submitting. Apply this as a linting rule in personal code review: search for any call site with three or more consecutive undefined or null arguments and convert it.
+
+### tlongwell-block
+**Trajectory:** improving — The earliest PRs (#3320, #6024) required the most review rounds and the most fundamental structural rework, while the most recent PR (#6822) was approved in a single comment with no blocking findings, and #6572 converged in three rounds with tightly scoped residual issues — suggesting the author is learning from feedback and shipping incrementally cleaner changes over the window.
+
+**Strengths:**
+- Persistent debugging and iterative resolution: across PRs #3320, #6024, and #6572, the author consistently works through multi-round review cycles, addressing each blocking finding and converging on approval without abandoning difficult feedback. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Correctness focus on network and concurrency boundaries: PR #3320 demonstrates deliberate handling of auth lifecycle races (Promise.race with overflow guard, bounded pre-connect queues), reflecting awareness of edge cases at async boundaries. (consistent)
+- Broad scope of contribution: the window spans desktop performance (JS-to-Rust migration), protocol specification (NIP-FI), database correctness (FTS exclusion migration), and relay auth — demonstrating cross-cutting product-engineering range. (emerging)
+- Schema migration correctness: PR #6822 correctly traces the gap across multiple migration files and preserves per-database policy rather than flattening it, showing careful backward-compatibility reasoning. (emerging) — *Semantic Versioning 2.0.0 — https://semver.org/*
+
+**Growth areas:**
+- Cross-scope lifecycle isolation: PRs #6024 and #6572 each required 4–5 review rounds primarily because scope-crossing state leaks (stale fetch canceling wrong scope, failed flush injecting events into a sibling scope, read-marker drops during scope open) were introduced or left unresolved across multiple revisions. This pattern appears in both PRs. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before submitting any PR that touches multi-scope state (archive sync, unread channels, community queries), write a short lifecycle contract comment at each scope boundary stating which scope owns the resource and what happens when that scope closes mid-operation. Add at minimum one integration test that exercises two concurrent scopes with interleaved failures to catch cross-contamination before review.
+- Startup/ordering races in UI data loading: PR #6572 required an additional revision specifically because post-subscription and reconnect refreshes were not sequenced behind cache hydration, causing the app to hide behind hydration or swallow refreshes. This class of bug (ordering assumption not encoded in code structure) also appeared in PR #6024 with the read-marker advance being dropped during scope open. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For any feature that gates rendering or data refresh on an async initialization step, explicitly model the loading state machine (idle → hydrating → ready → refreshing) rather than using ad-hoc boolean guards. A small shared utility or documented pattern for sequencing post-subscription work behind hydration would prevent this class of defect from recurring across PRs.
+- Protocol specification precision: PR #5946 (NIP-FI) received a dismissal citing that normative contracts were not satisfiable as written — specifically that byte-exact exit tests left signed and transport bytes unpinned (JWS signs encoded octets, not logical claim sets). This indicates a gap in translating cryptographic correctness requirements into unambiguous spec language. (occasional) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** When authoring protocol specs that include cryptographic normative tests, include a reference implementation or test vector section that pins the exact encoded bytes used in each example signature, and add a sentence explicitly stating that implementations must sign the serialized octets rather than the logical structure. Pairing with a reviewer who has shipped a JWS/JWT implementation before the first review round would catch this class of issue early.
+- Proactive edge-case coverage before submission: across PRs #3320, #6024, and #6572 the pattern is that correctness blockers (buffer overflow on pre-connect queue, stalled signer defeating timeout, cross-scope event injection) are caught by reviewers rather than by the author's own pre-submission analysis. This suggests the author's self-review pass does not yet systematically enumerate failure modes at async and scope boundaries. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a lightweight pre-submission checklist specific to async/scope-boundary changes: (1) What happens if this operation is cancelled mid-flight? (2) Can state leak into a sibling scope? (3) Is there a bounded worst-case for any queue or buffer introduced? Writing answers in the PR description before requesting review would surface these issues earlier and reduce multi-round cycles.
+
+### tulsi-builder
+**Trajectory:** improving — Early PRs (#6702, #6716) required five or more review rounds each to resolve correctness and accessibility defects, while later PRs (#6900, #7126) converged in fewer cycles and drew 'high risk' approvals with no post-approval rework, suggesting the author is internalizing reviewer expectations over the window.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback — consistently addresses P2 defects across multiple review rounds and lands approvable code (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Cross-cutting UI feature delivery spanning renderer, navigation lifecycle, and shared theme tokens in a desktop client architecture (consistent)
+- Willingness to tackle complex Unicode and text-normalization edge cases (line separators, CRLF, NEL, LS) after they are surfaced (emerging)
+
+**Growth areas:**
+- First-pass correctness on edge cases — reviewers repeatedly find P2 defects (Unicode over-highlighting, same-route highlight clearing, WCAG AA color contrast) that require multiple revision cycles before merge (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, maintain a personal pre-review checklist that covers: (1) Unicode boundary conditions for any text-processing code, (2) navigation lifecycle state teardown for any route-aware feature, and (3) accessibility contrast ratios against all themes for any color-bearing UI change. Walking through this checklist on PR #6702, #6716, and #6946 before submission would likely have eliminated several revision rounds each.
+- Accessibility compliance — WCAG AA contrast requirements were missed in at least two separate PRs (#6716 mention foreground, #6900 mention badges), indicating this is not checked proactively (consistent) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** Integrate an automated contrast-ratio check (e.g., axe-core or Storybook a11y addon) into the local dev loop or CI pipeline so WCAG AA failures surface before review. Additionally, add a short accessibility section to the PR template (contrast checked: yes/no, themes tested: list) so the author self-verifies before requesting review.
+- State management ownership boundaries — the same-route highlight clearing defect in PR #6702 was initially fixed at the caller site rather than at the correct ownership boundary, requiring an additional round trip (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When fixing a state lifecycle bug, explicitly ask: 'Is this fix in the component that owns this state, or am I patching callers?' Document the answer in the PR description. A brief architecture note (one or two sentences) identifying ownership in each PR would prompt this reasoning before the reviewer has to raise it.
+- Data pipeline completeness — PR #7126 initially dropped the public description field before the 'Add Agent' step in the community catalog path, a missing-field propagation gap that recurs as a pattern when features cross renderer/relay/persistence layers (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** For any feature that moves a new data field across an IPC or relay boundary, draw a one-line data-flow diagram (renderer → Tauri command → SQLite → relay → catalog) and confirm each hop carries the new field before writing code. Attaching this diagram to the PR description as a checklist reduces the chance that one hop is silently dropped.
+
+### wesbillman
+**Trajectory:** stable — Across the full window the author consistently delivers high-volume, security-aware changes and responds well to feedback, but the same gaps — insufficient mutation-sensitive tests, residual auth-boundary holes on first submission, and lifecycle teardown omissions — recur in both early and late PRs without a clear narrowing trend.
+
+**Strengths:**
+- Shipping across a broad surface area — desktop, mobile, CLI, relay, CI, and ACP — with consistent attention to protocol correctness and authorization boundaries (consistent)
+- Iterating quickly on reviewer feedback: most PRs show rapid follow-up commits that directly address blocking findings rather than arguing against them (consistent) — *https://google.github.io/eng-practices/review/*
+- CI and tooling hygiene: proactively adding first-class gates (file-size policy, Rust cache contract) to prevent class-level regressions (emerging)
+- Security-aware default posture: authorization boundaries are generally fail-closed and ownership checks are scoped to the correct identity (NIP-OA, managed-agent, relay-signed) (consistent) — *https://owasp.org/www-project-top-ten/*
+
+**Growth areas:**
+- Mutation-resistant test coverage: reviewers repeatedly find that new production authorization and lifecycle paths are not regression-protected — mutations to key guards leave the full test suite green (PRs #6953, #6415, #6485, #6996, #6961) (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, run a manual mutation pass on every new guard introduced: delete or invert the condition, confirm at least one test fails. Adopt a pre-push checklist item: 'does removing this branch break a test?' Focus especially on authorization gates and lifecycle fences, which are the most common sites of reviewer-caught gaps. Pair with a reviewer early (draft PR or async design note) when the change touches a relay/auth boundary to surface coverage gaps before the full review cycle.
+- First-attempt completeness on security-sensitive boundaries: initial submissions frequently contain a residual authorization bypass or identity-attribution hole that survives into the second or third review round, requiring multiple CHANGES_REQUESTED cycles (PRs #6086, #6338, #6953, #6533, #6961) (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** Before submitting, walk every caller of the new authorization path and ask 'what is the weakest input that reaches this gate, and does it still fail closed?' Write that walkthrough as a short comment block in the PR description. For changes rated high/critical risk, request an early design review from jedwards27 or wpfleger96 at the RFC or draft stage rather than after a full implementation.
+- Test contract completeness for policy/CI scripts: tests for policy scripts (Rust cache contract, file-size ceilings) repeatedly miss mutation-sensitive boundary assertions — passing even when the policy would not fire on a real violation (PRs #6618, #6485) (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** For every policy test, include at least one fixture that should trigger enforcement and assert it actually does. Treat the test as a specification: write the failing case first, then the script. Review the test by asking 'if I introduce the known-bad condition, does this test catch it?' before pushing.
+- Lifecycle teardown and in-flight cancellation: async queues and subscriptions are sometimes left without a complete teardown fence, allowing stale activations or disposed subscriptions to produce effects after the owning scope is gone (PRs #6427, #6415, #6996) (consistent)
+  → **Support:** Adopt a teardown checklist for every new async queue or subscription: (1) does cleanup abort in-flight work via AbortController or generation counter? (2) is the guard checked at execution time, not only at enqueue time? (3) is there a regression test that disposes the owner mid-flight and asserts no side effect? Use this checklist explicitly in the PR description for any lifecycle-touching change.
+- Keeping E2E and integration test assertions synchronized with intentional contract changes: changed behavior sometimes ships without updating the corresponding E2E assertion, causing deterministic CI failures (PR #6427 dm-double-notification, PR #6533) (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** When a PR intentionally changes a user-visible contract (notification title format, deletion authorization), grep for all test files that assert the old value before submitting. Add 'test impact' as a mandatory section in the PR description listing any E2E assertions touched by the behavioral change.
+
+### wpfleger96
+**Trajectory:** improving — Later PRs (September 2026) show faster blocker resolution, fewer rounds of changes per PR, and cleaner initial submissions in lower-stakes areas (CI, docs, chore), though high-complexity security and protocol-lifecycle PRs continue to require significant iteration, indicating domain-specific growth is ongoing but not yet consistent.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: consistently pushes corrective commits that close specific blockers identified by reviewers, often within the same PR lifecycle, across feature, fix, and perf work. (consistent) — *https://google.github.io/eng-practices/review/*
+- Broad scope delivery: ships end-to-end changes spanning Rust backend, TypeScript/React desktop, CLI, CI, and database schema within single coherent PRs, demonstrating strong cross-layer ownership. (consistent)
+- Security-sensitive domain participation: engages with auth, trust-boundary, and cryptographic primitives (NIP-FI, NIP-98, JWKS, permission gating) and iterates to close reviewer-identified security blockers. (consistent) — *https://owasp.org/www-project-top-ten/*
+- Performance-aware design: deliberately structures parallelism (relay directory rebuild, discover_acp_providers cheap/forced split, reference resolution) and reasons about concurrency budgets. (emerging)
+
+**Growth areas:**
+- Explicit error-path and failure-propagation completeness: reviewers repeatedly surface gaps where error states are swallowed, not surfaced to callers, or routed to wrong observers. Seen in PR #6330 (forced-discovery failures invisible to Settings hook), PR #5545 (rejected-token cache entries left live), PR #4625 (stale effort values persisted silently), PR #6447 (false-empty instead of load error), and PR #5712 (fail-open malformed-response path). (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, explicitly enumerate every error/failure branch in the changed code and verify each one either propagates to a caller-visible result, surfaces in the UI, or is logged with observable context. Consider adding a self-review checklist item: 'For each new async operation or fallible call, where does the error go?' Pair on one PR where a senior engineer walks through error-path tracing at the diff level before submission.
+- Race condition and loading-state correctness: multiple PRs require multiple rounds of changes to fix loading-state races, stale-state rollback gaps, and concurrent-write ordering. Seen in PR #5706 (archive predicate returns false before snapshot exists), PR #5905 (rapid archive changes leave stale kind 13535), PR #6330 (forced discovery pending/failed state not blocking onboarding advance), PR #4625 (EffortPicker write races dialog Save). (consistent)
+  → **Support:** Before submitting PRs that touch async state or shared mutable state, write out a state-machine diagram (even informally in the PR description) covering all intermediate states: loading, error, stale, and settled. Request a focused pre-review on the state-transition logic from a peer before formal review. Study the existing patterns in the codebase for how loading predicates gate downstream actions and replicate them explicitly.
+- Security boundary precision in auth and trust contexts: initial submissions contain fail-open paths, algorithm/key-type mismatches, attacker-controlled input reaching typed operations, and overly broad authorization exceptions. Seen in PR #6776 (JWKS snapshot unbounded, algorithm/curve mismatch not rejected), PR #6394 (prompt wording created permission rather than restriction), PR #3995 (publisher-controlled avatar URLs fetched on browse), PR #5712 (malformed wire messages forwarded as authorized). (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** For PRs touching authentication, authorization, or external-input handling, apply an explicit threat-modeling pass before submission: identify every attacker-controlled input, every trust decision, and every fail-open branch. Use OWASP A01 (Broken Access Control) and A02 (Cryptographic Failures) as a checklist. Consider scheduling a 30-minute whiteboard session with a security-focused reviewer before the first draft to agree on the trust boundary design, reducing multi-round correction cycles.
+- Lifecycle and protocol contract completeness in event-driven and distributed systems: reviewers consistently find cases where tombstones are mis-ordered, sync subscriptions omit a required event kind, adoption paths skip enqueuing cross-device witness events, or deletion/creation races can resurrect deleted entities. Seen in PR #5112 (tombstone older than retained head, catalog adoption missing owner sync, delayed share resurrects deletion, community boundary rejection missing), PR #5904 (membership delta vs. full roster backfill), PR #5905 (archive/unarchive not scheduling nest regeneration). (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For PRs implementing event-sourced or protocol-level state transitions, write out the full event lifecycle in the PR description: create, update, delete, tombstone, sync, and replay. Explicitly list every subscription filter or event kind that must be included and verify the code against that list. Consider writing integration-level tests that exercise ordering edge cases (e.g., delayed events, rapid state changes) before requesting review, so reviewers can verify behavior rather than reason about it.
+- Test coverage accompanying changes: across 36 PRs, reviewer feedback consistently focuses on behavioral correctness gaps discovered through code inspection rather than failing tests, suggesting test coverage is not consistently paired with new behavior or error paths. (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal norm of writing at least one test per new error path and one per new state transition before opening a PR for review. For complex PRs (auth, event lifecycle, concurrency), write tests first and include them in the initial submission so reviewers can verify intent via tests rather than discovering gaps through inspection alone. Track the ratio of reviewer-found behavioral bugs to total PRs as a personal metric and aim to reduce it over the next quarter.
+
+---
+
+## 4. Team Gap Analysis
+
+### Where the team is strong
+| Area | Evidence | Standard |
+|------|----------|----------|
+| Deep correctness reasoning on concurrency and async race conditions | Multiple signals show reviewers (wesbillman, tlongwell-block) tracing precise race windows: buffered frame ordering, Promise.race semantics, auth timeout interaction, and FIFO invariants across drain sequences. | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ |
+| Security: input validation, XSS/content-injection, and authorization ordering | Chessing234 consistently flags credential scope in CI workflows and access-control ordering; wpfleger96 identifies attacker-controlled blob URLs served as typed documents and pubkey canonicalization bypasses; both cite OWASP guidance. | OWASP Top 10 — https://owasp.org/www-project-top-ten/ |
+| Regression test design and behavioral coverage | Chessing234 explicitly evaluates whether tests pin invariants that matter (ordering, edge cases, determinism); tlongwell-block adds deterministic E2E regression seams; the team distinguishes pre-existing flakes from newly introduced failures. | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ |
+| Structured, constructive review framing | Chessing234's fingerprint shows a consistent pattern of acknowledging the correctness of the primary fix before surfacing remaining gaps, reducing friction and keeping discussion focused. | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ |
+| Panic/overflow safety in systems-level code | wpfleger96 flags u64→i64 cast wrapping and chrono::Duration::seconds panic risk from moderator-supplied input, showing awareness of safe arithmetic at language boundaries. | — |
+
+### Gaps and blind spots
+| Area | Gap Type | Missing Standard | Recommendation |
+|------|----------|-----------------|----------------|
+| Observability: logging, tracing, and metrics on new code paths | blind_spot | — | Add an observability checklist item to the PR template requiring authors to document what new structured log events, metrics, or trace spans are emitted for each new code path; schedule a 1-hour team session on what 'debuggable in production' means for this codebase. |
+| API contract stability: breaking changes to public interfaces are not flagged or versioned in reviews | blind_spot | Semantic Versioning 2.0.0 — https://semver.org/ | Add a CI gate using a tool such as oasdiff (for REST) or buf breaking (for Protobuf) to detect breaking changes automatically; add 'does this change a public interface?' as a mandatory checklist question in the PR template. |
+| Dependency additions: justification, pinning, and supply-chain awareness | coverage_gap | — | Add a CI gate enforcing lockfile integrity (e.g., cargo deny, npm audit, or dependabot alerts as required checks); add a PR template question requiring authors to justify new dependencies and confirm version pinning. |
+| Documentation of non-obvious decisions: ADRs, inline rationale, and design intent | coverage_gap | The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/ | Adopt a lightweight ADR convention (e.g., docs/decisions/NNNN-title.md) and add a checklist item asking 'is there a non-obvious design decision that needs a comment or ADR?' — particularly for concurrency design, security boundaries, and protocol choices. |
+| Silent approvals: 124 of 354 approvals carry no review comment, and 61 of 272 PRs have no human engagement | coverage_gap | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ | Enforce a branch protection rule requiring at least one substantive (non-silent) review comment before merge; track silent-approval ratio as a team health metric in retrospectives. |
+| Test coverage: failure paths and negative cases are inconsistently required in reviews | knowledge_gap | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ | Standardize a test-coverage checklist question: 'Does this PR include tests for error/failure paths, not just the happy path?' — and run coverage diff tooling (e.g., Codecov) as an informational CI check to surface untested branches. |
+| Error handling: swallowed errors and silent partial results in async and Rust code | knowledge_gap | — | Add a mandatory PR checklist item: 'Are all errors surfaced explicitly — no unwrap/expect in production paths, no silently discarded Result/Option values?' Consider a clippy lint gate (e.g., clippy::unwrap_used) and ESLint rules for unhandled promise rejections. |
+| Audit logging for privileged mutations: roster changes, moderation actions, and access control changes leave no durable record | knowledge_gap | OWASP Top 10 — https://owasp.org/www-project-top-ten/ | Create a team convention (documented in a short ADR) that all mutations to privileged tables (roster, moderation, permissions) must emit an append-only audit event; add a code review checklist item for 'does this privileged mutation produce an audit record?' |
+
+### Review culture
+The team has a high-quality nucleus of reviewers (wesbillman, wpfleger96, Chessing234, tlongwell-block) who demonstrate genuinely deep, multi-dimensional review on complex PRs, surfacing concurrency hazards, security flaws, and invariant violations with precision. However, the 45% silent-approval rate and the 22% no-engagement rate indicate that review depth is concentrated in a small subset of contributors and PRs, creating a systemic coverage risk where entire change categories — particularly observability, dependency management, and API contract stability — receive no team-wide scrutiny. Raising the floor through PR template checklists and mandatory CI gates would distribute the burden of correctness more evenly and reduce reliance on a few expert reviewers.
+
+---
+
+## Methodology & Caveats
+
+- **Window:** 2026-08-17 → 2026-09-03 | **PRs analyzed:** 272 | **PRs skipped (no reviews):** 0
+- **Lens:** product-engineering (v1, experimental)
+- **Tooling gates present:** biome
+- **What this analysis cannot see:** verbal review culture (Slack), reviewer availability constraints, domain ownership, or PRs merged without review.
+
+---
+
+## Appendix: Reference Standards
+
+- **Google Engineering Practices: code review**: https://google.github.io/eng-practices/review/
+- **DORA research**: https://dora.dev/research/
+- **OWASP Top 10**: https://owasp.org/www-project-top-ten/
+- **Semantic Versioning 2.0.0**: https://semver.org/
+- **The Pragmatic Programmer (Hunt & Thomas)** *(secondary)*: https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/

--- a/tricorder/2026-09-08-block__buzz.md
+++ b/tricorder/2026-09-08-block__buzz.md
@@ -1,0 +1,946 @@
+---
+date: 2026-09-08
+repo: block/buzz
+window: 2026-08-17 → 2026-09-03
+pr_count: 272
+contributors: ['Chessing234', 'Illuminfti', 'Maxwellimus', 'TheSentinel454', 'atishpatel', 'baxen', 'bradseiler', 'brow', 'evanchen7', 'jedwards27', 'jmecom', 'kalvinnchau', 'klopez4212', 'kruegermj', 'kursmark-sq', 'loganj', 'lucasisaza', 'mahanti', 'matt2e', 'morgmart', 'ngthuydiem', 'philazar', 'ravarora2', 'salman1993', 'tellaho', 'thomaspblock', 'tlongwell-block', 'tulsi-builder', 'wesbillman', 'wpfleger96']
+visibility: private
+generated_by: tricorder v1.1.0
+lens: product-engineering
+---
+
+# PR Review Analysis — block/buzz — 2026-09-08
+
+> Window: 2026-08-17 → 2026-09-03 | 272 PRs | 30 contributors
+
+---
+
+## 1. Patterns Ready to Institutionalize
+
+| Pattern | Category | Current Maturity | Next Step | Standard |
+|---------|----------|-----------------|-----------|----------|
+| Security trust-boundary enforcement (NIP-98 auth, cross-tenant keying, relay claim validation) — enforced by judgment of a small reviewer core | — | rule | Encode the team's known vulnerability patterns as Semgrep or CodeQL rules so enforcement is deterministic and not reviewer-dependent. Document the trust-boundary model in a SECURITY.md and reference it from the PR template. | deterministic |
+| Test coverage requests — present across 196 PRs but almost entirely at guidance maturity with no human reviewer engagement | — | guidance | Adopt a coverage-delta CI gate (Codecov with a fail-on-drop threshold) and add a mandatory reviewer checklist prompt. Elevate from guidance to rule by documenting the minimum coverage expectation in CONTRIBUTING.md. | rule |
+| API contract snapshot diffing across the TypeScript/Rust boundary — currently caught by human judgment on rule-maturity signals | — | rule | Generate TypeScript type snapshots and Rust public-API diffs automatically in CI and require explicit human sign-off on breaking diffs. This converts a judgment-dependent practice into a deterministic gate. | deterministic |
+| Observability conventions for new async code paths — sporadic guidance-level comments by a minority of reviewers | — | guidance | Document a minimum observability contract in CONTRIBUTING.md (structured log at entry/error for every new async path). Add a reviewer checklist prompt and run a team training session. Target convention maturity within one quarter. | convention |
+| Dependency pinning and supply-chain hygiene — currently zero human review engagement | — | judgment | Adopt GitHub dependency-review-action and cargo-audit as blocking CI gates. Add a PR-template question requiring authors to justify new dependencies. Elevate to rule maturity by enforcing digest pinning for all CI image references. | rule |
+
+---
+
+## 1b. Oversight Density
+
+Computed from the harvested record, no model involved. In agentic development, review is where human oversight concentrates; this section shows where it does and does not land.
+
+- PRs with no human engagement (approve-only or nothing): **61 of 272**
+- Silent approvals (approve with no comment): **124 of 354**
+- Inline comments: **74** by human reviewers, **365** by bots or AI reviewers, 378 by PR authors replying on their own PRs
+- PRs where a bot commented and no human reviewer did: **34 of 272**
+
+Per axis: of the PRs that changed files under the axis, who commented on those files.
+
+| Axis | High-stakes | PRs touching | Human reviewer | Bot only | Nobody | Silent share | Comments | Reviewers |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| dependency-management |  | 31 | 0 | 1 | 30 | 100% | 0 | 0 |
+| test-coverage | yes | 183 | 1 | 3 | 179 | 100% | 1 | 1 |
+| documentation |  | 53 | 1 | 0 | 52 | 98% | 4 | 1 |
+| security-hygiene | yes | 259 | 25 | 33 | 201 | 90% | 67 | 10 |
+| observability | yes | 249 | 25 | 31 | 193 | 90% | 67 | 10 |
+| api-contract-stability | yes | 235 | 24 | 31 | 180 | 90% | 66 | 10 |
+| error-handling | yes | 235 | 24 | 31 | 180 | 90% | 66 | 10 |
+
+| Reviewer | PRs | Approvals | Silent approvals | Silent share | Inline comments / PR |
+|---|---:|---:|---:|---:|---:|
+| tlongwell-block | 4 | 4 | 4 | 100% | 0.0 |
+| klopez4212 | 3 | 2 | 2 | 100% | 0.0 |
+| kalvinnchau | 10 | 8 | 7 | 88% | 0.2 |
+| wesbillman | 99 | 75 | 56 | 75% | 0.13 |
+| brow | 9 | 8 | 5 | 62% | 0.56 |
+| jmecom | 5 | 4 | 2 | 50% | 1.0 |
+| wpfleger96 | 62 | 61 | 30 | 49% | 0.52 |
+| atishpatel | 9 | 9 | 3 | 33% | 0.44 |
+| ravarora2 | 3 | 3 | 1 | 33% | 0.0 |
+| jedwards27 | 118 | 168 | 11 | 6% | 0.03 |
+| themiguelamador | 11 | 1 | 0 | 0% | 0.0 |
+| Chessing234 | 8 | 0 | 0 | — | 0.0 |
+| philazar | 4 | 3 | 0 | 0% | 0.0 |
+
+---
+
+## 2. Reviewer Focus Fingerprints
+
+### Chessing234
+**Style:** thorough | **Signal quality:** high — Comments are consistently structured, technically precise, cite specific code patterns, and distinguish the valid core fix from residual gaps — demonstrating deep domain understanding rather than surface-level scanning.
+
+**Primary focus areas:**
+- Correctness of edge cases and logic gaps in the core fix — verifying the stated fix is complete and doesn't introduce new failure modes (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Security: secrets and credentials scoped too broadly, especially in CI/CD workflows touching untrusted code (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Test quality and behavioral coverage — ensuring tests pin the exact invariants that matter, not just happy paths (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Access control and authorization ordering — ensuring policy gates are applied in both code paths and in the correct sequence (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Acknowledging the correctness of the primary fix before raising concerns — structured as 'fix is right, but here are the remaining gaps' (always)
+- Completeness of migration or schema changes — ensuring all relevant code paths (not just the new one) are updated consistently (often)
+- UX-level correctness: state transitions that can leave users stuck or cause unintended behavior (often)
+
+**Apparent blind spots:**
+- Performance implications — no comments across any PR about latency, query cost, bundle size, or allocation overhead — Zero mentions of performance concerns across 8 PRs covering DB schema, CI, desktop UI, and backend policy logic, despite multiple opportunities (FTS index changes, channel agent reuse, segmented controls).
+- Observability — no comments about logging, metrics, or tracing for new behavior — PRs touching agent provisioning, security gating, and DB migrations have no observability feedback despite these being areas where runtime visibility matters.
+- Dependency hygiene — no review of new dependencies, version pins, or supply-chain risks beyond the single SHA-pin acknowledgment in CI — The only dependency mention is approving existing pinned action SHAs; no scrutiny of any new library or transitive dependency introduced.
+- Documentation of decisions — no requests for ADRs, changelog entries, or inline explanation of non-obvious design choices — The benchmark PR's README table is praised but no documentation gaps are called out across any PR, even for complex policy precedence rules or migration strategies.
+
+### TheSentinel454
+**Style:** advisory | **Signal quality:** medium — Comments are substantive and push on real issues (duplication, doc accuracy, CI hygiene), but several are questions that defer resolution to the author rather than blocking on specific standards, and whole categories like security and error-handling go completely unaddressed.
+
+**Primary focus areas:**
+- Test organization, placement, and CI discoverability — ensures tests run in the right lane, are not duplicated across jobs, and follow established conventions for discovery scripts (always)
+- Documentation accuracy and operational explicitness — docs must match actual artifacts (e.g., image tag format), and must state scope, restrictions, and non-obvious caveats clearly (often)
+- CI timeout hygiene — job timeouts must be set to realistic values, not overly conservative defaults (sometimes)
+- Code duplication and DRY violations — questions repeated utility functions and pushes toward consolidation (sometimes) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+- Correctness of logic changes — asks for explicit rationale when values or behavior changes in ways that are not self-evident (sometimes)
+- Observability and metrics for operational unknowns — flags missing metrics when decisions (e.g., timeouts) lack empirical data (sometimes)
+- Architectural debt acknowledgment — explicitly calls out structural problems (e.g., run-on-boot migrations) even if they are not fixed in the current PR (sometimes)
+
+**Apparent blind spots:**
+- Security review — no comments across four PRs touch authz, secrets handling, injection, or trust boundaries, even in a PR that adds CI workflows and env-var-driven configuration — PR #6229 introduces env-var-parsed DB credentials/timeouts and PR #6709 adds a workflow publishing Docker images; neither prompted any security-oriented comment from this reviewer.
+- Error handling and failure modes — no comments examine what happens when DB operations fail, timeouts fire, or CI steps error out — The timeout PR (#6229) is focused on configuration correctness but the reviewer never asks about client-visible failure behavior when timeouts are hit.
+- Performance implications — no comments address query plans, index usage, or test suite runtime cost beyond CI job-level wall-clock time — PR #6730 restructures a large test suite; no discussion of per-test cost or database state overhead appears in the reviewer's comments.
+- API contract stability and versioning — no comments about backward compatibility when env-var names or public library interfaces change — PR #6229 renames/moves env-var parsing across binaries with no comment from this reviewer about whether dependent callers are updated or whether the change is breaking.
+
+### atishpatel
+**Style:** advisory | **Signal quality:** medium — Reviews are substantive on prompt correctness and structural concerns but are sparse across most PRs, with several approvals carrying only boilerplate or no inline comments, limiting pattern confidence.
+
+**Primary focus areas:**
+- Prompt content correctness and behavioral coverage — ensuring removed or simplified prompt sections don't leave agents without necessary instructions or discovery paths (often)
+- Benchmark dataset structure and organization — preferring cleaner directory layouts and appropriate model tier selection (sometimes)
+- Prompt specificity — ensuring context surfacing instructions are precise enough to be actionable (sometimes)
+- End-to-end tracing of change impact through rendering/delivery paths before approving (often)
+
+**Apparent blind spots:**
+- Test coverage for new behavior — no comments across any PR about adding or improving unit/integration tests for code changes — Across 9 PRs, test-related commentary is limited to noting that existing benchmark CI passed; the reviewer never requests new test cases or questions coverage gaps for changed logic.
+- Security hygiene — no comments on auth, secrets, or trust boundaries — None of the review comments touch on security concerns despite reviewing prompt injection surfaces and MCP scoping changes where trust-boundary issues could arise.
+- Error handling — no comments on failure modes or error propagation — No inline or summary comments across any PR raise questions about what happens when tool calls fail, prompts are malformed, or edge cases occur.
+- API contract stability — no comments on versioning or backward compatibility — PRs touching base prompt structure and ACP context delivery could break downstream consumers; the reviewer does not flag these risks explicitly.
+
+### baxen
+**Style:** thorough | **Signal quality:** high — Every comment is reproducible (includes exact file paths, repro steps, and test cases), the reviewer self-corrects when wrong, distinguishes priority levels (P1/P2), and tracks whether fixes fully close the stated invariant gap.
+
+**Primary focus areas:**
+- API contract invariants: ensuring wire-level constraints (request/response correlation, field presence, action matching, outcome validation) are enforced by types and validators rather than documented convention (always)
+- Serialization determinism and idempotency: ensuring bytes frozen at validation time are the only bytes sent on the wire, preventing re-serialization drift across retry attempts (always)
+- Strict deserialization: rejecting unknown fields, explicit nulls, and unexpected siblings at every wire boundary including nested types and re-exported types (always) — *OWASP Top 10*
+- Identity correlation correctness: ensuring identifiers (UUIDs, pubkeys, cursors) are canonicalized before comparison so that semantically equivalent values are never rejected or confused (often)
+- Error model correctness: ensuring error variants carry accurate side-effect semantics (pre-dispatch vs. post-dispatch, retryable vs. terminal) and are not contradicted by documentation (often)
+- Test coverage quality: ensuring tests represent durable structural invariants rather than surface-level heuristics that can be bypassed by renaming or wrapping (often)
+- Deployment environment tracing: verifying that security-critical configuration changes are safe across all non-dev deployment paths before approval (sometimes)
+- Pagination cursor design: ensuring cursor-based pagination cannot loop or skip records due to non-opaque, non-unique cursor values (sometimes)
+
+**Apparent blind spots:**
+- CI/build infrastructure review — PR #7168 splitting CI into reusable workflows received only 'Looks clean' with no inline comments despite being a structural change to the build system; baxen applied no scrutiny comparable to source-code reviews.
+- Observability and logging — Across all three PRs, no comments address logging, tracing, metrics, or alerting hooks, even in the broker contract PR where action outcomes and error codes would be natural observability attachment points.
+- Performance characteristics — No comments address latency, allocation patterns, or throughput concerns across any PR, even in the broker client where serialization and retry loops are performance-sensitive paths.
+- Documentation of decisions (ADRs, inline rationale) — Baxen writes detailed rationale in review comments and fix responses but never requests that this rationale be captured in code comments, ADRs, or changelogs for future maintainers.
+
+### brow
+**Style:** advisory | **Signal quality:** high — Comments are precise, cite specific line ranges and measured outcomes (including mutation test results and reproducible probes), and consistently distinguish blocking from non-blocking findings.
+
+**Primary focus areas:**
+- Test coverage gaps for newly introduced or modified logic branches (often) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Mutation testing to verify that new guard conditions are actually falsifiable by the test suite (sometimes)
+- State transition correctness in asynchronous/reactive mobile flows (e.g., backgrounding, resuming, UI state flags) (sometimes)
+- Edge cases in retry and backoff logic producing degenerate zero-delay windows (sometimes)
+- Event replay/buffering correctness when chunk or socket lifecycle changes mid-stream (sometimes)
+- CI/CD build pipeline correctness — exercising real linker paths rather than stub scripts (sometimes)
+
+**Apparent blind spots:**
+- Security review of audio/relay data flows and push-gateway endpoints — PRs #6056, #6558, and #7158 touch audio bridging, Huddle protocol downgrade, and push-gateway deployment — all trust-boundary-crossing surfaces — yet no security-oriented comments appear from brow on authorization, data exposure, or input validation.
+- API contract stability and versioning — Protocol downgrade (PR #6558) and push-gateway schema changes (PR #7158) could break existing clients or require versioning discipline; brow left no comments on backward compatibility or semver implications.
+- Observability hooks (logging, metrics, alerting) — Across 11 PRs covering cold-startup performance, relay sessions, and push infrastructure, brow never comments on whether new latency paths, error rates, or retry storms are instrumented for production visibility.
+- Documentation of non-obvious design decisions — Complex design choices — protocol downgrade rationale, chunk supersession logic, relay lifecycle — receive no requests for inline comments or ADRs from brow across any reviewed PR.
+- Performance regressions in newly introduced code paths — PR #6996 is explicitly about cold startup and rendering performance, yet brow's comments focus on correctness and test coverage, not on whether the changes introduce allocations, N+1 patterns, or new startup costs.
+
+### evanchen7
+**Style:** advisory | **Signal quality:** low — Only one PR with two inline comments is available, making it impossible to establish reliable patterns or distinguish consistent priorities from one-off observations.
+
+**Primary focus areas:**
+- Accessibility of dynamic UI updates: live regions for count changes and descriptive button labels (sometimes)
+- Scoping and deferring architectural concerns (e.g., on-demand loading, IPC/UI-state redesign) out of focused fixes (sometimes) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Performance bounding of expensive operations (e.g., file preview caps) (sometimes)
+
+**Apparent blind spots:**
+- Test coverage for new behavior — No comments reference unit, integration, or snapshot tests for the UI changes or the backend pagination cap; only one PR reviewed so sample is very small.
+- Security hygiene and input validation — No comments touch trust boundaries, path traversal risks in the repository tree logic, or authz concerns despite backend file-system access being involved.
+- Error handling and failure modes — No comments address what happens when the backend returns errors, partial data, or exceeds the 250-file cap in unexpected ways.
+- API contract stability between frontend IPC and backend commands — The reviewer explicitly deferred IPC redesign to a future PR without flagging versioning or backward-compatibility implications of the current interim contract.
+
+### jedwards27
+**Style:** blocking | **Signal quality:** high — Every blocking finding is tied to a specific file, line range, and concrete failure scenario with a reproduction path; verdicts clearly distinguish P1/P2 severity, track resolution across multiple rounds, and require causal test coverage before approving.
+
+**Primary focus areas:**
+- Async state boundary correctness: detached/unawaited operations that can complete after community/identity/relay switches, writing stale data to the wrong tenant or user (always)
+- Race conditions in concurrent async operations where a later result can overwrite a newer authoritative value (stale-refresh/stale-write races) (always)
+- Security: trust-boundary enforcement — relay-signed events must be verified before authorization decisions; forged or author-claimed fields must not substitute for signed authority (always) — *OWASP Top 10*
+- Test regression oracle quality: tests must exercise the actual production wiring, not a parallel test-only path; mutations that bypass production code must be caught (always)
+- Accessibility: keyboard navigation completeness (Tab order, Shift+Tab, focus return after dismissal, inert/aria-hidden coverage of visually covered layers), WCAG contrast compliance (always)
+- Native lifecycle correctness: camera, audio, recorder, and platform-view teardown/replacement must be fenced against races between disposal, re-initialization, and cancellation (often)
+- Exact-head CI gate enforcement: will not approve when required CI is red or cancelled, even when code is otherwise clear (often)
+- API contract stability: relay filter semantics, NIP protocol correctness (NIP-01/NIP-10/NIP-45/NIP-OA), and Tauri IPC wire contracts must not silently change behavior (often) — *Semantic Versioning 2.0.0*
+- Fail-closed defaults: indeterminate or error states must not silently degrade to a permissive/empty/ordinary-channel result (often)
+- Cross-tenant/cross-identity isolation: persisted state, query-cache keys, and UI must be scoped to relay+pubkey to prevent one community's data leaking into another (often)
+- Error-handling completeness: failures in multi-step operations (delete, upload, save) must not partially succeed and leave durable inconsistent state; rollback must be atomic (often)
+- Reduced-motion and accessibility animation: OS prefers-reduced-motion must be honored for new CSS transitions (sometimes)
+- CI/supply-chain policy: GitHub Actions action references must be pinned to full SHA; composite actions within the repo must also be covered by the same policy (sometimes)
+
+**Apparent blind spots:**
+- Performance characteristics of new relay/network code (N+1 queries, unbounded fanout) — raised only once (PR #6712 workflow grid), not systematically across all relay-querying PRs — Dozens of PRs introduce new relay subscriptions or queries with no comment on query cost or fanout; the single N+1 finding in #6712 appears to be an exception triggered by an obvious regression, not a consistent pattern.
+- Dependency additions and version pins for non-CI dependencies (Flutter packages, npm packages, Cargo crates) — No review comment across 119 PRs questions why a new library was added, whether it is maintained, or checks its transitive footprint; focus is entirely on behavioral correctness of the code using existing dependencies.
+- Observability: logging, tracing, and metrics coverage for new production paths — New relay admission, audio, push notification, and agent-wake paths are reviewed for correctness but no comment ever requests a log line, metric, or trace span to make failures observable in production.
+- Documentation of non-obvious architectural decisions (ADRs, inline comments explaining why) — Review comments are exclusively about runtime behavior; no comment across any PR asks for a comment explaining why a particular concurrency strategy, rollback approach, or protocol choice was made.
+- Style/lint hygiene and naming conventions — Zero comments on naming, formatting, or idiomatic style across all 119 PRs; all feedback is behavioral.
+
+### jmecom
+**Style:** advisory | **Signal quality:** high — Every inline comment names the exact code path, explains the root cause, and gives a concrete exploit or failure scenario, indicating high-signal, well-reasoned reviews.
+
+**Primary focus areas:**
+- Input validation and integer safety: catches numeric casts that can wrap, overflow, or panic (u64→i64 cast feeding chrono::Duration::seconds) (often)
+- Trust-boundary and authorization bypass: flags paths where canonicalization gaps or missing normalization let crafted inputs skip intended access control checks (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Audit trail and durable records for privileged mutations: flags upsert/delete operations on security-critical tables that leave no history (sometimes)
+- Validation-normalization split: identifies cases where validation accepts a value but discards the normalized form, letting unnormalized data propagate to execution (often)
+- Type invariant preservation: notes when a parsed type claims a semantic invariant (e.g., valid secp256k1 pubkey) that isn't actually enforced at parse time (sometimes)
+- CI/dependency version pinning and supply-chain hygiene: verifies version bumps are justified, pinned, and that upstream fixes are confirmed (sometimes)
+
+**Apparent blind spots:**
+- Test coverage for new behavior — Across all substantive code PRs (#3777, #6742) the reviewer raised no comments about missing or inadequate tests for the new auth paths, validation logic, or action contract; correctness concerns were flagged without requiring tests to demonstrate them.
+- Observability and logging — No comments on logging, metrics, or tracing hooks were made across any PR, including #3777 which introduced deployment-wide admin auth roles—a high-value place to add audit logs beyond the DB record the reviewer did mention.
+- API contract stability and versioning — PR #6742 defined a public agent-to-broker action contract but the reviewer left no comments about backward compatibility, versioning strategy, or what happens to existing callers if the contract changes.
+- Documentation of non-obvious decisions — No comments requested documentation, ADRs, or inline explanations for design choices (e.g., why upsert vs. insert-only, why the 64-hex type doesn't validate the curve point at parse time).
+
+### kalvinnchau
+**Style:** thorough | **Signal quality:** high — Comments are highly specific, citing exact file paths and line numbers, reproducing the logic flaw precisely, and stating the concrete failure mode — findings are independently verifiable and actionable rather than vague suggestions.
+
+**Primary focus areas:**
+- State machine completeness: exhaustive enumeration of status/lifecycle variants with no fall-through to wrong terminal states (often)
+- Protocol/API contract fidelity: ensuring request/response fields (e.g., nonces, capability lists, lifecycle kinds) are correctly included or checked at every code path (often)
+- Stale state / race conditions in UI state machines: detecting cases where toggling or transitioning leaves residual data from a prior runtime/config (sometimes)
+- Error propagation vs. graceful degradation: blocking critical user-facing operations on non-critical enrichment steps (sometimes)
+- Data normalization consistency: ensuring canonicalization applied at ingest is applied before lookups so case/format mismatches don't cause silent misses (sometimes)
+- Regression test coverage for specific fixed behaviors: verifying that the fix is exercised by tests, not just that tests exist (often)
+- Security hygiene for auth/relay systems: fail-closed config, constant-time validation, token lifecycle, CSP (sometimes) — *OWASP Top 10*
+
+**Apparent blind spots:**
+- Observability: logging, metrics, and tracing hooks are never mentioned across any PR — None of the 11 PRs include any comment about missing or inadequate logging, metrics, or distributed tracing, even in PRs touching network I/O, agent spawn bridges, and catalog discovery where observability would be expected.
+- Dependency justification and supply-chain hygiene — No comments about new crate/npm dependencies, version pinning, or supply-chain risk appear in any reviewed PR, including PRs that add new features in Rust and TypeScript.
+- Performance: latency, allocation, or N+1 query concerns — No performance-oriented comments appear across the 11 PRs, including PRs touching database migrations, catalog queries, and media bucket operations where query efficiency is relevant.
+- Documentation of non-obvious design decisions (ADRs, inline rationale) — Reviews confirm behavior is correct but do not flag absent explanations of why specific design choices (e.g., why older-workspace compatibility admits empty metadata) are made, suggesting documentation completeness is not checked.
+
+### klopez4212
+**Style:** blocking | **Signal quality:** high — Every comment cites a precise reproduction path or invariant violation, names the exact fix commit, and describes an added regression test that demonstrates the broken behavior, making the feedback unambiguous and verifiable.
+
+**Primary focus areas:**
+- Race conditions and concurrency correctness: overlapping async operations, stale closures capturing old relay/identity/session context, and missing scope fences across community switches, sign-outs, and reconnects (always)
+- Regression test coverage for every bug fixed: every fix comment cites an added regression test proving the broken path fails without the fix (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Security hygiene for relay-authenticated endpoints: NIP-98 replay guard, membership gate, validated input bounds before rate-limit token consumption, and credential/auth header scoping (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Resource lifecycle and cleanup: unreleased streams, orphaned temp files, unbounded concurrent Promises, object URL leaks, camera disposal during lifecycle transitions, and codec/muxer cleanup on timeout (often)
+- API contract stability between client and relay/native layers: wire format compatibility, protocol versioning in mesh framing, method-channel contracts, and cross-platform voice-note Markdown/imeta pairing (often) — *Semantic Versioning 2.0.0 — https://semver.org/*
+- Idempotency and duplicate-action guards: double-tap, repeated callbacks during animation transitions, overlapping async completions firing multiple times (often)
+- Public API documentation: doc comments on constructors, fields, lifecycle contracts, and ownership semantics for every exported symbol (often)
+- Bounded resource consumption: per-response size caps, request timeouts, rate-limit configuration, download limits, and image downsampling ceilings (often)
+- Module boundary enforcement: preventing cross-feature imports that couple sibling features, extracting shared widgets to the shared layer (sometimes)
+- Accessibility: VoiceOver/TalkBack semantics nodes, WCAG contrast, Dynamic Type scaling, and accessible action labels on custom controls (sometimes)
+- File size ceiling enforcement: source files must stay under 1,000 lines; oversized files are split into focused siblings (sometimes)
+- Fail-closed defaults for security-sensitive feature gates: Huddle availability, identity resolution, and relay membership must default to hidden/disabled until all providers settle (sometimes)
+
+**Apparent blind spots:**
+- Dependency additions and supply-chain changes — Across 27 PRs spanning Rust crates, Flutter packages, and npm packages, no comment mentions a new dependency being added, its justification, version pinning, or license. The reviewer never flags a new pub.dev, crates.io, or npm package.
+- CI/build infrastructure and configuration changes — Several PRs touch Tauri build configs, Gradle, and Swift package files; the reviewer never comments on build scripts, CI workflow files, or runner configuration.
+- Observability: logging, metrics, and tracing hooks — The reviewer never mentions whether new features (GIF search, Huddles, voice notes, profile editing) emit structured logs, metrics, or distributed traces, even though these are network-heavy, latency-sensitive features.
+- Error user-facing messaging quality — The reviewer fixes machine-token exposure once (relay_membership_required) but never independently raises whether error messages shown to users are helpful, localized, or safe. User-visible error strings in Dart and Swift are not called out.
+- Backward compatibility of stored/persisted data formats — With the exception of the Pollen migration PR, the reviewer does not raise questions about schema migrations, SQLite column changes, or Shared Preferences key renames that could affect users upgrading from older app versions.
+
+### loganj
+**Style:** blocking | **Signal quality:** medium — The reviewer (or their AI proxy) leaves detailed, commit-pinned, technically specific findings, but the small sample of 3 PRs and the explicit 'I'm Larry' AI-proxy framing make it difficult to attribute consistent human judgment patterns with high confidence.
+
+**Primary focus areas:**
+- Correctness of boundary conditions and edge-case behavior in new feature logic (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- End-to-end causal contract verification: ensuring that every transformation stage (input → intermediate → compiled output) is tested as a single chain rather than in isolation (always)
+- Scope discipline — approvals are explicitly scoped to a specific commit hash and a defined behavioral slice; out-of-scope changes are flagged as requiring a separate review round (always)
+- Silent failure / discard of inputs that should be rejected or surfaced to the caller (often)
+- API/transport contract stability across build variants and deep-link routing (often) — *Semantic Versioning 2.0.0 — https://semver.org/*
+
+**Apparent blind spots:**
+- Security hygiene (auth boundaries, injection, privilege escalation) — Across three PRs touching CLI input parsing, named build isolation, and agent wake-up workflows — all common surfaces for trust-boundary issues — no security-category comment appears.
+- Observability (logging, tracing, metrics) — No comment in any PR references whether new code paths emit logs, traces, or metrics; this is especially notable for the agent wake-up PR where observability of workflow events would be expected.
+- Documentation of decisions (ADRs, inline comments for non-obvious design choices) — Reviews focus entirely on runtime behavior and test coverage; no comment requests explanation of why a design choice was made or asks for inline documentation.
+- Dependency additions or version pinning — No PR review mentions new dependencies, their justification, or supply-chain risk, even in the Cargo/build.rs context where dependency changes are plausible.
+
+### matt2e
+**Style:** thorough | **Signal quality:** high — Comments are precise, reproduce concrete edge cases with specific inputs, explain the causal chain from the defect to observable failure, and include the corrected behavior — consistently high signal with no vague or stylistic noise.
+
+**Primary focus areas:**
+- Byte vs. character encoding boundary errors in string length validation and truncation (sometimes)
+- React memoization invalidation from unstable object/JSX references created inline per-render (sometimes)
+- Logic gate mismatches between condition checks and the actual action target — silent wrong-target side effects (sometimes)
+- Keyboard modifier key handling in input event disambiguation (e.g. Shift+Space vs plain Space) (sometimes)
+- Test coverage pinning specific regression scenarios with realistic edge-case inputs (often)
+
+**Apparent blind spots:**
+- Security implications of the changes (authz gaps, trust boundaries, injection risks) — Neither PR review mentions security concerns despite changes that modify channel membership and message routing — areas where incorrect actor assignment or channel targeting could be a trust-boundary issue.
+- Observability and logging for failure paths — The silent wrong-channel member-add bug is identified as a logic error but no suggestion is made to add logging or alerting when the fallback path executes; error visibility is not raised.
+- API contract stability and backward compatibility — No comments across either PR address whether changes to project channel or mention-resolution APIs break existing callers or require versioning.
+- Documentation of non-obvious decisions — Complex business logic (agent bot membership gating, mention debounce flushing) receives no prompts for inline documentation or ADRs in either review.
+
+### morgmart
+**Style:** advisory | **Signal quality:** low — Only one PR reviewed with two inline comments, providing insufficient data to establish reliable patterns or blind spots.
+
+**Primary focus areas:**
+- Visual rendering correctness of UI preferences — verifying that spacing/density settings are applied consistently across all surfaces (conversation rows, inbox rows, markdown, preview) (always)
+- Scope documentation for UI preference changes — ensuring that the copy/UI text accurately describes which surfaces a setting affects (always)
+- Single source of truth for CSS token ownership — checking that a single variable controls spacing rather than competing hard-coded values (always)
+
+**Apparent blind spots:**
+- Test coverage for new preference behavior — No comments reference unit or integration tests verifying that font size or density preferences persist, render, or apply correctly; all observed comments are about visual outcome validation rather than automated test presence.
+- Accessibility implications of density/font-size changes (e.g., minimum touch target sizes, WCAG contrast at smaller sizes) — Comments focus on pixel values and spacing rendering but do not raise accessibility compliance concerns for compact or small-font modes.
+- Performance implications of CSS variable usage or re-renders triggered by preference changes — No comments address render cost, style recalculation scope, or whether preference changes cause expensive repaints.
+- API contract / persistence layer for user preferences — Comments are exclusively about visual rendering; no mention of how preferences are stored, synced, or whether the schema is backward-compatible.
+
+### philazar
+**Style:** advisory | **Signal quality:** low — The vast majority of reviews are brief approvals ('lgtm') with minimal substantive feedback, providing very few data points about what the reviewer consistently evaluates.
+
+**Primary focus areas:**
+- High-level architectural and metric design for evaluation systems (sometimes)
+- Correctness of test fixture content (e.g., accidentally committed AI-generated placeholder data) (sometimes)
+
+**Apparent blind spots:**
+- Test coverage of new behavior — Across 5 PRs including a feature addition, benchmark layers, and a bug fix, there are no comments requesting or evaluating test coverage for new code paths.
+- Security hygiene and trust boundaries — No security-related comments appear across any PR, including the desktop ACP session experiment which introduces session scoping.
+- Error handling — No comments address error propagation or failure behavior in any of the reviewed PRs, including the fix for cold memory retrieval.
+- API contract stability — No comments address backward compatibility or versioning despite PRs touching benchmark structure and desktop session experiments.
+- Observability and logging — No mention of logging, metrics, or tracing hooks across any PR.
+
+### ravarora2
+**Style:** terse | **Signal quality:** low — All three reviews consist solely of 'lgtm' approval comments with no substantive feedback, making it impossible to infer meaningful focus patterns.
+
+**Primary focus areas:**
+
+**Apparent blind spots:**
+- Test coverage of new behavior — No comments across any of the 3 PRs addressing whether new tests were added or existing tests adequately cover the fix.
+- API contract stability and backward compatibility — PR #6062 involves a camelCase field rename in a config-write payload, which could be a breaking change for existing clients, yet no comment was made about compatibility.
+- Error handling and edge cases — All three PRs received immediate approval with no discussion of failure modes, edge cases, or error propagation.
+- Correctness and logic review — Reviewer left only 'lgtm' comments with no substantive analysis of the fixes in any PR, suggesting no deep review of logic.
+- Observability and operational impact — PR #6898 disables a database vacuum truncation heartbeat — a potentially significant operational change — with no comment on monitoring, rollback, or alerting.
+
+### salman1993
+**Style:** advisory | **Signal quality:** medium — Comments are substantive and technically grounded when present, but coverage is sparse across PRs — several approvals have no inline feedback at all, and entire categories (security, observability, API contracts) are never engaged.
+
+**Primary focus areas:**
+- Correctness of environmental assumptions and runtime context (e.g., HOME availability after env_clear on Windows) (often)
+- Test determinism: flaky or self-healing timers that can false-green on buggy code (often)
+- Realism and representativeness of benchmark/test fixtures and task inputs (sometimes)
+- Prompt/documentation progressive disclosure — avoiding unnecessary complexity for the common case (sometimes)
+- Benchmark configuration consistency (model held constant, configs symmetric across variants) (sometimes)
+
+**Apparent blind spots:**
+- Security review (e.g., path traversal in read_file/str_replace, injection risks) — PR #6271 touches path expansion logic (leading ~ in file paths) — a classic path traversal vector — and the reviewer's only comment addresses an environmental accuracy issue, not whether the expansion is safely bounded to allowed directories.
+- Dependency justification and supply-chain hygiene — PR #6222 is a security-motivated dependency bump (RUSTSEC advisory) and received only an approval with no comment on the version chosen, pinning strategy, or whether the bump is minimal.
+- API contract stability and backward compatibility — PR #6264 adds a new TTL field to `channels search` output; no comment was made about whether this is a breaking or additive change for existing consumers of that output.
+- Observability and error-handling — Across all seven PRs, no comment addresses logging, metrics, tracing hooks, or explicit error propagation paths, even in PRs touching network/IPC paths.
+
+### tellaho
+**Style:** advisory | **Signal quality:** low — Only one PR is available for analysis, and all visible comments are AI-generated resolution summaries rather than original reviewer comments, making it impossible to reliably infer the reviewer's own priorities or style.
+
+**Primary focus areas:**
+- State initialization correctness: ensuring create/duplicate operations produce the correct explicit default values rather than relying on backend defaults (sometimes)
+- UI safety guardrails: ensuring destructive or consequential state transitions (e.g., enabling a workflow) surface appropriate warnings to users (sometimes)
+- Form state correctness: preventing unintended side effects when editing one field from broadening or mutating other unrelated fields (sometimes)
+- Input normalization and parsing robustness: handling multiple valid formats (e.g., cron field arities, hex case) consistently and defensively (sometimes)
+- Test coverage for edge cases: expecting regression tests for the specific bugs caught (uppercase hex, frequent cron schedules at each arity) (often)
+
+**Apparent blind spots:**
+- Security review — No comments touch authentication, authorization, input sanitization for injection, or trust boundaries despite the PR touching workflow triggering logic.
+- Performance and scalability — No comments address rendering cost, query efficiency, or bundle impact despite changes to UI components.
+- API contract stability — The PR involves backend field conventions (enabled flag, cron format) but no comments address versioning or backward compatibility with older clients or API consumers.
+- Documentation — No comments request or acknowledge updates to READMEs, changelogs, or inline documentation for non-obvious decisions introduced by the PR.
+- Error handling — No comments address how failures (e.g., malformed cron, invalid hex) are surfaced to users or logged.
+
+### thomaspblock
+**Style:** blocking | **Signal quality:** high — The reviewer consistently identifies specific, reproducible security and correctness defects with exact file paths and call-path traces, and verifies fixes at named commit SHAs, producing highly actionable and verifiable feedback.
+
+**Primary focus areas:**
+- Cross-signer / cross-relay identity and authority boundary enforcement: ensuring that a channel, repository, or project owned by one signer/relay cannot be hijacked or reused by a foreign principal to route commands or gain authority (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Workspace state isolation and reset on identity/signer scope changes: verifying that mutable workspace state is fully cleared and reloaded when the active signer or project context changes, preventing stale state from leaking across sessions (always)
+- Adversarial routing analysis: tracing full call paths from entry points (ACP, CLI, managed-agent startup) through authorization checks to ensure no path bypasses authority validation (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- React memo/useMemo dependency completeness: catching incomplete dependency arrays that break memoization and cause stale closures or missed re-renders at component boundaries (sometimes)
+- UTF-8 / multi-byte string truncation correctness: ensuring string truncation happens at character boundaries (not byte offsets) to avoid mojibake or panics with CJK and other multi-byte content (sometimes)
+- CI failure triage: distinguishing pre-existing or unrelated CI failures from failures caused by the PR under review, and directing reviewees to retry rather than conflate (sometimes)
+
+**Apparent blind spots:**
+- Test coverage for new behavior: no comments request new unit or integration tests for the authorization paths, routing logic, or workspace reset behavior being introduced or fixed — Across all three PRs the reviewer audits logic and authority boundaries in detail but never asks for test additions. The only test mention is confirming an existing CJK regression test already passes.
+- Observability and logging: no comments on whether failed authority checks, identity mismatches, or routing rejections emit actionable logs or metrics — Security-critical rejection paths (foreign signer, ambiguous slug, require_repo_channel_binding failures) are traced for correctness but the reviewer never asks whether these paths surface diagnostic signals.
+- Documentation of non-obvious security decisions: no requests for inline comments or ADRs explaining why specific authority checks are required at each call site — The reviewer identifies and verifies the presence of guards but does not ask for documentation that would help future contributors understand why the guards exist.
+- Performance implications of repeated authority checks or workspace reconciliation on hot paths — The reviewer traces correctness of reconciliation and scoped event sync but never raises latency, allocation, or N+1 concerns even when tracing multi-step resolution chains.
+
+### tlongwell-block
+**Style:** advisory | **Signal quality:** low — With only approval actions and no recorded inline comments across all 4 PRs — spanning feature work, a security revert, and a race condition fix — there is insufficient signal to characterize meaningful review patterns.
+
+**Primary focus areas:**
+- Approving PRs without leaving substantive inline comments (always)
+
+**Apparent blind spots:**
+- Test coverage of new behavior — No comments observed across any of the 4 PRs regarding test presence, quality, or coverage gaps — including for PRs involving feature work (model capabilities manifest) and bug fixes (TipTap race condition).
+- API contract stability and breaking changes — PR #5597 drives model capabilities from a manifest — a potentially breaking change to how consumers discover capabilities — yet no comments were left about backward compatibility or versioning.
+- Security implications — PR #6311 reverts a security gate on relay-signed workflow messages, which has direct trust-boundary implications, yet no inline scrutiny was observed.
+- Error handling and edge cases — PR #6779 fixes a race condition in editor mounting; no comments were left examining whether the fix covers all race variants or handles failure states.
+- Correctness of revert rationale — PR #6311 is a revert of a security fix with no observed challenge to the rationale or request for a follow-up plan, despite the regression risk.
+
+### wesbillman
+**Style:** blocking | **Signal quality:** high — Reviews are pinned to exact SHAs, cite specific file paths and line numbers, reproduce failure scenarios, and track findings across multiple revision rounds with clear acceptance criteria — though nearly all substantive content is produced by automated sub-reviewer personas acting on wesbillman's account.
+
+**Primary focus areas:**
+- Security boundary enforcement: trust validation of external/attacker-controlled data before it affects application state, UI, or prompts (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- State machine correctness: lifecycle transitions must be complete, idempotent, and exhaustive — no wedged states, silent no-ops, or missing terminal paths (always)
+- Cross-scope/cross-tenant isolation: community, workspace, and identity boundaries must not leak data or actions across contexts (always)
+- API contract stability between layers: type definitions, wire formats, and field names must stay consistent across frontend/backend/mobile surfaces (always)
+- Race conditions and concurrent mutation ordering: shared state must be protected against interleaved writes, in-flight invalidation, and stale closure captures (always)
+- Error propagation and failure surface: errors must not be silently swallowed, must reach observable UI/caller state, and must not be confused with empty/success results (always)
+- Resource bounds: memory, concurrency, and process/file-descriptor limits must be global, not per-item, to prevent aggregate exhaustion (often)
+- Deterministic test coverage: tests must prove the specific invariant claimed, not just pass by accident due to retry windows or timing (often)
+- Cryptographic and protocol correctness: event IDs, replay guards, algorithm-to-key binding, and nonce uniqueness must be correct end-to-end (often) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Activation/workflow guard semantics: explicit disabled states and confirmation gates must be preserved across create, duplicate, edit, and toggle paths (sometimes)
+
+**Apparent blind spots:**
+- Accessibility: ARIA roles, labels, focus management, and contrast ratios are almost never raised proactively; they appear only when a separate automated lane surfaces them — Across 109 PRs the only accessibility findings visible in review text were surfaced by named sub-reviewers (Carl/Princess Donut personas), not by wesbillman's own observations — e.g., the ManageChannelSheet label finding and the thread-detail landing-target finding were both attributed to the automated lane.
+- Observability hooks: no review comment mentions missing logging, tracing, or metrics for new failure paths, even on complex distributed features like push notifications and OAuth single-flight — Despite many reviews of backend Rust services and complex async flows (PR #5545, #6269, #6776, #7109) there are zero visible comments requesting spans, counters, or structured log fields.
+- Dependency justification and supply-chain: new crate/package additions are never questioned for necessity, provenance, or version pinning — PRs like #6222 (h2 bump for RUSTSEC) received instant approval with no discussion of the upgrade scope, and no PR shows wesbillman questioning a new dependency addition.
+- Documentation of non-obvious decisions (ADRs, inline comments for protocol choices): approved without requesting explanation of why a specific algorithm or data structure was chosen — Approvals on protocol-heavy PRs (NIP-FI verifier #6776, NIP-98 admin auth #3777, NIP-30 emoji #7259) carry no requests for rationale comments or spec cross-references beyond what the automated reviewer raised.
+
+### wpfleger96
+**Style:** blocking | **Signal quality:** high — Reviews are consistently pinned to exact commit SHAs, blockers are traced to specific source lines with reproduction evidence, and each re-review explicitly verifies prior findings point-by-point, producing highly actionable and verifiable signal.
+
+**Primary focus areas:**
+- Security trust-boundary enforcement: NIP-98 auth, membership checks, replay guards, key material isolation, and access policy propagation are all traced end-to-end before approval (always) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Correctness of state machine and lifecycle logic: cancelled effects, generation fences, tenant-scope leaks, and race conditions between async steps are consistently caught (always)
+- Test coverage of new handler/boundary behavior: consistently requests tests for auth rejection, quota rejection, error paths, and integration seams when tests are absent (always) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- API contract stability and consistency across call sites: breaking changes to field names, endpoint paths, response shapes, and multi-interpreter parity are flagged as blockers (always) — *Semantic Versioning 2.0.0 — https://semver.org/*
+- Exact-head verification discipline: every review is pinned to an exact commit SHA and re-verified after each push, never approving on a stale head (always)
+- Observability hooks: metrics, audit trails, and advisory lock instrumentation are verified to be complete and semantically correct (often)
+- Performance: connection pool reuse, per-request resource allocation, and quota-charge ordering are flagged (sometimes)
+- Documentation accuracy: PR titles, inline comments, and config examples must match actual behavior; mismatches in docs that describe wrong semantics are blocked (sometimes)
+- Maintainability: shared constants to prevent drift, options objects over long positional parameter lists, and config-knob externalization (sometimes) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+
+**Apparent blind spots:**
+- Dependency additions and supply-chain hygiene: no comments across 63 PRs call out new crate/npm dependency justification, version pinning rationale, or license compatibility — Despite reviewing PRs that add new Rust crates and npm packages, no review comment addresses why a dependency was chosen, whether it's pinned, or supply-chain risk — only a single PR about a dependency cooldown policy was approved without substantive comment.
+- User-facing error message quality and localization: machine error tokens surfacing to UI are noted only once as a nit, never as a blocker — Only one nit comment mentions that a raw machine token (`relay_membership_required`) reaches the picker error state; in all other PRs with UI error paths, error message quality is not examined.
+- Bundle size and frontend performance impact: no comments on JavaScript bundle cost, lazy-loading, or render performance despite many desktop/React PRs reviewed — Multiple PRs touch desktop React components and add new UI features, but no review comment ever flags bundle size, code-splitting, or render cost.
+
+---
+
+## 3. Author Growth Profiles
+
+### Chessing234
+**Trajectory:** insufficient-data — Only one PR is available in the window, making it impossible to establish a chronological trend.
+
+**Strengths:**
+- Targeted bug fixes with clear intent — the PR addresses a specific broken wire contract (camelCase config-write payload fields) with a focused change (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Scope discipline — applying changes beyond what is necessary to fix the immediate issue (adding rename_all_fields to ConfigFieldType where it has no effect), creating noise in the diff and potential for future confusion (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before submitting, audit each changed file and ask: 'Does removing this change break the fix?' If no, omit it. Reviewers flagged this as P3 in a single PR — practice narrowing diffs by drafting a checklist of which symbols are in the critical path of the bug and limiting changes to only those.
+
+### Illuminfti
+**Trajectory:** insufficient-data — Only one PR is available in the review window, making it impossible to assess directional trends.
+
+**Strengths:**
+- Minimal, focused patches: the single PR targets a precise bug fix with the smallest complete repair, avoiding scope creep (emerging) — *https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Contribution compliance hygiene: DCO sign-off was missing from the commit, flagged as a blocking issue by reviewers (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Walk the author through the project's DCO/sign-off requirement (e.g., git commit -s) and add a local git hook or pre-push check to catch missing sign-offs before submission. Share the project's contributing guide if one exists.
+
+### Maxwellimus
+**Trajectory:** improving — Earlier PRs passed review with no blocking findings; the one CHANGES_REQUESTED cycle (PR #6460) was resolved quickly and completely, and the only surviving gap (stale description bullet) is minor — suggesting the author is internalizing review feedback across the window.
+
+**Strengths:**
+- Focused, well-scoped performance work: each PR targets a single, clearly named optimization (roster off critical path, prefetch on hover intent, render-cheap Projects surface), making changes easy to review and reason about. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive to reviewer feedback: in PR #6460 both P1 findings were resolved between review rounds, demonstrating willingness to act on substantive critique quickly. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Consistent use of conventional-commit prefixes (perf, fix, chore) that communicate intent and support automated changelog tooling. (consistent)
+
+**Growth areas:**
+- PR description hygiene: in PR #6460 an obsolete 'Contribution graph' optimization bullet was left in the description after the corresponding code was removed, requiring a follow-up reviewer comment to flag it. Stale descriptions mislead future readers and complicate bisection. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a personal checklist step before marking a PR ready-for-review: re-read the description against the final diff and strike any bullet that no longer corresponds to shipped code. A simple PR template with a 'Description matches final diff?' checkbox would enforce this habit.
+- Proactive dormancy/lifecycle guards on performance optimizations: PR #6460 initially shipped incremental card counters that remained active outside their intended layout context (a P1 finding). Similar lifecycle concerns surfaced in PR #6458 (fan refetch running after leave). The pattern suggests optimizations are conceived but their activation bounds are not fully audited before submission. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening any perf PR, run through an explicit lifecycle checklist: (1) What conditions must be true for this optimization to activate? (2) What conditions must be true for it to deactivate/clean up? (3) Is there a code path where it could fire outside those bounds? Adding a brief 'activation bounds' note to each PR description would surface this thinking for reviewers and build the habit.
+- Test coverage accompanying performance changes: none of the six PRs show reviewer commentary confirming new or updated tests for the optimized paths (hover-intent cleanup, fetch-lifecycle guards, render suppression). Observable correctness for performance code is particularly important because regressions are silent. (consistent) — *DORA research — https://dora.dev/research/*
+  → **Support:** For each perf PR, add at least one test that exercises the boundary condition being optimized (e.g., assert the fetch does not fire after a component unmounts, or assert prefetch is not triggered on a forum channel). Start small — a single lifecycle test per PR builds the habit and gives reviewers a clear signal that the bounds were considered.
+
+### TheSentinel454
+**Trajectory:** improving — Early PRs required reverts or many review rounds for correctness gaps, while later PRs (db runtime extraction, CI workflow split) show tighter scoping, faster reviewer convergence, and proactive documentation — though pre-submission completeness remains a recurring drag.
+
+**Strengths:**
+- Systematic, incremental refactoring: repeatedly breaks large modules into focused domain stores (replaceable events, community, channel membership, database runtime) with clean, verifiable pure-move semantics (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Observability mindset: proactively adds database pressure metrics, transaction timers, and advisory-lock instrumentation as first-class concerns alongside functional changes (consistent)
+- Infrastructure and CI improvement: consistently invests in build/test reliability (isolated Postgres lane, reusable workflow split, staged delivery qualification gate) (consistent) — *DORA research — https://dora.dev/research/*
+- Responsive iteration on reviewer feedback: addresses multi-round CHANGES_REQUESTED findings thoroughly and documents resolutions inline, enabling reviewers to verify each point (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Pre-submission completeness: multiple PRs (feat(db) session timeouts, ci Postgres lane, fix(acp) relay-signed messages) required 3+ review rounds or a full revert due to defects that could have been caught before posting — including migration-path gaps, audit-loss bugs, and CI reliability holes (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Establish a personal pre-push checklist for each PR type: for database changes verify migration idempotency and all pool consumers; for CI changes run the full workflow locally or in a fork before posting. Pair with a senior engineer on the first two PRs in each new domain to calibrate the expected completeness bar before opening for review.
+- Explicit error-path and edge-case coverage in tests: reviewer flagged a low-value ownership test for removal (PR #6777), and session-timeout tests initially missed the migration-pool exemption and audit-pool coverage — indicating test design tends toward happy-path first (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When writing tests, explicitly enumerate the failure modes for each new code path (timeout on migration lock, audit pool bypass, cross-tenant collision) and add at least one negative or boundary test per mechanism. Request a design review of the test plan from a reviewer before implementation to surface gaps early.
+- PR titling and commit conventions: PR #6777 landed with a non-conforming title despite CONTRIBUTING.md requiring Conventional Commits format; this was caught by the reviewer, not the author (occasional)
+  → **Support:** Add a git commit-msg hook or a local lint step (e.g. commitlint) that enforces Conventional Commits format before push; this eliminates the class of issue entirely without relying on reviewer catch.
+- Security hygiene in CI workflows: PR #7168 triggered multiple zizmor findings for commit SHAs not matching their version comment tags across all new reusable workflow files, indicating the security scanning implications of pinned-action patterns are not yet internalized (occasional) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** Run zizmor (or equivalent action-security linter) locally as part of the pre-push checklist for any CI workflow change. Review the team's pinned-action policy and add a one-time pairing session with a security-aware engineer to understand SHA-pinning best practices for GitHub Actions supply-chain integrity.
+
+### atishpatel
+**Trajectory:** insufficient-data — Only one PR is available for review, providing insufficient chronological signal to determine a trend.
+
+**Strengths:**
+- Functional correctness of implementation: the core logic change (routing mode 'set' to override_system_prompt) was verified as correct by the reviewer (emerging)
+- Defensive fallback handling: local method-not-found fallback was retained alongside the functional fix (emerging)
+
+**Growth areas:**
+- Repository attribution and policy compliance: the PR was blocked by a reviewer citing repository attribution policy violations, suggesting unfamiliarity with contribution norms around attribution or provenance of referenced external revisions (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before submitting PRs that reference or integrate external codebases or revisions (e.g., citing a specific Goose revision), review the project's CONTRIBUTING guide and attribution policy. If none exists, ask the maintainer to document expectations. Reviewers should point to the specific policy document at change-request time to make the requirement unambiguous.
+
+### baxen
+**Trajectory:** insufficient-data — Only one PR is available for review, so no chronological trend can be established, though the within-PR arc shows strong iterative improvement.
+
+**Strengths:**
+- Thorough API contract design and progressive hardening: baxen systematically identified wire invariants (retry idempotency, pagination cursors, response correlation, null handling, unknown fields) and iterated to close each gap across multiple commits, demonstrating sustained attention to explicit error paths and backward-compatible API evolution. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive and honest code review engagement: when reviewers (jmecom, Codex bot) identified real contradictions or bypass cases, baxen conceded clearly, reproduced findings before fixing them, and documented the correction reasoning inline — modeling the reviewer–author collaboration loop. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Observable validation layering: baxen introduced structured validation types (PreparedRequest, validate_for, exhaustive error-code tables, deny_unknown_fields) that make invariants machine-checkable rather than comment-only, aligning with the expectation that observable code carries its contracts in the type system. (consistent)
+
+**Growth areas:**
+- Catching wire-boundary invariants before review: multiple P1/P2 gaps (null-as-omission, unknown envelope fields, non-canonical UUID spellings, secp256k1 point validity, normalized-then-discarded arguments) were first surfaced by reviewers or the automated scanner rather than by baxen's own pre-submission validation pass. Each gap required a separate commit cycle to close. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR that defines a wire contract, run a self-review checklist that covers: (1) every Option<T> with serde(default) has a separate test for explicit JSON null, (2) every struct at a trust boundary uses deny_unknown_fields or a documented reason it cannot, (3) every string identity comparison has a canonicalization test with alternate spellings, and (4) every validate() call that produces a normalized value stores rather than discards it. Pair this with a short design-doc section listing each invariant and the type or test that enforces it, reviewed before the first commit.
+- Test coverage accompanying contract changes: the secret-scanner test file was removed as conceptually unsound, and several invariants (cursor round-trip, correlation with non-canonical UUIDs, BrokerResult direct deserialization) were proved only by reviewer-prompted reproduction steps rather than pre-existing tests shipped with the PR. (consistent) — *DORA research — https://dora.dev/research/*
+  → **Support:** Adopt a personal norm: every new validation rule ships with at least one positive test (valid input passes) and one negative test (the specific invalid input the rule targets fails). For PR #6742-style contracts, write the negative tests first as a design step — if the test is hard to write, the invariant is probably not yet represented in the type system. Review the DORA fast-feedback research to frame this as a cycle-time investment, not overhead.
+- Scoping initial invariant surface accurately: the PR started with a 'structurally unable to leak secrets' claim backed by a scanner that reviewers immediately showed was bypassable. Overstating what a mechanism guarantees created a correction burden and delayed approval. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When writing security or correctness claims in PR descriptions or doc comments, explicitly state the threat model and the specific bypass paths the mechanism does not cover. A sentence of the form 'This check does not defend against X' is more defensible than a universal claim, and surfaces scope discussions before review rather than during it.
+
+### bradseiler
+**Trajectory:** insufficient-data — Three PRs across a four-day window are too few to distinguish a directional trend, though the documentation feedback in PR #6709 is the only notable review signal and was resolved promptly.
+
+**Strengths:**
+- Delivering focused, well-scoped changes that earn approval with minimal reviewer friction (consistent) — *https://google.github.io/eng-practices/review/*
+- Addressing infrastructure and credential concerns (IRSA S3, versioned media bucket deletion) with targeted fixes (emerging)
+
+**Growth areas:**
+- Documentation accuracy and completeness: example code and operating contracts in docs fall out of sync with actual implementation details (occasional) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that includes documentation, do a final pass to verify every example reflects the exact tag/artifact format produced by the current code. Additionally, add an explicit 'Scope and Restrictions' section to any workflow doc that touches staging or release artifacts, clearly stating what environments the artifact may NOT be used in.
+- Proactive contract definition for staging/pre-release workflows: the operating boundaries (pre-merge only, not release-qualified, not for production or Kargo promotion) were absent until reviewer-prompted (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** When introducing new CI/CD staging lanes, include a short 'Operating Contract' block in the PR description and the accompanying docs at authoring time. A checklist item in the PR template—'Does this workflow produce non-release artifacts? If yes, document promotion restrictions.'—would make this a low-friction habit.
+
+### brow
+**Trajectory:** stable — Across all five PRs spanning August–September 2026, brow consistently reaches approval after multiple review cycles, but the same categories of gap — async lifecycle fencing, durable error recovery, and regression coverage — reappear in each successive PR without evidence of proactive mitigation, indicating a stable rather than improving pattern.
+
+**Strengths:**
+- Iterative responsiveness to reviewer feedback: brow consistently addresses blocking findings across multiple review cycles and reaches approval without abandoning PRs, demonstrating persistence through high-risk change sets (consistent) — *https://google.github.io/eng-practices/review/*
+- Scope of ambition: brow regularly authors complex, high-risk features (relay-backed channel discovery, push notification MVP, deployment infrastructure) indicating strong product engineering range (consistent)
+- Inline comment engagement: brow replies to inline review comments with substantive explanations of how findings were addressed, facilitating efficient re-review (emerging) — *https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Async lifecycle and tenant/identity boundary correctness: across PR #6243, #5915, and #6269, reviewers consistently flagged that detached async operations (directory loads, unread sync, push bootstrap, invite recovery) were not fenced against community switches, identity rotations, or sign-out, causing state leaks or liveness failures across tenant boundaries (consistent)
+  → **Support:** Before submitting any PR that introduces a detached async operation, brow should complete a self-checklist: (1) identify every async gap (await points and callbacks), (2) verify that the owning scope (community ID, signing identity, relay generation) is re-checked after each gap, and (3) add a unit or integration test that changes the active community or signs out mid-operation and asserts no state bleed. Pair with a senior reviewer specifically on the lifecycle section of each PR before requesting a full review.
+- Durable error and failure-recovery paths: PR #5915 (invite recovery not persisted across restarts), PR #6269 (push revocation not durable, bootstrap failures not retried), and PR #7158 (incremental DB migration missing) all show a recurring pattern of happy-path implementation without corresponding durable recovery or rollback logic (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For every new persistent state change or external enrollment step, brow should explicitly design the failure and partial-completion cases before writing the implementation. A lightweight design doc or PR description section titled 'Failure modes and recovery' should be required for high-risk PRs. Reviewers should be asked to evaluate this section first. For push and relay registration specifically, sketch a state machine with terminal failure and retry states before coding.
+- Regression test coverage accompanying fixes and infrastructure changes: PR #7187 fixed an iOS linker regression without a falsifiable regression guard, and PR #7158 changed the deployment schema snapshot without an incremental migration — both are patterns where the fix is correct but leaves the codebase vulnerable to recurrence (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Establish a personal norm: every bug fix PR includes at least one test that would have caught the original bug. For infrastructure/CI changes, add a path filter to CI that re-runs the relevant guard when the changed file is touched. Pair with the team on setting up a schema migration test harness so incremental migrations are verified automatically, reducing reliance on reviewer detection.
+- Security-sensitive surface area — token custody, APNs configuration, and deployment trust: PR #6269 saw multiple rounds of changes around APNs topic/environment misconfiguration and App Attest authority; PR #7158 had a deployment verification step that only retrieved an artifact rather than validating its integrity (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** When working on push token custody, APNs entitlements, or deployment artifact verification, brow should reference OWASP guidelines on cryptographic failures and software integrity before opening the PR. For deployment PRs specifically, have a security-focused reviewer audit the verification steps in documentation. Consider creating a team checklist for 'push security review' covering: token scope, environment/topic alignment, revocation durability, and artifact integrity checks.
+
+### evanchen7
+**Trajectory:** insufficient-data — Only one PR is available in the window, so no chronological trend can be established.
+
+**Strengths:**
+- Scoped, focused fixes: the PR targets a specific bug (truncated repository trees) without sprawling into unrelated areas, keeping the change reviewable and well-bounded. (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive to reviewer feedback: inline comments show the author (via Codex) acknowledged accessibility and IPC payload concerns and addressed the aria-live region gap in a follow-up commit. (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Incomplete feature parity after truncation removal: the backend returns all paths but `parse_ls_tree` / `parse_worktree_files` still set `preview_content = None` beyond the eager-preview cap, leaving files visible but unopenable — a P1 correctness gap caught by a reviewer rather than the author. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before submitting, walk through each user-facing action enabled by the change (open file, preview content) and verify it works end-to-end, not just that the data appears in the list. A short self-review checklist — 'can the user do X with every item now returned?' — would catch this class of regression before review.
+- IPC payload and memory impact not assessed: removing the file-list cap can produce very large payloads for big repositories; no size ceiling or streaming strategy was included or discussed in the PR description. (occasional) — *DORA research — https://dora.dev/research/*
+  → **Support:** When a change shifts data-volume constraints (e.g., removing a cap), include a brief impact note in the PR description estimating worst-case payload size and whether it is acceptable. For desktop IPC, consider documenting a follow-up ticket for backend pagination so the trade-off is explicit and tracked rather than deferred silently.
+- Accessibility considerations not proactively included: the aria-live region for the paginated count was only added after a reviewer raised it, suggesting a11y is not yet part of the author's default UI checklist. (occasional)
+  → **Support:** Add an accessibility spot-check to the personal definition-of-done for any UI change: dynamic content updates (counts, list changes) should have an aria-live region; interactive controls should have descriptive labels. Pairing with a team member on one accessibility-focused review session would help internalize the pattern.
+
+### jedwards27
+**Trajectory:** insufficient-data — Only two PRs are available and they span different artifact types (code fix vs. docs), making it impossible to establish a directional trend; more PRs touching similar surfaces are needed before a trajectory can be assessed.
+
+**Strengths:**
+- Targeted, well-scoped fixes: PR #6058 addresses a specific orientation bias in video resolution validation with a clean short/long-edge normalization approach that preserves the existing pixel envelope without breaking backward compatibility. (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Documentation discipline: PR #7061 proactively captures review-proven failure-path and async-state rules in contributor-facing docs, showing awareness that hard-won knowledge should be codified. (emerging) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+
+**Growth areas:**
+- Test coverage accompanying changes: neither PR surfaces evidence of added or updated tests. For a validation change like #6058 (portrait resolution acceptance), explicit unit tests covering the new orientation-agnostic boundary cases are expected in product-engineering work. (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** In the next PR that touches validation or parsing logic, require at least one new parameterized test covering the changed behavior (e.g., portrait vs. landscape dimension pairs at the boundary). Pair with a reviewer who can model what a complete test matrix looks like for the specific module, and reference the project's existing test patterns in crates/buzz-media as a template.
+- Explicit error-path documentation in code changes: the validation fix in #6058 changes acceptance criteria but reviewer notes do not indicate that error messages, user-facing rejection reasons, or logging were updated to reflect the new logic, leaving observability of the corrected path unclear. (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When submitting fixes to validation logic, include a brief PR description section titled 'Error paths touched' listing any changed rejection messages, log lines, or metrics. A one-time pairing session with a senior engineer to walk through the observability checklist for buzz-media would help build this habit early.
+
+### jmecom
+**Trajectory:** improving — Early PRs (#6838, #6816) required multiple CHANGES_REQUESTED rounds for missed production paths, while later PRs (#6913, #7004) received single-round approvals with no blocking findings, suggesting the author is internalizing reachability feedback over the window.
+
+**Strengths:**
+- Security-focused engineering: consistently ships changes that address real security boundaries — access policies, signing keys, authorization time bounds, and advisory routing — with clear threat modeling evident in the work (consistent) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Responsiveness to review feedback: across multiple PRs (especially #6838 and #6816) the author iterates quickly on CHANGES_REQUESTED cycles, addressing blocking correctness and security findings and landing approvals (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Small, focused changesets: PRs have narrow scope (remove a fallback, enforce a cooldown, fix authorization) which supports fast review cycles and low blast radius (consistent) — *DORA research — https://dora.dev/research/*
+
+**Growth areas:**
+- Full-path coverage before opening a PR: in #6838 the fix only covered one provisioning path; two production call-sites (useMentionSendFlow.ts, useQuickBotDrop.ts, template application) that omit respondTo were missed, requiring two additional CHANGES_REQUESTED rounds. In #6816 the review-freshness contract omitted baseSha, requiring another round. This pattern of incomplete reachability analysis appears across multiple PRs. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a security or correctness PR, explicitly enumerate every call-site or code path that touches the affected invariant (e.g., grep/AST search for all callers of the changed function, all jobs that read the changed contract). Add a checklist in the PR description listing each path and confirming coverage. A pairing session with a senior engineer on one upcoming PR to walk through this reachability exercise together would accelerate the habit.
+- Test coverage accompanying security fixes: reviewer feedback in #6838 noted the helper test was mutation-sensitive but the real composer identity-reuse path still bypassed the helper, suggesting the test did not exercise the actual production flow. No reviewer comments across the window celebrate strong test additions for security-critical paths. (consistent) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** For every security-fixing PR, require at least one integration or end-to-end test that exercises the exact production entry point being hardened — not just the extracted helper. Pair with the team's test infrastructure owner to identify the right test layer (e.g., Playwright for the composer flow in #6838). Reference the failing state (test red before fix, green after) in the PR description to make coverage intent explicit.
+- Proactive documentation of trust boundaries and invariants in PRs: reviewers in #6816 and #6838 had to independently trace the trust model (auth re-resolution, head pinning, policy precedence). The author does not appear to pre-document these in PR descriptions, which increases reviewer load and the chance of missed edge cases. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a short security-PR template: (1) state the invariant being enforced, (2) list every path that must satisfy it, (3) describe how the change closes the gap on each path, (4) note paths explicitly out of scope. This shifts reachability analysis from reviewers back to the author and shortens review cycles.
+
+### kalvinnchau
+**Trajectory:** stable — Across all five PRs the pattern is consistent — competent initial implementation with recurring gaps in runtime validation and edge-case coverage that are caught by review rather than self-caught, with no clear reduction in reviewer-identified issues from the earliest to the most recent PR.
+
+**Strengths:**
+- Responds to review feedback and iterates to resolution without abandoning PRs (consistent) — *https://google.github.io/eng-practices/review/*
+- Delivers self-contained, well-scoped features and fixes (manifest alignment, catalog discovery, UI controls) that reviewers can trace end-to-end (consistent)
+- Works across the full stack (Rust backend, TypeScript frontend, Playwright E2E) indicating broad ownership of changes (consistent)
+
+**Growth areas:**
+- Pre-merge runtime verification — multiple PRs ship with bugs caught only by automated reviewer E2E runs (Global Defaults label not persisting, floating-point zoom accumulation, UC model service admission without API-type screening), suggesting changes are not manually or locally validated against the full user-visible flow before submission (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Establish a personal pre-PR checklist that includes running the project's E2E suite locally (pnpm build:e2e + playwright test) and exercising the specific UI state that changed — especially persisted/closed picker states and boundary conditions — before opening the PR. Pair once with the reviewer to walk through their E2E capture workflow so the author internalizes what signals to look for.
+- Explicit error-path and edge-case coverage — reviewer-identified gaps (FQN special-casing only on Rust side, missing supported_api_types screening, floating-point endpoint drift) indicate edge cases are not being considered during initial implementation (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For each new code path, explicitly enumerate: (1) what happens at the minimum and maximum valid inputs, (2) what happens when an optional field is absent or empty, and (3) whether both sides of a dual-implementation (Rust + TS) receive the same logic. Add a brief comment in the PR description documenting these cases considered, which creates accountability and a review anchor.
+- Cross-interpreter parity — logic added to one interpreter (Rust or TypeScript) is repeatedly not mirrored in the other, requiring reviewer correction (FQN check absent from TS side in PR #6918) (emerging)
+  → **Support:** When a behavioral rule must exist in both Rust and TypeScript interpreters, create a shared test fixture or integration test that exercises both paths and fails if they diverge. If the codebase lacks such a harness, propose adding one as part of the PR that introduces dual-interpreter logic.
+- Dead-code hygiene — reviewer found immediately-overwritten assignments (dead `capability_model` field in PR #6918), suggesting insufficient self-review before submission (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before marking a PR ready, do one pass reading only the diff (not the full file) looking specifically for assignments, imports, or branches that are never read downstream. Enable and address compiler/linter warnings as a forcing function.
+
+### klopez4212
+**Trajectory:** improving — Later PRs (7121, 7112, 6978, 6583) show klopez4212 addressing more reviewer findings per cycle and shipping increasingly comprehensive fixes, but the same foundational gaps in async lifecycle, test coverage, and accessibility appear repeatedly, indicating the improvement is in execution speed rather than in eliminating root causes.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback — consistently addresses blocking findings across multiple revision cycles without abandoning the PR (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Cross-platform scope — ships coordinated changes across Flutter/Dart, Swift/iOS, Kotlin/Android, Rust relay, and TypeScript/desktop in a single PR lifecycle (consistent)
+- Security-aware relay proxy design — GIF proxy PR (5554) correctly keeps API key server-side, implements NIP-98 verification, replay guard, membership enforcement, per-pubkey quota, and response-size cap (emerging) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+- Test accompaniment — adds focused widget regressions, Playwright E2E specs, and unit tests alongside production code changes when prompted; coverage is improving across the window (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- File-size discipline — responds to 1,000-line ceiling violations by splitting files into focused siblings (profile editor tests, NativeEmojiPicker, image capture sub-widgets, AppDelegate packager) (consistent)
+
+**Growth areas:**
+- Shipping incomplete error and lifecycle paths — consistently misses terminal error handling, cancellation fences, and teardown races in async native/Dart code on first submission (Huddles MVP, voice notes, profile editing, emoji picker, camera capture all had P1/P2 lifecycle blockers) (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that touches async lifecycle (recording, playback, upload, camera, community switch), author should produce a written teardown/cancellation checklist: for every async operation, document what happens if (a) the widget/route unmounts, (b) the community changes, (c) the operation partially succeeds. A senior reviewer should sign off on this checklist rather than discovering gaps post-submission.
+- Proactive regression test coverage — tests are added reactively after reviewers flag missing coverage rather than shipped with the initial PR; the same gap appears in voice notes, profile editing, emoji picker, huddle presence, timeline tail, and message actions (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal pre-PR checklist: for every new public API or behavioral invariant, write at least one focused widget/unit test before opening the PR. Pairing with jedwards27 or wesbillman to review a draft test plan before coding would surface coverage gaps earlier and reduce the number of change-request rounds.
+- Accessibility completeness — VoiceOver/TalkBack semantics, live regions, Dynamic Type, and contrast are consistently flagged as missing on first submission across mobile emoji picker, message actions, profile editing, avatar editor, activity highlight, and voice note waveform (consistent)
+  → **Support:** Add an accessibility checklist to the PR template for mobile changes: (1) every interactive widget has a semantics label, (2) live-region announcements cover async state changes, (3) Dynamic Type is exercised with a large-text widget test, (4) new iOS native controls pass VoiceOver manual verification. Running TalkBack/VoiceOver on a device against each new surface before opening the PR would eliminate the majority of these late-cycle findings.
+- Intentional deferral of valid reviewer concerns — repeated pattern of marking reviewer-raised bugs as 'intentional' or 'out of scope' when they are later confirmed to be real defects (emoji category rail, keyboard inset, skin-tone sync, iOS theme mismatch, Reduce Motion avatar handoff) (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** When declining a reviewer suggestion, write a falsifiable technical reason (e.g., 'UIKit already handles this at layer X') rather than citing design intent. If a reviewer re-raises the same concern, treat that as a signal to prototype the fix before deciding. A lightweight async post-mortem after each PR that required >4 change-request rounds would help identify which 'intentional' replies were actually mistaken.
+- API and public symbol documentation — doc comments on new public constructors, callbacks, constants, and exported helpers are consistently absent on first submission and added only after P1 reviewer flags (consistent)
+  → **Support:** Add a pre-commit lint step or CI check that enforces doc comments on all public Dart/Swift symbols introduced in the diff. Treat documentation as part of the definition of done before opening the PR, not as a separate cleanup task. Reviewing one well-documented PR from a colleague before opening each new PR would build the habit quickly.
+- State machine correctness in distributed/concurrent scenarios — replay ordering, generation fencing, admission tombstoning, and stale settlement in the Huddle presence runtime required a very large number of change-request rounds across PRs 7112, 6056, 6312, and 6297 (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For features involving relay-backed lifecycle state (presence, roster, liveness), author should draw an explicit state machine diagram including all terminal and retry states before writing code, and share it with jedwards27 for review. Deterministic property-based or sequential-replay unit tests against the state machine model should ship with the initial PR rather than being added incrementally after regressions are identified by reviewers.
+
+### kruegermj
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to establish a directional trend.
+
+**Strengths:**
+- Targeted, coherent CSS stacking-context fix with clear scoping rationale (emerging)
+
+**Growth areas:**
+
+### kursmark-sq
+**Trajectory:** insufficient-data — Only one PR is available in the review window, which is insufficient to establish any trend or pattern.
+
+**Strengths:**
+
+**Growth areas:**
+
+### loganj
+**Trajectory:** improving — Early PRs in the window (e.g., #6222) show process gaps like missing DCO, while later high-complexity PRs (#7127, #7129) show loganj self-reviewing intermediate states and writing targeted fixes that satisfy reviewers more quickly across iterations, suggesting growing review-loop efficiency even if first-submission correctness on state-handling remains a recurring gap.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: across multiple high-risk PRs (e.g., #7122, #7127, #7129), loganj consistently pushes targeted follow-up commits that directly address reviewer blockers, often closing findings within the same review cycle. (consistent) — *https://google.github.io/eng-practices/review/*
+- Scoped, well-bounded changes: PRs tend to address a single concern (e.g., autocomplete filtering in #6156, mention spacing in #7128, provenance markers in #7129), making them tractable to review and limiting blast radius. (consistent) — *https://google.github.io/eng-practices/review/*
+- Security and dependency hygiene: proactive dependency bump for a published CVE/RUSTSEC advisory (#6222) demonstrates awareness of supply-chain risk and timely response. (emerging) — *https://owasp.org/www-project-top-ten/*
+
+**Growth areas:**
+- Correctness of state/availability semantics on first submission: PRs #7122 and #7127 both required multiple CHANGES_REQUESTED rounds for the same class of defect — unknown/pending states being collapsed into a concrete value (e.g., 'Offline') rather than preserved as undefined. This is a recurring first-attempt gap in handling ambiguous or unresolved runtime state. (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR that touches presence, availability, or any tri-state/nullable status field, add a checklist item: 'Does every consumer of this value handle undefined/unknown without collapsing it to a default?' Add a unit test asserting that an unresolved input produces an unresolved output, not a fallback sentinel. Pair with a reviewer early (design-level comment) on any PR touching signed runtime or policy state.
+- Test coverage accompanying production changes: multiple high-risk PRs (especially #7122 and #7127) required reviewer-prompted test additions or synchronization repairs late in the review cycle rather than including them in the initial commit. Tests for edge-state paths (e.g., failed/disconnected reads, retry journeys) arrived as follow-up commits. (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal pre-push gate: for any PR touching data derivation or UI state, include at least one test covering the 'unknown/error' path before opening for review. Reference the DORA finding that fast feedback loops require test coverage at the PR level. Consider a PR description template with a required 'Tests added for happy path, error path, and unknown/pending state' checkbox.
+- DCO/commit hygiene: PR #6222 received a P1 flag for a missing Signed-off-by trailer, indicating the commit signing workflow is not yet habitual. (occasional)
+  → **Support:** Configure a local Git hook (prepare-commit-msg or commit-msg) that automatically appends the Signed-off-by trailer, or add 'git commit -s' as a muscle-memory alias. This is a one-time setup that eliminates the class of error permanently.
+- Nondeterministic test gates added within PRs: PR #7129 was blocked because a reviewer-required smoke gate added by the PR was itself nondeterministic at the initial head, and PR #7127 required multiple E2E synchronization repairs for async races in the test harness. (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Run newly added E2E or integration tests locally at least three times before pushing to catch flakiness. For async/event-driven tests, apply an explicit wait-for-state assertion rather than timing-based waits, and document the synchronization strategy in a comment. Consider a local script that re-runs only the PR-added tests N times and reports pass rate.
+
+### lucasisaza
+**Trajectory:** insufficient-data — Only one PR is available in the review window, providing no basis for trend analysis.
+
+**Strengths:**
+
+**Growth areas:**
+
+### mahanti
+**Trajectory:** stable — All three PRs follow the same pattern of correct eventual delivery after multiple reviewer-identified defect cycles, with no clear reduction in the number of blocking findings per PR over the review window.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback: across all three PRs, mahanti consistently revises and resubmits until blockers are resolved, demonstrating a productive review loop (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Delivering user-visible and platform-spanning features (avatar rendering, experiment gating, persistent agent experience) that require coordinating multiple subsystems (consistent)
+- Sustaining work through high reviewer round-trip counts (PR #6902 had 10+ review cycles) without abandoning the PR, indicating persistence and ownership (consistent) — *DORA research — https://dora.dev/research/*
+
+**Growth areas:**
+- Atomic, safe state mutation and rollback correctness: reviewers flagged fail-open resolvers (PR #6902), partial-deletion leaving inconsistent state (PR #7223), and rollback failures that durably tear assignments across scopes (PR #7223). The same class of defect — incomplete or non-atomic cleanup — appeared across two PRs. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Pair with a senior engineer on a focused session covering transactional state-machine design: model each destructive operation as acquire-mutate-commit with explicit compensation on any failure branch before touching persistent state. Practice by rewriting PR #7223's delete_managed_agent flow on a whiteboard showing the exact ordering of process stop, assignment clear, and persist steps, and identifying which failures require rollback.
+- Compile-time / runtime capability boundary enforcement: PR #6902 required multiple cycles to correctly separate OSS and protected-build module graphs; the fail-open default and missing explicit disable in child workspaces were caught by reviewers, not surfaced proactively. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before submitting any PR that introduces a feature flag or build-time gate, author a short design note (even a PR description section) that explicitly states: (1) what is included/excluded in each artifact, (2) the default when the capability is absent, and (3) how the OSS child explicitly disables rather than omits the flag. Ask a reviewer to validate this note before code review begins to catch boundary mismatches early.
+- Error-path coverage and explicit failure handling: across PR #6902 (fail-open resolver) and PR #7223 (unguarded pre-deletion of assignments), the happy path was implemented but failure branches were under-specified, requiring reviewer discovery. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a personal checklist item before each PR submission: for every destructive or async operation, enumerate at least two failure modes in a code comment or test, and assert the system is left in a valid state for each. Start by adding these assertions retrospectively to PR #7223's with_agent_assignment rollback path as a learning exercise.
+- Upfront scope and risk articulation: several PRs were initially rated medium risk by reviewers but escalated to high (PR #6902 packaging boundary, PR #7223 cleanup durability) after deeper inspection, suggesting the author's own risk assessment lags behind reviewer findings. (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, write a one-paragraph risk section in the description that names the blast radius (which platforms, which persistent stores, which concurrent actors). Share it with a peer for a 10-minute verbal review before opening the PR formally. This surfaces high-risk paths earlier and reduces late-cycle REQUEST CHANGES cycles.
+
+### matt2e
+**Trajectory:** improving — Earlier PRs (August) sailed through with zero or one review round; the more complex async and focus-ownership work in late August and September attracted multi-round cycles, but the author closed every blocker within the same PR, and reviewers on the final PRs note prior findings resolved — indicating growing ability to handle harder problem classes even if initial coverage still has gaps.
+
+**Strengths:**
+- Narrow, well-scoped fix PRs: the majority of PRs target a single, clearly identified bug with contained blast radius (UI thread offloading, scrolling stabilization, right-click tray hiding, mention draft space, pulsing agents). Reviewers consistently note changes are 'narrowly scoped' and approve with minimal iteration. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive iteration on reviewer feedback: when blockers are raised (e.g., mixed-selection link paste in #6684, Shift+Space regression in #6862, keyboard accessibility in #6860), the author produces corrective commits in the same PR cycle rather than abandoning or reopening. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Test coverage accompanies behavioral changes: reviewers on #6862 and #6684 specifically call out test guard-rails ('the guard rails in the tests are the good part') as correctly pinning edge cases like partial-name matches, modifier-key guards, and IME composition states. (consistent)
+- Correct use of UI-thread separation for runtime/native calls: PR #6445 was approved without blocking findings after reviewers traced the full members-sidebar gate and native command contract, indicating solid platform-layer discipline. (emerging)
+
+**Growth areas:**
+- Keyboard accessibility coverage in interactive UI components: PR #6860 required six consecutive CHANGES_REQUESTED rounds across multiple heads because focus ownership and Shift+Tab keyboard paths to overlay controls were repeatedly dropped or regressed. The same class of omission (keyboard user path to mention Options) recurred across every iteration until explicitly restored. (consistent)
+  → **Support:** Before submitting any PR that modifies focus management, overlays, or composer controls, run a self-audit checklist covering: Tab/Shift+Tab traversal into and out of all interactive children, keyboard-only activation of every overlay trigger, and focus restoration on dismiss. Pair with an accessibility-aware teammate for a 30-minute walkthrough on the first PR after this review to build muscle memory for the pattern.
+- Concurrency and lifecycle ordering in async publish flows: PR #7154 generated the longest review cycle (8+ CHANGES_REQUESTED rounds) because the publish-before-wake ordering introduced multiple races — premature 'message sent' UI confirmation before relay acceptance, detached wake without settled authorization, duplicate deployment on A→B→A community switches, and a 200 ms grace window that still published without confirmed auth. These are distinct but structurally related failures in async sequencing. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For any PR that reorders async operations (publish, wake, deploy, authorize), produce an explicit sequence diagram or state-machine sketch before writing code and attach it to the PR description. Review it against these three questions: (1) Can the UI report success before the server confirms? (2) Can a detached async branch outlive its owning context? (3) Is authorization re-evaluated after all suspensions? Schedule a design review with a senior engineer before implementation on high-risk async PRs to catch ordering assumptions early.
+- Anticipating partial/mixed-state edge cases in editor operations: PR #6684 initially missed the case where a mixed markable/unmarkable selection would be consumed after only partial link application. This is consistent with the mention-space PR (#6862) missing the Shift+Space modifier and the autocomplete PR (#6860) missing keyboard-only paths — a pattern of 'happy path' completeness with gaps in mixed or adversarial input states. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a pre-submission adversarial test habit for editor/input PRs: enumerate at least three 'what if the selection is not clean?' scenarios (mixed node types, modifier keys held, IME composing, empty range) and write or verify a test for each before requesting review. Reviewing one prior PR per quarter where an edge-case gap was caught can help internalize the pattern.
+- Force-push hygiene: in PR #6860 a force-push dropped a previously approved keyboard-accessibility fix, requiring the reviewer to flag the regression explicitly. This added at least one extra review round. (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** When rebasing or amending during an active review, diff the outgoing force-push against the previously approved head before pushing and call out in the PR comment what was intentionally removed vs. preserved. Consider using fixup commits instead of force-pushes during the review window to keep reviewer context intact.
+
+### morgmart
+**Trajectory:** improving — Chronologically, PRs move from multi-round changes-requested cycles (#6529) toward clean first-pass approvals (#6892, #6665), suggesting the author is internalizing surface-coverage thinking and landing tighter changes over the window.
+
+**Strengths:**
+- Placing fixes at the correct contract owner — changes are scoped to the authoritative source (e.g., Rust producer for feed categories, root rem for zoom) rather than patching symptoms at call sites (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Responsive iteration on reviewer feedback — across multiple PRs (especially #6359 and #6529) the author resolves raised issues and lands clean re-reviews, indicating strong collaboration hygiene (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Appropriately narrow feature scope — changes are consistently described as deliberately bounded (e.g., narrow link parser, small ownership split for zoom), reducing blast radius per change (consistent)
+
+**Growth areas:**
+- Validation and ordering correctness on first submission — PR #6359 required a revision to fix local validation ordering for the explicit target form before it could be approved, indicating the initial implementation missed an edge-case sequencing invariant (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that involves multi-step input parsing or validation chains, write out the intended execution order as inline comments or a brief doc-comment on the entry function, then verify each step in a test. Add at least one unit test per distinct input path (canonical link, malformed link, missing fields) to catch ordering regressions before review.
+- Sustained changes-requested cycles on UI interaction PRs — PR #6529 accumulated three consecutive CHANGES_REQUESTED rounds before approval, suggesting shared-surface UI changes (toolbar, reaction rail) ship without fully mapping all interaction contexts (keyboard, touch, narrow layout, inbox) upfront (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** For shared message-action surface changes, create a short pre-PR checklist that enumerates every consumer surface (channel, thread, inbox, keyboard shortcut, touch, narrow layout) and confirm each is handled or explicitly out of scope. Share this checklist in the PR description to make coverage visible to reviewers and reduce round-trips.
+- CI readiness at time of review request — PR #6193 received an initial COMMENT verdict specifically because required CI had not completed successfully at the exact head, adding unnecessary review latency (occasional) — *DORA research — https://dora.dev/research/*
+  → **Support:** Adopt a personal discipline of waiting for all required status checks to pass on the exact PR head before requesting review. Use GitHub's draft PR state during active iteration and convert to ready-for-review only after CI is green, reducing reviewer context-switching and rebase churn.
+
+### ngthuydiem
+**Trajectory:** insufficient-data — Only one PR is available for review, which is insufficient to establish a meaningful trajectory.
+
+**Strengths:**
+- Test correctness and precision: identified and fixed a subtle test fragility caused by a separator character collision with wordlist entries, demonstrating careful attention to test reliability (emerging)
+
+**Growth areas:**
+
+### philazar
+**Trajectory:** insufficient-data — Only one PR is available, so no chronological trend can be established; the author shows responsiveness and a testing instinct but needs to develop more rigorous pre-submission verification habits.
+
+**Strengths:**
+- Responsive to reviewer feedback: acted quickly on inline comments (e.g., slug realism) and iterated through multiple change-request cycles without abandoning the PR (emerging) — *https://google.github.io/eng-practices/review/*
+- Regression test coverage: proactively added a benchmark regression task alongside the memory-retrieval fix, demonstrating awareness of observable, verifiable behavior (emerging)
+
+**Growth areas:**
+- Grader/verifier correctness: the score_evidence() function accepted semantically negated answers (e.g., 'Do not use net_gpv') because it matched on token presence alone, requiring multiple change-request rounds before the logic was sound (occasional)
+  → **Support:** Before submitting evaluation or scoring code, explicitly enumerate false-positive and false-negative cases in a comment or docstring, and add at least one negation-phrased test fixture to confirm the grader rejects it. Pair-review grader logic with a teammate before opening the PR to catch logical blind spots early.
+- Test fixture realism: a randomly generated slug ('7f2a') was committed without intentional design, only corrected after a reviewer question (occasional) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a personal checklist for test fixtures: every hardcoded value should have a one-line comment explaining its origin and why it was chosen. For seed data, prefer values that are either semantically meaningful or explicitly documented as arbitrary, reducing reviewer cognitive load.
+
+### ravarora2
+**Trajectory:** insufficient-data — Only two PRs in the window, both approved cleanly on consecutive days, which is positive but too small a sample to establish a directional trend.
+
+**Strengths:**
+- Observable instrumentation: both PRs add well-scoped, meaningful metrics (readiness signals and pool acquisition tracking) with no critical findings across independent review lanes (emerging)
+- Clean, reviewable changesets: reviewers found no critical or important issues in either PR, suggesting disciplined scoping and self-review before submission (emerging) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Test coverage accompanying instrumentation changes: review summaries do not mention tests validating new metric emission paths or correctness of recorded values (occasional) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For each new metric path, add at least one unit or integration test that asserts the metric is emitted with expected labels/values under a known condition; reviewers should explicitly check for this in future PRs to build the habit.
+- Explicit error path coverage in metrics: neither PR summary mentions handling or recording failure/timeout states in the new metric instrumentation (occasional)
+  → **Support:** When adding observability code, document and test the failure branch (e.g., pool acquisition timeout, unhealthy readiness state) so dashboards and alerts can distinguish error conditions from absence of data.
+
+### salman1993
+**Trajectory:** improving — Earlier PRs show raw correctness gaps caught by reviewers (Windows path parity, scripted-event races, resource lifecycle), while later PRs demonstrate salman1993 self-reviewing and responding to agent-reviewers with precise, well-explained fixes, suggesting growing internalization of reviewer expectations even as new feature surface area continues to introduce fresh edge cases.
+
+**Strengths:**
+- Prompt engineering and agent instruction design: consistently delivers focused, purposeful changes to base prompts and ACP guidance with clear rationale for each addition or removal (consistent)
+- Benchmark infrastructure: builds well-structured evaluation harnesses with layered regression and workflow task separation, verifier adversarial coverage, and clear README documentation (consistent)
+- Iterative responsiveness to review feedback: consistently addresses reviewer blockers with follow-up commits and explicit comments explaining how each concern was resolved (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Cross-cutting feature scoping: PRs are tightly scoped to a single concern (session policy, tilde expansion, deduplication), making them straightforward to review and merge (consistent) — *DORA research — https://dora.dev/research/*
+
+**Growth areas:**
+- Edge-case and resource lifecycle handling in infrastructure code: multiple PRs (session pool LRU/TTL in #6732, Windows HOME vs USERPROFILE parity in #6271, scripted-event completion race in #6448/#6487) required reviewers to identify missing bounds or correctness gaps before merge (consistent) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before opening a PR that introduces a new resource pool, concurrent state, or OS-dependent path, author a checklist of failure modes (exhaustion, race, platform divergence) and document how each is handled or explicitly deferred. Pair with a senior reviewer for a pre-PR walkthrough of the lifecycle diagram so gaps surface before the formal review cycle rather than through multiple CHANGES_REQUESTED rounds.
+- Deterministic test design: E2E tests in #6887 relied on timing-based assertions (4s delay inside a 5s Playwright retry window) that could false-green on the buggy implementation, requiring two rounds of reviewer-identified rework before a correct manual gate was introduced (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a practice of explicitly asking 'can this test pass on the broken code?' for every new assertion before submitting. For UI/async tests, prefer explicit gates or intercept stubs over time-based tolerances, and write at least one negative assertion (e.g., assert the stale value appears before the fix lands) to prove the test actually detects the bug.
+- Completeness of UI feature delivery: #7208 shipped a new agent preset without the required catalog copy entry, leaving a visible gap in the product UI that reviewers had to catch (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Maintain a per-feature checklist for UI additions (copy strings, help text, icons, accessibility labels) and run through it before marking a PR ready-for-review. A short PR template section ('UI checklist: [ ] copy added [ ] help text updated') would surface these gaps at authoring time rather than review time.
+- Anticipating downstream behavioral impact when removing prompt or code guardrails: #6340 removed CLI command discovery guidance without pairing it with an improved --help output, and #6501 initially dropped workspace grounding without a behavioral replacement, each requiring a reviewer to flag the regressive impact (consistent) — *The Pragmatic Programmer (Hunt & Thomas) (secondary) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When a PR removes existing guidance or guardrails, explicitly document in the PR description what previously-covered behavior is now covered elsewhere, or what new mechanism replaces it. If no replacement exists, treat the removal as a breaking change and either add the replacement in the same PR or defer the removal.
+
+### tellaho
+**Trajectory:** improving — Later PRs (#6837, #6718, #7242) resolve in fewer review rounds and receive first-round or near-first-round approval, suggesting tellaho is internalizing reviewer expectations around test quality and contract completeness, even though the same structural gaps still appear in new feature work.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: consistently addresses blocking findings across multiple review rounds and ships to approval (consistent) — *https://google.github.io/eng-practices/review/*
+- Scoped, focused PRs: changes are generally narrowly targeted to a specific feature or fix area (composer, workflows, sidebar, desktop layout) rather than sprawling across unrelated systems (consistent)
+- UI/UX surface coverage: delivers user-visible features and polish (chip wrapping, tooltip contrast, sidebar overflow, composer caret) with consistent attention to behavioral correctness (consistent)
+- Engagement with inline review comments: in PR #6470 the author actively commented on reviewer findings and acknowledged fixes commit-by-commit (emerging) — *https://google.github.io/eng-practices/review/*
+
+**Growth areas:**
+- Test oracle quality and regression proof: reviewers repeatedly flag that added tests do not deterministically cover the failure being fixed (PR #6606 WebKit stale path, PR #6581 nondeterministic tooltip regression, PR #6897 smoke contract not updated), requiring additional iterations solely to strengthen test evidence (consistent)
+  → **Support:** Before opening a PR, write the regression test first and confirm it fails on the pre-fix code, then passes after the fix. For UI/layout regressions, make the test assertion deterministic by awaiting a stable DOM condition rather than relying on timing. Pair with a senior engineer to review the test oracle before the PR is posted, targeting the 'tests accompanying changes' expectation of the product-engineering lens.
+- Cross-surface contract consistency: features are initially implemented on one code path but the same contract is missing from sibling paths (PR #6009: WS REQ fixed but HTTP /query, COUNT, and cache paths left broken; PR #6008: enable/disable path silent on failure), requiring multiple CHANGES_REQUESTED rounds to achieve full coverage (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before marking a PR ready, enumerate every call site or transport surface that participates in the changed contract (e.g., HTTP, WebSocket, cache, and event-bus paths) and verify each one is covered by the implementation and by at least one test. A checklist comment in the PR description listing each surface and its disposition would both surface gaps early and communicate intent to reviewers.
+- Explicit error path handling: silent failures appear repeatedly (PR #6008: rejected update_workflow calls left visible status unchanged; PR #6470: activation boundary bypassable without warning), indicating that unhappy paths are not systematically considered during initial implementation (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Adopt a 'what happens when this call fails?' checklist for every async operation or state mutation: decide explicitly whether the failure should surface an error state, revert optimistic UI, or be logged. Document the decision in a code comment. Add at least one test for the rejection/error path alongside the happy-path test before opening the PR.
+- Accessibility correctness on first submission: nested interactive elements and missing reduced-motion support surface as blocking P1/P2 findings across multiple PRs (PR #6008 nested Radix Switch inside menuitemcheckbox, PR #6000 collapse animation lacking prefers-reduced-motion guard) (consistent)
+  → **Support:** Run axe-core or a similar automated accessibility audit locally as part of the development loop before opening any PR that adds or modifies interactive UI. Add a prefers-reduced-motion check to a shared animation utility and require its use in code review guidelines for any new CSS transition or animation. A short pairing session with the team's accessibility lead to review ARIA role constraints would help build intuition for nested-interactive patterns.
+- State invariant completeness in complex UI features: initial submissions of multi-state features (workflow editor dirty state, agent addressing persistence, composer mention lifecycle) frequently miss edge-case invariants — Back/Forward bypass of dirty guard (PR #6575), module-global clear tombstone scope leak (PR #6793), duplicate-mention deletion loop (PR #6956) — each requiring 3–5 additional review rounds (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For features with persistent or lifecycle state, write a state-machine diagram or prose invariant list (e.g., 'enabled field is never absent after save', 'automatic mention ownership is cleared on user deletion') before coding. Include that invariant list in the PR description so reviewers can validate against it. Consider property-based or scenario-table tests that enumerate state transitions, not just the happy path.
+
+### thomaspblock
+**Trajectory:** improving — Later PRs (#6980, #7013, #7137) resolved blockers in fewer review rounds and with cleaner fixes than the highly iterative early PRs (#6003, #6590), indicating that thomaspblock is internalizing reviewer feedback on trust-boundary correctness and test coverage, though the same root-cause patterns still appear at submission time.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: consistently addresses blocker findings across multiple review rounds and lands PRs after thorough remediation (consistent) — *https://google.github.io/eng-practices/review/*
+- Self-directed adversarial/security review: proactively conducts and posts Cassandra security re-reviews on own and adjacent PRs, tracing trust boundaries through mutable relay/identity state (consistent) — *https://owasp.org/www-project-top-ten/*
+- Feature scope management: delivers focused, well-scoped PRs (UI polish, navigation, empty states, error surfaces) alongside larger architectural changes (consistent)
+- Cross-boundary defect recognition: demonstrates growing ability to identify and fix cross-tenant, cross-identity, and cross-relay state leaks after initial reviewer flags (emerging) — *https://owasp.org/www-project-top-ten/*
+
+**Growth areas:**
+- Catching async/concurrent trust-boundary defects before review: repeated P1 blockers across PRs #6003, #6368, #6590, #6939 involve mutable relay/identity state being read at different points in async flows, leading to cross-tenant or stale-authority context leaking to agents (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** Before submitting any PR that touches agent startup, relay selection, or project authority resolution, apply a written checklist: (1) identify every async await point in the flow, (2) verify that relay URL and signing identity are captured as immutable locals before the first await and never re-read from mutable state afterward, (3) confirm that failure modes close rather than fall through to a degraded context. Pair with a senior reviewer to walk through one PR using this checklist explicitly before submission.
+- Test coverage accompanying changes: multiple PRs required reviewer-demanded regression tests (e.g., #6429 mention caret, #7013 channel history retry, #6980 empty-state assertion scope) before approval; tests were added reactively rather than proactively (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal pre-submission rule: every new observable behavior (error state, retry, caret insertion, auth boundary) must have at least one Playwright or unit test that would fail if the production wiring broke. Reference the project TESTING.md contract. Before marking a PR ready, add a checklist item confirming each new code path has a corresponding test that exercises the real wiring, not a mock-only path.
+- Accessibility and keyboard lifecycle correctness: PRs #6901 and #6429 both required multiple rounds to fix focus management, tab-order isolation for covered elements, and focus-return after dismissal (consistent)
+  → **Support:** For any PR that adds, removes, or layers UI panels (sheets, drawers, threads), run a manual keyboard-only walkthrough as part of personal QA before submission: Tab through all interactive elements, confirm covered content is inert and AX-hidden, verify Escape and close-button dismissal returns focus to a logical target. Add a corresponding Playwright accessibility assertion covering at least the covered-inert and focus-return cases.
+- Atomic, self-contained fix commits: several PRs (notably #6003 and #6590) accumulated many round-trip fix commits addressing one or two blockers at a time rather than batching related fixes, increasing review overhead (occasional) — *https://google.github.io/eng-practices/review/*
+  → **Support:** When addressing multiple related P1 blockers in a single round, batch all fixes into one commit (or a small logical set) with a clear description of which finding each change resolves. This reduces reviewer context-switching and makes the diff easier to verify. Discuss with the team whether a pre-review 'fix bundle' convention should be formalized.
+- API/function signature hygiene: inline reviewer note on #6003 flagged an 11-positional-parameter function with five consecutive undefined arguments; suggests insufficient attention to interface design when adding parameters (occasional) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When a function call requires more than three or four positional arguments, refactor to an options object before submitting. Apply this as a linting rule in personal code review: search for any call site with three or more consecutive undefined or null arguments and convert it.
+
+### tlongwell-block
+**Trajectory:** improving — The earliest PRs (#3320, #6024) required the most review rounds and the most fundamental structural rework, while the most recent PR (#6822) was approved in a single comment with no blocking findings, and #6572 converged in three rounds with tightly scoped residual issues — suggesting the author is learning from feedback and shipping incrementally cleaner changes over the window.
+
+**Strengths:**
+- Persistent debugging and iterative resolution: across PRs #3320, #6024, and #6572, the author consistently works through multi-round review cycles, addressing each blocking finding and converging on approval without abandoning difficult feedback. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Correctness focus on network and concurrency boundaries: PR #3320 demonstrates deliberate handling of auth lifecycle races (Promise.race with overflow guard, bounded pre-connect queues), reflecting awareness of edge cases at async boundaries. (consistent)
+- Broad scope of contribution: the window spans desktop performance (JS-to-Rust migration), protocol specification (NIP-FI), database correctness (FTS exclusion migration), and relay auth — demonstrating cross-cutting product-engineering range. (emerging)
+- Schema migration correctness: PR #6822 correctly traces the gap across multiple migration files and preserves per-database policy rather than flattening it, showing careful backward-compatibility reasoning. (emerging) — *Semantic Versioning 2.0.0 — https://semver.org/*
+
+**Growth areas:**
+- Cross-scope lifecycle isolation: PRs #6024 and #6572 each required 4–5 review rounds primarily because scope-crossing state leaks (stale fetch canceling wrong scope, failed flush injecting events into a sibling scope, read-marker drops during scope open) were introduced or left unresolved across multiple revisions. This pattern appears in both PRs. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** Before submitting any PR that touches multi-scope state (archive sync, unread channels, community queries), write a short lifecycle contract comment at each scope boundary stating which scope owns the resource and what happens when that scope closes mid-operation. Add at minimum one integration test that exercises two concurrent scopes with interleaved failures to catch cross-contamination before review.
+- Startup/ordering races in UI data loading: PR #6572 required an additional revision specifically because post-subscription and reconnect refreshes were not sequenced behind cache hydration, causing the app to hide behind hydration or swallow refreshes. This class of bug (ordering assumption not encoded in code structure) also appeared in PR #6024 with the read-marker advance being dropped during scope open. (consistent) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For any feature that gates rendering or data refresh on an async initialization step, explicitly model the loading state machine (idle → hydrating → ready → refreshing) rather than using ad-hoc boolean guards. A small shared utility or documented pattern for sequencing post-subscription work behind hydration would prevent this class of defect from recurring across PRs.
+- Protocol specification precision: PR #5946 (NIP-FI) received a dismissal citing that normative contracts were not satisfiable as written — specifically that byte-exact exit tests left signed and transport bytes unpinned (JWS signs encoded octets, not logical claim sets). This indicates a gap in translating cryptographic correctness requirements into unambiguous spec language. (occasional) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** When authoring protocol specs that include cryptographic normative tests, include a reference implementation or test vector section that pins the exact encoded bytes used in each example signature, and add a sentence explicitly stating that implementations must sign the serialized octets rather than the logical structure. Pairing with a reviewer who has shipped a JWS/JWT implementation before the first review round would catch this class of issue early.
+- Proactive edge-case coverage before submission: across PRs #3320, #6024, and #6572 the pattern is that correctness blockers (buffer overflow on pre-connect queue, stalled signer defeating timeout, cross-scope event injection) are caught by reviewers rather than by the author's own pre-submission analysis. This suggests the author's self-review pass does not yet systematically enumerate failure modes at async and scope boundaries. (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a lightweight pre-submission checklist specific to async/scope-boundary changes: (1) What happens if this operation is cancelled mid-flight? (2) Can state leak into a sibling scope? (3) Is there a bounded worst-case for any queue or buffer introduced? Writing answers in the PR description before requesting review would surface these issues earlier and reduce multi-round cycles.
+
+### tulsi-builder
+**Trajectory:** improving — Early PRs (#6702, #6716) required five or more review rounds each to resolve correctness and accessibility defects, while later PRs (#6900, #7126) converged in fewer cycles and drew 'high risk' approvals with no post-approval rework, suggesting the author is internalizing reviewer expectations over the window.
+
+**Strengths:**
+- Responsive iteration on reviewer feedback — consistently addresses P2 defects across multiple review rounds and lands approvable code (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+- Cross-cutting UI feature delivery spanning renderer, navigation lifecycle, and shared theme tokens in a desktop client architecture (consistent)
+- Willingness to tackle complex Unicode and text-normalization edge cases (line separators, CRLF, NEL, LS) after they are surfaced (emerging)
+
+**Growth areas:**
+- First-pass correctness on edge cases — reviewers repeatedly find P2 defects (Unicode over-highlighting, same-route highlight clearing, WCAG AA color contrast) that require multiple revision cycles before merge (consistent) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, maintain a personal pre-review checklist that covers: (1) Unicode boundary conditions for any text-processing code, (2) navigation lifecycle state teardown for any route-aware feature, and (3) accessibility contrast ratios against all themes for any color-bearing UI change. Walking through this checklist on PR #6702, #6716, and #6946 before submission would likely have eliminated several revision rounds each.
+- Accessibility compliance — WCAG AA contrast requirements were missed in at least two separate PRs (#6716 mention foreground, #6900 mention badges), indicating this is not checked proactively (consistent) — *OWASP Top 10 — https://owasp.org/www-project-top-ten/*
+  → **Support:** Integrate an automated contrast-ratio check (e.g., axe-core or Storybook a11y addon) into the local dev loop or CI pipeline so WCAG AA failures surface before review. Additionally, add a short accessibility section to the PR template (contrast checked: yes/no, themes tested: list) so the author self-verifies before requesting review.
+- State management ownership boundaries — the same-route highlight clearing defect in PR #6702 was initially fixed at the caller site rather than at the correct ownership boundary, requiring an additional round trip (occasional) — *The Pragmatic Programmer (Hunt & Thomas) — https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** When fixing a state lifecycle bug, explicitly ask: 'Is this fix in the component that owns this state, or am I patching callers?' Document the answer in the PR description. A brief architecture note (one or two sentences) identifying ownership in each PR would prompt this reasoning before the reviewer has to raise it.
+- Data pipeline completeness — PR #7126 initially dropped the public description field before the 'Add Agent' step in the community catalog path, a missing-field propagation gap that recurs as a pattern when features cross renderer/relay/persistence layers (occasional) — *Google Engineering Practices: code review — https://google.github.io/eng-practices/review/*
+  → **Support:** For any feature that moves a new data field across an IPC or relay boundary, draw a one-line data-flow diagram (renderer → Tauri command → SQLite → relay → catalog) and confirm each hop carries the new field before writing code. Attaching this diagram to the PR description as a checklist reduces the chance that one hop is silently dropped.
+
+### wesbillman
+**Trajectory:** stable — Across the full window the author consistently delivers high-volume, security-aware changes and responds well to feedback, but the same gaps — insufficient mutation-sensitive tests, residual auth-boundary holes on first submission, and lifecycle teardown omissions — recur in both early and late PRs without a clear narrowing trend.
+
+**Strengths:**
+- Shipping across a broad surface area — desktop, mobile, CLI, relay, CI, and ACP — with consistent attention to protocol correctness and authorization boundaries (consistent)
+- Iterating quickly on reviewer feedback: most PRs show rapid follow-up commits that directly address blocking findings rather than arguing against them (consistent) — *https://google.github.io/eng-practices/review/*
+- CI and tooling hygiene: proactively adding first-class gates (file-size policy, Rust cache contract) to prevent class-level regressions (emerging)
+- Security-aware default posture: authorization boundaries are generally fail-closed and ownership checks are scoped to the correct identity (NIP-OA, managed-agent, relay-signed) (consistent) — *https://owasp.org/www-project-top-ten/*
+
+**Growth areas:**
+- Mutation-resistant test coverage: reviewers repeatedly find that new production authorization and lifecycle paths are not regression-protected — mutations to key guards leave the full test suite green (PRs #6953, #6415, #6485, #6996, #6961) (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, run a manual mutation pass on every new guard introduced: delete or invert the condition, confirm at least one test fails. Adopt a pre-push checklist item: 'does removing this branch break a test?' Focus especially on authorization gates and lifecycle fences, which are the most common sites of reviewer-caught gaps. Pair with a reviewer early (draft PR or async design note) when the change touches a relay/auth boundary to surface coverage gaps before the full review cycle.
+- First-attempt completeness on security-sensitive boundaries: initial submissions frequently contain a residual authorization bypass or identity-attribution hole that survives into the second or third review round, requiring multiple CHANGES_REQUESTED cycles (PRs #6086, #6338, #6953, #6533, #6961) (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** Before submitting, walk every caller of the new authorization path and ask 'what is the weakest input that reaches this gate, and does it still fail closed?' Write that walkthrough as a short comment block in the PR description. For changes rated high/critical risk, request an early design review from jedwards27 or wpfleger96 at the RFC or draft stage rather than after a full implementation.
+- Test contract completeness for policy/CI scripts: tests for policy scripts (Rust cache contract, file-size ceilings) repeatedly miss mutation-sensitive boundary assertions — passing even when the policy would not fire on a real violation (PRs #6618, #6485) (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** For every policy test, include at least one fixture that should trigger enforcement and assert it actually does. Treat the test as a specification: write the failing case first, then the script. Review the test by asking 'if I introduce the known-bad condition, does this test catch it?' before pushing.
+- Lifecycle teardown and in-flight cancellation: async queues and subscriptions are sometimes left without a complete teardown fence, allowing stale activations or disposed subscriptions to produce effects after the owning scope is gone (PRs #6427, #6415, #6996) (consistent)
+  → **Support:** Adopt a teardown checklist for every new async queue or subscription: (1) does cleanup abort in-flight work via AbortController or generation counter? (2) is the guard checked at execution time, not only at enqueue time? (3) is there a regression test that disposes the owner mid-flight and asserts no side effect? Use this checklist explicitly in the PR description for any lifecycle-touching change.
+- Keeping E2E and integration test assertions synchronized with intentional contract changes: changed behavior sometimes ships without updating the corresponding E2E assertion, causing deterministic CI failures (PR #6427 dm-double-notification, PR #6533) (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** When a PR intentionally changes a user-visible contract (notification title format, deletion authorization), grep for all test files that assert the old value before submitting. Add 'test impact' as a mandatory section in the PR description listing any E2E assertions touched by the behavioral change.
+
+### wpfleger96
+**Trajectory:** improving — Later PRs (September 2026) show faster blocker resolution, fewer rounds of changes per PR, and cleaner initial submissions in lower-stakes areas (CI, docs, chore), though high-complexity security and protocol-lifecycle PRs continue to require significant iteration, indicating domain-specific growth is ongoing but not yet consistent.
+
+**Strengths:**
+- Iterative responsiveness to review feedback: consistently pushes corrective commits that close specific blockers identified by reviewers, often within the same PR lifecycle, across feature, fix, and perf work. (consistent) — *https://google.github.io/eng-practices/review/*
+- Broad scope delivery: ships end-to-end changes spanning Rust backend, TypeScript/React desktop, CLI, CI, and database schema within single coherent PRs, demonstrating strong cross-layer ownership. (consistent)
+- Security-sensitive domain participation: engages with auth, trust-boundary, and cryptographic primitives (NIP-FI, NIP-98, JWKS, permission gating) and iterates to close reviewer-identified security blockers. (consistent) — *https://owasp.org/www-project-top-ten/*
+- Performance-aware design: deliberately structures parallelism (relay directory rebuild, discover_acp_providers cheap/forced split, reference resolution) and reasons about concurrency budgets. (emerging)
+
+**Growth areas:**
+- Explicit error-path and failure-propagation completeness: reviewers repeatedly surface gaps where error states are swallowed, not surfaced to callers, or routed to wrong observers. Seen in PR #6330 (forced-discovery failures invisible to Settings hook), PR #5545 (rejected-token cache entries left live), PR #4625 (stale effort values persisted silently), PR #6447 (false-empty instead of load error), and PR #5712 (fail-open malformed-response path). (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Before opening a PR, explicitly enumerate every error/failure branch in the changed code and verify each one either propagates to a caller-visible result, surfaces in the UI, or is logged with observable context. Consider adding a self-review checklist item: 'For each new async operation or fallible call, where does the error go?' Pair on one PR where a senior engineer walks through error-path tracing at the diff level before submission.
+- Race condition and loading-state correctness: multiple PRs require multiple rounds of changes to fix loading-state races, stale-state rollback gaps, and concurrent-write ordering. Seen in PR #5706 (archive predicate returns false before snapshot exists), PR #5905 (rapid archive changes leave stale kind 13535), PR #6330 (forced discovery pending/failed state not blocking onboarding advance), PR #4625 (EffortPicker write races dialog Save). (consistent)
+  → **Support:** Before submitting PRs that touch async state or shared mutable state, write out a state-machine diagram (even informally in the PR description) covering all intermediate states: loading, error, stale, and settled. Request a focused pre-review on the state-transition logic from a peer before formal review. Study the existing patterns in the codebase for how loading predicates gate downstream actions and replicate them explicitly.
+- Security boundary precision in auth and trust contexts: initial submissions contain fail-open paths, algorithm/key-type mismatches, attacker-controlled input reaching typed operations, and overly broad authorization exceptions. Seen in PR #6776 (JWKS snapshot unbounded, algorithm/curve mismatch not rejected), PR #6394 (prompt wording created permission rather than restriction), PR #3995 (publisher-controlled avatar URLs fetched on browse), PR #5712 (malformed wire messages forwarded as authorized). (consistent) — *https://owasp.org/www-project-top-ten/*
+  → **Support:** For PRs touching authentication, authorization, or external-input handling, apply an explicit threat-modeling pass before submission: identify every attacker-controlled input, every trust decision, and every fail-open branch. Use OWASP A01 (Broken Access Control) and A02 (Cryptographic Failures) as a checklist. Consider scheduling a 30-minute whiteboard session with a security-focused reviewer before the first draft to agree on the trust boundary design, reducing multi-round correction cycles.
+- Lifecycle and protocol contract completeness in event-driven and distributed systems: reviewers consistently find cases where tombstones are mis-ordered, sync subscriptions omit a required event kind, adoption paths skip enqueuing cross-device witness events, or deletion/creation races can resurrect deleted entities. Seen in PR #5112 (tombstone older than retained head, catalog adoption missing owner sync, delayed share resurrects deletion, community boundary rejection missing), PR #5904 (membership delta vs. full roster backfill), PR #5905 (archive/unarchive not scheduling nest regeneration). (consistent) — *https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/*
+  → **Support:** For PRs implementing event-sourced or protocol-level state transitions, write out the full event lifecycle in the PR description: create, update, delete, tombstone, sync, and replay. Explicitly list every subscription filter or event kind that must be included and verify the code against that list. Consider writing integration-level tests that exercise ordering edge cases (e.g., delayed events, rapid state changes) before requesting review, so reviewers can verify behavior rather than reason about it.
+- Test coverage accompanying changes: across 36 PRs, reviewer feedback consistently focuses on behavioral correctness gaps discovered through code inspection rather than failing tests, suggesting test coverage is not consistently paired with new behavior or error paths. (consistent) — *https://google.github.io/eng-practices/review/*
+  → **Support:** Adopt a personal norm of writing at least one test per new error path and one per new state transition before opening a PR for review. For complex PRs (auth, event lifecycle, concurrency), write tests first and include them in the initial submission so reviewers can verify intent via tests rather than discovering gaps through inspection alone. Track the ratio of reviewer-found behavioral bugs to total PRs as a personal metric and aim to reduce it over the next quarter.
+
+---
+
+## 4. Team Gap Analysis
+
+### Where the team is strong
+| Area | Evidence | Standard |
+|------|----------|----------|
+| Correctness and logic-gap detection | 861 correctness patterns across 225 PRs from 17 reviewers, with 469 rule-maturity and 13 deterministic signals. Core reviewers (jedwards27, wesbillman, wpfleger96, klopez4212) consistently catch async state boundaries, race conditions, and logic mismatches before merge. | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ |
+| Security trust-boundary enforcement | 169 security patterns across 84 PRs from 16 reviewers, 104 at rule maturity. OWASP-cited findings include NIP-98 replay guards, cross-tenant state leaks, attacker-controlled blob serving, and CI permission scoping. Breadth of reviewer participation (16 of 30) is notable. | OWASP Top 10 — https://owasp.org/www-project-top-ten/ |
+| API contract stability across the TypeScript/Rust boundary | 59 api-contract patterns across 53 PRs from 9 reviewers, with 23 at rule maturity. Reviewers catch serialization field-name mismatches, missing crate re-exports, and cross-layer contract propagation failures. | Semantic Versioning 2.0.0 — https://semver.org/ |
+| CI discipline and green-before-approve culture | Multiple rule-maturity signals show approval withheld on red CI, file-size ratchet enforcement, and Biome formatting gates. Conventional Commits and DCO trailers enforced at merge time. | DORA research — https://dora.dev/research/ |
+| Error-handling coverage | 930 patterns (correctness + error-handling combined) across 225 PRs from 17 reviewers. Swallowed async errors, partial-failure silent discard, stale focus restorer mutations, and unhandled lifecycle stranding are all caught consistently at rule maturity. | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ |
+
+### Gaps and blind spots
+| Area | Gap Type | Missing Standard | Recommendation |
+|------|----------|-----------------|----------------|
+| Dependency management receives virtually no human review — 100% of touching PRs had no human reviewer comment | coverage_gap | OWASP Top 10 — https://owasp.org/www-project-top-ten/ | ci-gate: Add a mandatory dependency-review step (e.g., GitHub's dependency-review-action or cargo-audit + npm audit pinned in CI) that blocks merge on new high/critical advisories and requires human sign-off on any new transitive dependency. Supplement with a checklist item in the PR template asking authors to justify new dependencies and confirm digest pinning. |
+| Test coverage comments are almost entirely absent from human reviewers — 182 of 183 touching PRs had no human comment; the axis is effectively delegated to bots | coverage_gap | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ | checklist: Add an explicit reviewer checklist gate ('Does this PR include tests for new behavior and failure paths?') to the PR template. Pair with a ci-gate: enforce a coverage-delta threshold (e.g., Codecov or cargo-tarpaulin) that fails if branch coverage drops. Designate at least one human reviewer per PR to own the test-coverage axis. |
+| Observability coverage is shallow and inconsistently applied — 37 patterns across only 28 PRs from 8 reviewers, mostly at guidance maturity; 90% of touching PRs received no human comment | knowledge_gap | DORA research — https://dora.dev/research/ | training: Run a team session anchored to DORA's observability findings. Establish a convention (document in CONTRIBUTING.md) that every new async code path must emit at minimum one structured log line at entry/error, and add a reviewer checklist prompt. Elevate the best existing patterns (e.g., PR #6597 deploy-signal enumeration) into shared templates. |
+| Security hygiene is strong among a small core but 90% of touching PRs receive no human comment — effectively delegated to AI review on most PRs | coverage_gap | OWASP Top 10 — https://owasp.org/www-project-top-ten/ | tooling: Introduce CodeQL or Semgrep with rules targeting the team's known vulnerability patterns (NIP-98 bypass, cross-tenant keying, blob URL injection). This converts security from a judgment-dependent practice to a deterministic gate. Pair with a rotation so at least one of the five high-signal security reviewers is assigned to every security-adjacent PR. |
+| API contract stability: 90% of touching PRs received no human comment — heavily delegated to AI review | coverage_gap | Semantic Versioning 2.0.0 — https://semver.org/ | ci-gate: Generate and diff TypeScript type snapshots and Rust public-API fingerprints (cargo-public-api) on every PR. Require explicit human approval when the diff shows a breaking change. Add a PR-template checklist item: 'Does this change alter any public interface, wire format, or CLI contract?' |
+| Documentation of non-obvious decisions is inconsistent — 52 of 53 touching PRs had no human comment; coverage exists but is concentrated in a single reviewer | knowledge_gap | Google Engineering Practices: code review — https://google.github.io/eng-practices/review/ | checklist: Add a PR-template prompt ('Does this change include non-obvious decisions that need inline comments or an ADR?'). Introduce a lightweight ADR convention for architectural changes. Broaden participation by including documentation review as an explicit axis in reviewer assignments, not a secondary concern. |
+| High volume of silent approvals and bot-only-reviewed PRs creates an oversight gap across all axes | coverage_gap | DORA research — https://dora.dev/research/ | tooling: Enforce a CODEOWNERS file requiring at least one non-author human reviewer with at least one non-approval comment (use GitHub's 'Require review from Code Owners' plus a branch protection rule disallowing approve-only with zero comments via a comment-count check bot). Target the 61 no-engagement PRs and 34 bot-only PRs first. |
+
+### Review culture
+The team has a strong, well-distributed correctness and security review culture anchored by a small core of high-signal reviewers (jedwards27, wesbillman, wpfleger96, klopez4212) who enforce rule-level standards consistently and cite authoritative references. However, the oversight model is dangerously concentrated: 61 of 272 PRs had no human engagement at all, 34 were reviewed only by bots, and 124 of 354 reviews were silent approvals, meaning the majority of the review burden falls on fewer than five people and several critical axes (dependency management, test coverage, observability) are effectively unreviewed by humans on the vast majority of PRs. The team should invest in broadening reviewer participation through CODEOWNERS rotation and PR-template checklists, and should convert its strongest judgment-level conventions into deterministic CI gates to reduce dependence on individual reviewer availability.
+
+---
+
+## Methodology & Caveats
+
+- **Window:** 2026-08-17 → 2026-09-03 | **PRs analyzed:** 272 | **PRs skipped (no reviews):** 0
+- **Lens:** product-engineering (v1, experimental)
+- **Tooling gates present:** biome
+- **What this analysis cannot see:** verbal review culture (Slack), reviewer availability constraints, domain ownership, or PRs merged without review.
+
+---
+
+## Appendix: Reference Standards
+
+- **Google Engineering Practices: code review**: https://google.github.io/eng-practices/review/
+- **DORA research**: https://dora.dev/research/
+- **OWASP Top 10**: https://owasp.org/www-project-top-ten/
+- **Semantic Versioning 2.0.0**: https://semver.org/
+- **The Pragmatic Programmer (Hunt & Thomas)** *(secondary)*: https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/


### PR DESCRIPTION
## Summary
- Adds six tricorder synthesis reports produced between Sep 2 and Sep 8, 2026.
- Three runs on block/buzz trace the tool's own fixes: the pre-lens run with dbt-contaminated gaps, the lens run whose Phase 4 saw under 1% of the record, and the Sep 8 re-run with the whole-record digest.
- Two runs on block/berd and one on anthropics/claude-cookbooks from the lens validation work.

## Changes
- `tricorder/2026-09-02-block__buzz.md` — 187 PRs, pre-lens baseline
- `tricorder/2026-09-02-block__berd.md`, `tricorder/2026-09-03-block__berd.md` — berd under product-engineering-desktop
- `tricorder/2026-09-04-anthropics__claude-cookbooks.md` — cookbooks run
- `tricorder/2026-09-04-block__buzz.md` — 272 PRs, product-engineering lens, truncated Phase 4 input
- `tricorder/2026-09-08-block__buzz.md` — same cache, Phase 4 re-run with the record digest

## Test plan
- [ ] Sep 8 buzz report section 4 lists all seven lens axes as present and names security and API contract stability as strengths
- [ ] No report except Sep 2 buzz cites dbt, SQLFluff, or Kimball
- [ ] Front matter `lens:` field is present on the Sep 3+ reports and absent on the Sep 2 ones

## Related
Related to dhk/tricorder#56 and dhk/tricorder#55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
